### PR TITLE
Set a default key for Ideas as with Threads.

### DIFF
--- a/lib/DDGC/DB/Result/Idea.pm
+++ b/lib/DDGC/DB/Result/Idea.pm
@@ -199,7 +199,7 @@ sub get_url {
 	$key =~ s/-+/-/g;
 	$key =~ s/-$//;
 	$key =~ s/^-//;
-	return $key;
+	return $key || 'url';
 }
 
 no Moose;


### PR DESCRIPTION
Fully non-ASCII and non-alphanum idea titles can result in keys not being generated which means a method can never be matched to present the Idea content - idea_redirect continues to redirect to itself without a key.

Example:

https://duck.co/ideas/idea/283/

Thanks to @mwmiller for report.

Also needs:

``` sql
UPDATE idea SET key='url' WHERE key='';
```
