### PR TITLE
Attempted fix for $c->user->set_avatar crashes.

### DIFF
--- a/lib/DDGC/DB/Result/User.pm
+++ b/lib/DDGC/DB/Result/User.pm
@@ -445,7 +445,7 @@ sub gravatar_to_avatar {
 		return 0;
 	}
 
-	$self->store_avatar($filename);
+	return unless $self->store_avatar($filename);
 	$self->generate_thumbs;
 }
 
@@ -467,6 +467,7 @@ sub generate_thumbs {
 sub store_avatar {
 	my ($self, $file) = @_;
 	my $destination = ($self->avatar_filename({ mkpath => 1 }));
+	return 0 unless ( -f $file );
 	copy($file, "$destination") or die "Error storing avatar: $!";
 }
 
@@ -500,7 +501,7 @@ sub set_avatar {
 	$self->delete_avatar if (-f $self->avatar_filename . "_delete" );
 	my @files = $self->files_in_stash;
 	return unless @files;
-	$self->store_avatar($files[-1]);
+	return unless $self->store_avatar($files[-1]);
 	$self->generate_thumbs;
 	unlink @files;
 }


### PR DESCRIPTION
Since I am not able to reproduce this, I'm inserting an extra check for
file existence before attempting the copy.

Really, store_avatar should only receive source filenames which exist
from files_in_stash but that appears not to be happening.
