### PR TITLE
Fix for issue #93 - Cannot add github account if it contains a dash

### DIFF
--- a/lib/DDGC/User/Page.pm
+++ b/lib/DDGC/User/Page.pm
@@ -49,7 +49,7 @@ my @attributes = (
 	github => 'Your GitHub username' => {
 		type => 'remote',
 		validators => [sub {
-			m/^[\w\.-_]+$/ ? () : ("Invalid GitHub username")
+			( m/^[[:alnum:]-]+$/ && m/^[^-]/ ) ? () : ("Invalid GitHub username")
 		}],
 		params => {
 			url_prefix => 'https://github.com/',


### PR DESCRIPTION
Made a new PR because I'm an idiot and created the original one off my own master branch.

Went with @crazedpsyc's char class suggestion.
