### PR TITLE
IA Page <-> Users many_to_many relationship.

### DIFF
--- a/lib/DDGC/DB/Result/InstantAnswer.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer.pm
@@ -169,6 +169,9 @@ column unsafe => {
 has_many 'issues', 'DDGC::DB::Result::InstantAnswer::Issues', 'instant_answer_id';
 has_many 'blocks', 'DDGC::DB::Result::InstantAnswer::Blocks', 'instant_answer_id';
 
+has_many 'instant_answer_users', 'DDGC::DB::Result::InstantAnswer::Users', 'instant_answer_id';
+many_to_many 'users', 'instant_answer_users', 'user';
+
 no Moose;
 __PACKAGE__->meta->make_immutable;
 

--- a/lib/DDGC/DB/Result/InstantAnswer/Users.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer/Users.pm
@@ -1,0 +1,29 @@
+package DDGC::DB::Result::InstantAnswer::Users;
+# ABSTRACT: Users with write access to IA pages
+
+use Moose;
+use MooseX::NonMoose;
+extends 'DDGC::DB::Base::Result';
+use DBIx::Class::Candy;
+use DateTime::Format::Human::Duration;
+use namespace::autoclean;
+
+table 'instant_answer_users';
+
+column instant_answer_id => {
+	data_type => 'text',
+};
+
+column users_id => {
+	data_type => 'bigint',
+};
+
+primary_key (qw/instant_answer_id users_id/);
+
+belongs_to 'instant_answer', 'DDGC::DB::Result::InstantAnswer', 'instant_answer_id';
+belongs_to 'user', 'DDGC::DB::Result::User', 'users_id';
+
+
+no Moose;
+__PACKAGE__->meta->make_immutable;
+

--- a/lib/DDGC/DB/Result/User.pm
+++ b/lib/DDGC/DB/Result/User.pm
@@ -193,6 +193,9 @@ has_many 'github_users', 'DDGC::DB::Result::GitHub::User', 'users_id', {
   cascade_delete => 0,
 };
 
+has_many 'instant_answer_users', 'DDGC::DB::Result::InstantAnswer::Users', 'users_id';
+many_to_many 'instant_answers', 'instant_answer_users', 'instant_answer';
+
 many_to_many 'languages', 'user_languages', 'language';
 
 belongs_to 'profile_media', 'DDGC::DB::Result::Media', 'profile_media_id', { join_type => 'left' };

--- a/lib/DDGC/DB/ResultSet/InstantAnswer/Users.pm
+++ b/lib/DDGC/DB/ResultSet/InstantAnswer/Users.pm
@@ -1,0 +1,9 @@
+package DDGC::DB::ResultSet::InstantAnswer::Users;
+# ABSTRACT: Resultset class for Instant Answer Users
+
+use Moose;
+extends 'DDGC::DB::Base::ResultSet';
+use namespace::autoclean;
+
+1;
+


### PR DESCRIPTION
DDL:

``` sql
CREATE TABLE "instant_answer_users" (
  "instant_answer_id" text NOT NULL,
  "users_id" bigint NOT NULL,
  PRIMARY KEY ("instant_answer_id", "users_id")
);

ALTER TABLE "instant_answer_users" ADD CONSTRAINT "instant_answer_users_fk_instant_answer_id" FOREIGN KEY ("instant_answer_id")
  REFERENCES "instant_answer" ("id") ON DELETE RESTRICT ON UPDATE CASCADE DEFERRABLE;

ALTER TABLE "instant_answer_users" ADD CONSTRAINT "instant_answer_users_fk_users_id" FOREIGN KEY ("users_id")
  REFERENCES "users" ("id") ON DELETE RESTRICT ON UPDATE CASCADE DEFERRABLE;
```

Demo:

```
$ use lib 'lib'; use DDGC; my $d = DDGC->new
$DDGC1 = DDGC=HASH(0x2d52408);

$ my $ia = $d->rs('InstantAnswer')->first;  
DDGC::DB::Result::InstantAnswer #laser_ship

$ $ia->users                                

$ my $user = $d->rs('User')->first;         
DDGC::DB::Result::User #1

$ $ia->add_to_users($user)         
DDGC::DB::Result::User #1

$ $ia->users                       
DDGC::DB::Result::User #1

$ $user->instant_answers  
DDGC::DB::Result::InstantAnswer #laser_ship
```
