### PR TITLE
Don&#039;t double escape comments.

### DIFF
--- a/lib/DDGC/Comments/Comment.pm
+++ b/lib/DDGC/Comments/Comment.pm
@@ -35,7 +35,7 @@ sub has_children {
 
 sub content {
     my $content = shift->db->content;
-    $content =~ s/&/&amp;/g; $content =~ s/>/&gt;/g; $content =~ s/</&lt;/g;
+    $content =~ s/&/&amp;/g; $content =~ s/>/&gt;/g; $content =~ s/</&lt;/g; $content =~ s/\n/<br>/g;
     $content = change_uris($content, sub { "<a href=\"$_[0]\">$_[0]</a>" } );
 }
 

--- a/templates/comment/comment.tt
+++ b/templates/comment/comment.tt
@@ -1,5 +1,5 @@
 <div class="comment">
-	<p class="comment_content"><@ FILTER truncate(200) @><@ comment.content | html | replace("\n", "<br />") @><@ END @>
+	<p class="comment_content"><@ FILTER truncate(200) @><@ comment.content @><@ END @>
 		<@ IF comment.content.length > 200 @>
 			[ <a class="comment_expand_link" href="javascript:;">more</a> ]
                 <span class="comment_expanded_content" style="display:none;">


### PR DESCRIPTION
Previously, `<` has changed into `&amp;lt;`. Now it changes to `&lt;`.
