### PR TITLE
replace ReleaseOnlyWithLatest with PromptIfStale

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,9 +7,9 @@ license = Perl_5
 copyright_holder = DuckDuckGo, Inc. L<http://duckduckgo.com/>
 copyright_year   = 2014
 
-[ReleaseOnlyWithLatest]
+[PromptIfStale]
 index = http://duckpan.org
-package = Dist::Zilla::Plugin::UploadToDuckPAN
+module = Dist::Zilla::Plugin::UploadToDuckPAN
 
 [Prereqs::FromCPANfile]
 


### PR DESCRIPTION
ReleaseOnlyWithLatest was deprecated today which is causing Travis tests to fail, this fixes that. The chose package, PromptIfStale was suggested by Getty in the POD for ReleaseOnlyWithLatest

//cc @jagtalon @mwmiller @jbarrett 
