### PR TITLE
[Minor edit:] Fixed casing of GitHub in footer.

### DIFF
--- a/share/perldoc/duckpan.html
+++ b/share/perldoc/duckpan.html
@@ -78,7 +78,7 @@
 				<p class="footer-nav"><a href="https://dukgo.com/base/welcome">Home</a> <a href="https://duckduckgo.com/privacy">Privacy</a> <a href="https://duckduckgo.com/feedback">Feedback</a></p>
 			</div>
 			<div class="twothird">
-				<p>Powered by <a href="http://www.perl.org/" target="_blank">Perl</a> Delivered by <a href="http://nginx.org/" target="_blank">nginx</a> Source at <a href="https://github.com/duckduckgo/community-platform" target="_blank">github</a> &copy; <a href="https://duckduckgo.com">DuckDuckGo, Inc.</a></p>
+				<p>Powered by <a href="http://www.perl.org/" target="_blank">Perl</a> Delivered by <a href="http://nginx.org/" target="_blank">nginx</a> Source at <a href="https://github.com/duckduckgo/community-platform" target="_blank">GitHub</a> &copy; <a href="https://duckduckgo.com">DuckDuckGo, Inc.</a></p>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Fixed casing of GitHub in footer related to DuckPAN.
