### PR TITLE
Entity-ise msgstrs in po output.

### DIFF
--- a/lib/DDGC/DB/Result/Token/Language.pm
+++ b/lib/DDGC/DB/Result/Token/Language.pm
@@ -5,6 +5,7 @@ use Moose;
 use MooseX::NonMoose;
 extends 'DDGC::DB::Base::Result';
 use DBIx::Class::Candy;
+use HTML::Entities;
 use namespace::autoclean;
 
 table 'token_language';
@@ -151,8 +152,7 @@ sub gettext_snippet {
 sub gettext_escape {
 	my ( $self, $content ) = @_;
 	$content =~ s/\\/\\\\/g;
-#	$content =~ s/\n/\\n/g;
-	$content =~ s/"/\\"/g;
+	$content = HTML::Entities::encode_entities( $content, '<>&\'"' );
 	return $content;
 }
 


### PR DESCRIPTION
Before:

``` po
msgid "affected"
msgstr "\"><img src=x onerror=alert(1)>"

msgid "affectionate"
msgstr "\"><img src=x onerror=alert(1)>"

msgid "afflicted"
msgstr "\"><img src=x onerror=alert(1)>"
```

After:

``` po
msgid "affected"
msgstr "&quot;&gt;&lt;img src=x onerror=alert(1)&gt;"

msgid "affectionate"
msgstr "&quot;&gt;&lt;img src=x onerror=alert(1)&gt;"

msgid "afflicted"
msgstr "&quot;&gt;&lt;img src=x onerror=alert(1)&gt;"
```

Needs integration testing with publisher with live data... has this been done in the past? @yegg @sdougbrown @zekiel @nilnilnil 
