### PR TITLE
Use a maximum of 2 units when describing comment / thread age.

### DIFF
--- a/lib/DDGC/Util/DateTime.pm
+++ b/lib/DDGC/Util/DateTime.pm
@@ -21,7 +21,7 @@ sub dur {
 
 	$units = [qw/ days hours /]    if ($diff->days > 0);
 	$units = [qw/ months days /]   if ($diff->months > 0);
-	$units = [qw/ years months /]  if ($diff->years > 0);
+	$units = [qw/ years /]  if ($diff->years > 0);
 
 	return DateTime::Format::Human::Duration->new->format_duration(
 		$diff,


### PR DESCRIPTION
Issue #175
