### PR TITLE
Fix for reported stack traces.

### DIFF
--- a/lib/DDGC/Web.pm
+++ b/lib/DDGC/Web.pm
@@ -274,10 +274,8 @@ sub wiz_finished {
 sub finalize_error {
 	my $c = shift;
 	my $msg = (ref $c->error eq 'ARRAY') ? join "\n", @{$c->error} : $c->error;
-	$c->clear_errors;
-	my $log_reference = $c->d->errorlog($msg);
-	$c->error("A fatal error occurred and we could not complete your request. If this error persists, please email ddgc\@duckduckgo.com and quote the reference $log_reference.");
-	$c->NEXT::finalize_error();
+	$c->stash->{log_reference} = $c->d->errorlog($msg);
+	$c->next::method();
 }
 
 # Start the application

--- a/templates/error.tx
+++ b/templates/error.tx
@@ -58,7 +58,7 @@
               <img src="/ddgc_static/img/duckduckgo-icon.png" alt="DuckDuckGo" class="media__img  h1" />
               <div class="media__body">
                 <h3>Sorry...</h3>
-                <p><: r($finalize_error) :></p>
+                <p>"A fatal error occurred and we could not complete your request. If this error persists, please email ddgc@duckduckgo.com and quote the reference <: $log_reference :>."</p>
                 <p><a href='/forum'>Discuss</a> | <a href='/duckduckhack'>Develop</a> | <a href='/translate'>Translate</a></p>
               </div>
             </div>


### PR DESCRIPTION
Nuking the errormsg array was wrong. Continue logging and reporting log entry id but leave the error array in place.
