### PR TITLE
Widen emails for mobile (and desktop) viewing, fixes #132

### DIFF
--- a/lib/DDGC.pm
+++ b/lib/DDGC.pm
@@ -543,7 +543,6 @@ sub template_styles {{
 		'border' => '1px solid #d7d7d7',
 		'border-left-width' => '6px',
 		'background-color' => '#ffffff',
-		'margin-right' => '60px',
 		'margin-top' => '-2px',
 		'padding' => '14px',
 	},

--- a/templates/i/event_notification_group/email.tx
+++ b/templates/i/event_notification_group/email.tx
@@ -19,11 +19,11 @@
 			</tr>
 			<: if $_.user_notification_group.email_has_content && cur_user().email_notification_content { :>
 				<tr>
-					<td width="60" colspan="3">&nbsp;</td>
-					<td valign="top">
+					<td width="5" colspan="1">&nbsp;</td>
+					<td valign="top" colspan="4" width="100%">
 						<: i($_,$_.user_notification_group.type ~ '/email') :>
 					</td>
-					<td width="50" colspan="2" valign="top" align="left">&nbsp;</td>
+					<td width="5" colspan="1" valign="top" align="left">&nbsp;</td>
 				</tr>
 			<: } :>
 		</table>


### PR DESCRIPTION
//cc @jbarrett @sdougbrown @chrismorast 

I've attempted to make mobile emails work better. It seems our email template has a lot of (maybe too much?)  whitespace beside the content which looks okay on desktop, but awful on mobile -- specifically iOS. On android in Gmail and AquaMail the template is alright because the content is scaled and I'm able to zoom. I believe this isn't the case on iOS (don't have a phone to test with...).

I'm very new to HTML emails and from the little I've read it seems that CSS @media selectors are sometimes used but aren't very reliable as many popular email apps ignore them.

This fix basically widens the whole notification template.

Before:
![image](https://cloud.githubusercontent.com/assets/873785/3254198/e1877e0a-f1f0-11e3-9a21-20c1418eae4a.png)

After:
![image](https://cloud.githubusercontent.com/assets/873785/3254205/06a55c16-f1f1-11e3-8424-69b26d99e527.png)

If this is a step in the right direction, would either of you happen to know how I can test this?

Alternatively it seems that there might be some webkit specifc css settings we can use to prevent iOS from zooming the text -- that might be a quicker/easier fix. See http://stackoverflow.com/questions/11801685/issue-stopping-iphone-resizing-html-e-mails
