### PR TITLE
Require action token to submit comments.

### DIFF
--- a/lib/DDGC/Web/Controller/Comment.pm
+++ b/lib/DDGC/Web/Controller/Comment.pm
@@ -55,6 +55,7 @@ sub delete : Chained('do') Args(1) {
 sub add :Chained('base') :Args(2) {
 	my ( $self, $c, $context, $context_id ) = @_;
 	return unless $c->user || ! $c->stash->{no_reply};
+	$c->require_action_token;
 	unless ($c->user) {
 		$c->response->redirect($c->chained_uri('My','login'));
 		return $c->detach;

--- a/templates/i/comment_add.tx
+++ b/templates/i/comment_add.tx
@@ -1,5 +1,6 @@
 <: if $context and $context_id and $c.user { :> 
 	<form method="post" class="comment_reply  js-reply_<: $context_id:>  js-hide" action="<: $u('Comment','add',$context,$context_id) :>">    
+		<input type="hidden" name="action_token" value="<: $action_token :>">
 		<div class="user-avatar icon-user">
 			<: i($c.user,'userpic', { userpic_size => 48 }) :>
 		</div>


### PR DESCRIPTION
Applies to all contexts - forums, blog, translations, languages etc.

I see no reason for us not to do this.
