### PR TITLE
Titles are escaped / entity-ised elsewhere, treating title as plain text should be safe

### DIFF
--- a/lib/DDGC/Web/Controller/Duckduckhack.pm
+++ b/lib/DDGC/Web/Controller/Duckduckhack.pm
@@ -50,7 +50,7 @@ sub fetch_doc {
     my $http_content = $response->decoded_content;
     my $scraper = scraper {
       process "#duckduckhack-body", doc => "HTML";
-      process "title", title => "HTML";
+      process "title", title => "TEXT";
     };
     my $res = $scraper->scrape($http_content);
     $content = $res->{doc};


### PR DESCRIPTION
Thanks to @nilnilnil for pointing this one out.
