### PR TITLE
Fix for issue #112 - only decrement reply count for 'thread' forums.

### DIFF
--- a/lib/DDGC/DB/Result/Comment.pm
+++ b/lib/DDGC/DB/Result/Comment.pm
@@ -105,6 +105,12 @@ __PACKAGE__->indices(
 
 sub comments { shift->children_rs }
 
+sub comments_count {
+	my ( $self ) = @_;
+	my $count = $self->get_column('comments_count') +
+	            ( ( $self->context eq 'DDGC::DB::Result::Thread' ) ? -1 : 0 );
+}
+
 after insert => sub {
 	my ( $self ) = @_;
 	$self->user->add_context_notification('replies',$self);

--- a/templates/i/comment_rs/forum.tx
+++ b/templates/i/comment_rs/forum.tx
@@ -14,7 +14,7 @@
   <div class="body  body--round">
     <: for results($_) -> $comment { :>
       <: my $context_obj = $comment.get_context_obj :>
-  	  <: my $reply_count = $comment.get_column('comments_count') + ($comment.context == 'DDGC::DB::Result::Thread' ? -1 : 0) :>
+      <: my $reply_count = $comment.comments_count :>
       <: # my $children_count = $context_obj.comment.children.count :>
       <div class="row">
         <div class="forum-item">


### PR DESCRIPTION
The reason this is decremented for forums is that the thread starter is also a comment and is counted in the SQL as a reply.

Other forums don't have a 'comment' thread starter so their reply count is correct.

This fixes the specific off-by-one issue Zac observed, though I think ghostbusting / far off counts warrant further work.
