### PR TITLE
&_category in forums tries to access third argument.

### DIFF
--- a/lib/DDGC/DB/Result/Thread.pm
+++ b/lib/DDGC/DB/Result/Thread.pm
@@ -131,7 +131,8 @@ sub _build_categories {
 }
 
 sub _category {
-    shift->categories->{$_[1]};
+    my ( $self, $category ) = @_;
+    $self->categories->{$category};
 }
 
 sub started_term {


### PR DESCRIPTION
In old code, `shift` was used before `$_[1]`. Because `shift` **removes** first array element, the `$_[1]` was actually referencing third argument. This commit fixes that.
