### PR TITLE
Remove notifications prefetch_all

### DIFF
--- a/lib/DDGC/DB/Result/User.pm
+++ b/lib/DDGC/DB/Result/User.pm
@@ -305,6 +305,7 @@ sub undone_notifications {
 			event_notifications => [qw( user_notification )],
 		}],
 		order_by => { -desc => 'event_notifications.created' },
+		cache_for => 300,
 		$limit ? ( rows => $limit ) : (),
 	});
 }


### PR DESCRIPTION
This will result in a shed load of database hits for unread notifications, but in my testing that happens to run more quickly than the query generated by the prefetch config.

@yegg @zekiel This is a long-shot effort at improving notification performance.
