### PR TITLE
Reducing token and translation count cache times to 5 minutes.

### DIFF
--- a/lib/DDGC/Web/Controller/Translate.pm
+++ b/lib/DDGC/Web/Controller/Translate.pm
@@ -39,7 +39,7 @@ sub index :Chained('base') :PathPart('') :Args(0) {
 				alias => 'token_count_col',
 			})->count_rs->as_query,
 		},
-		cache_for => 3600,
+		cache_for => 300,
 	});
 	$c->bc_index;
 }
@@ -209,7 +209,7 @@ sub domain :Chained('logged_in') :PathPart('') :CaptureArgs(1) {
 		},
 		order_by => { -asc => 'language.locale' },
 		prefetch => [ 'language' ],
-		cache_for => 3600,
+		cache_for => 300,
 	});
 	$c->stash->{token_domain_languages} = [$c->stash->{token_domain_languages_rs}->all];
 	for (@{$c->stash->{token_domain_languages}}) {


### PR DESCRIPTION
When people are translating, it would be nice to actually show percentage changes while balancing performance concerns.
