### PR TITLE
added method="post" to form in modal_login.tx

### DIFF
--- a/templates/modal_login.tx
+++ b/templates/modal_login.tx
@@ -1,6 +1,6 @@
 <div id="login-box" class="reveal-modal modal-form account-form">
 	<h4>Login</h4>
-	<form action="<: $u('My','login') :>">
+	<form action="<: $u('My','login') :>" method="post">
 		<div class="input-wrap"><input type="text" placeholder="Your Username" name="username" class="text" value="<: $username :>" /></div>
 		<div class="input-wrap"><input type="password" placeholder="Your Password" name="password" class="text password" /></div>
 		<fieldset class="buttons">


### PR DESCRIPTION
The user's username and password were being displayed in cleartext in the URL. This should fix that.
