### PR TITLE
fix index column headers

### DIFF
--- a/js/ia_pages/index.handlebars
+++ b/js/ia_pages/index.handlebars
@@ -1,3 +1,33 @@
+<table>
+
+<thead style="border-bottom: 1px solid #CCC">
+<tr>
+<td> </td>
+<td>
+    <a id="sort_name">name</a>
+</td>
+
+<td>
+    <a id="sort_descr">description</a>
+</td>
+<td>
+    <a id="sort_src">source</a>
+</td>
+<td>
+    <a id="sort_status">status</a>
+</td>
+<td>
+    topics
+</td>
+
+<td>
+    <a id="sort_repo">repo</a>
+</td>
+</tr>
+</thead>
+
+<tbody>
+
 
 
 {{#each ia}}
@@ -18,13 +48,14 @@
         {{src_name}}
     </td>
 
+    <td style="padding-right: 1em">
+        {{dev_milestone}}
+    </td>
+
     <td>
         {{#each topic}} <span class="ia_topic">{{this}}</span> {{/each}}
     </td>
 
-    <td style="padding-right: 1em">
-        {{dev_milestone}}
-    </td>
 
     <td style="padding-right: 1em">
         {{repo}}
@@ -32,3 +63,7 @@
 
 </tr>
 {{/each}}
+
+</tbody>
+
+</table>

--- a/root/static/css/ia.css
+++ b/root/static/css/ia.css
@@ -39,3 +39,6 @@
 	display: none;
 }
 
+#ia_index td {
+    padding-left:4px;
+}

--- a/templates/instantanswer/index.tx
+++ b/templates/instantanswer/index.tx
@@ -2,33 +2,6 @@
 
 <p>this is an alpha prototype of the full index to Instant Answers.</p>
 
-<table>
 
-<thead style="border-bottom: 1px solid #CCC">
-<tr>
-<td> </td>
-<td>
-    <a id="sort_name">name</a>
-</td>
-<td>
-    topic
-</td>
-
-<td>
-    <a id="sort_descr">description</a>
-</td>
-<td>
-    <a id="sort_status">stat</a>
-</td>
-
-<td>
-    <a id="sort_repo">repo</a>
-</td>
-</tr>
-</thead>
-
-<tbody id="ia_index">
-
-</tbody>
-
-</table>
+<div id="ia_index">
+</div>


### PR DESCRIPTION
quick fix on column headers on the index page. moved table definition to handlebars template.

@MariagraziaAlastra 
