### PR TITLE
Fix for issue #93 - Cannot add github account if it contains a dash

### DIFF
--- a/lib/DDGC/User/Page.pm
+++ b/lib/DDGC/User/Page.pm
@@ -49,7 +49,7 @@ my @attributes = (
 	github => 'Your GitHub username' => {
 		type => 'remote',
 		validators => [sub {
-			m/^[\w\.-_]+$/ ? () : ("Invalid GitHub username")
+			( m/^[\w\-]+$/ && m/^[^\-]/ ) ? () : ("Invalid GitHub username")
 		}],
 		params => {
 			url_prefix => 'https://github.com/',


### PR DESCRIPTION
Github's own rule is:

"Username may only contain alphanumeric characters or dashes and cannot
begin with a dash."

New validator should cover both of these conditions.

The other part of this issue is, Github, as far as I can tell, does not allow non-ASCII characters. Under normal circumstances, \w will match characters of a given encoding rather than bytes. Is there a case for using \p{PerlWord} here?
