### PR TITLE
Commit user edits

### DIFF
--- a/script/ddgc_commit_edits.pm
+++ b/script/ddgc_commit_edits.pm
@@ -9,56 +9,94 @@ use JSON;
 
 my $d = DDGC->new;
 
-my $results = $d->rs('InstantAnswer')->search( {updates => { '!=', undef}});
 
-# each IA that has an update
-while( my $ia = $results->next() ){
+my $argv = $ARGV[0];
 
-    my $edits = from_json($ia->get_column('updates'));
-    my $ia_name = $ia->get_column('name');
-    print "IA: $ia_name\n";
+if($argv){
+    commit_edits($argv);
+}
+else{
+    list_ia_with_edits();
+}
 
-    # each edit
-    foreach my $edit (@{ $edits }){
-       my $time  = '';
-       my $field = '';
-       my $value = '';
-       my $input = '';
 
-       # get time for the edit
-       foreach $time (keys %{$edit}) {
+sub list_ia_with_edits {
+    my $results = $d->rs('InstantAnswer')->search( {updates => { '!=', undef}});
+    print "No staged edits\n" if $results == 0;
+    print "The following IAs have staged edits\n" if $results != 0;
+    while( my $ia = $results->next() ){
+        my $name = $ia->get_column('name');
+        print qq(\t$name\n);
+    }
+}
 
-           # each field in the edit
-            foreach $field (keys %{ $edit->{$time} } ){
-                $value = $edit->{$time}->{$field};
-                my $orig_val = $ia->get_column($field);
+sub commit_edits {
 
-                # see if this field has changed
-                if($value eq $orig_val){
-                    # warn "Skipping  unchanged field\n";
-                }
-                else{
-                    print "Field: $field\n";
-                    print "\tEdit: $edit->{$time}->{$field}\n";
-                    print "\tOrig: $orig_val\n\n";
+    my $results = $d->rs('InstantAnswer')->search( {name => ucfirst $argv});
 
-                    while(check_input($input)){
-                        print "Accept Edit? [y/n]: ";
-                        $input = <>;
-                        chomp $input;
+    if($results == 0){
+        print "No IA named $argv\n";
+        exit 0;
+    }
+
+    # each IA that has an update
+    while( my $ia = $results->next() ){
+
+
+        my $edits = $ia->get_column('updates');
+
+        if(!$edits){
+            print "No staged edits for $argv\n";
+            exit 0;
+        }
+
+        $edits = from_json($edits);
+
+        my $ia_name = $ia->get_column('name');
+        print "IA: $ia_name\n";
+
+        # each edit
+        foreach my $edit (@{ $edits }){
+            my $time  = '';
+            my $field = '';
+            my $value = '';
+            my $input = '';
+
+            # get time for the edit
+            foreach $time (keys %{$edit}) {
+
+                # each field in the edit
+                foreach $field (keys %{ $edit->{$time} } ){
+                    $value = $edit->{$time}->{$field};
+                    my $orig_val = $ia->get_column($field);
+
+                    # see if this field has changed
+                    if($value eq $orig_val){
+                        # warn "Skipping  unchanged field\n";
                     }
-                    print "\n";
+                    else{
+                        print "Field: $field\n";
+                        print "\tEdit: $edit->{$time}->{$field}\n";
+                        print "\tOrig: $orig_val\n\n";
 
-                    # update the data in the db
-                    if($input eq "y" || $input eq "Y"){
-                        print "updating field\n\n";
-                        $ia->update({$field => $value});
+                        while(check_input($input)){
+                            print "Accept Edit? [y/n]: ";
+                            $input = <STDIN>;
+                            chomp $input;
+                        }
+                        print "\n";
+
+                        # update the data in the db
+                        if($input eq "y" || $input eq "Y"){
+                            print "updating field\n\n";
+                            $ia->update({$field => $value});
+                        }
                     }
                 }
             }
         }
+        $ia->update({updates => undef});
     }
-    $ia->update({updates => undef});
 }
 
 sub check_input {


### PR DESCRIPTION
@jbarrett @russellholt @MariagraziaAlastra 

Added a script that goes through all the staged user edits and asks if you would like to add the change or not.  Accepted changes are made to the appropriate field in the database and unaccepted edits are thrown out.  This doesn't do anything for multiple edits to the same field though.

I made some edits to two IAs (calculator, lyrics).  The output from the script is below
![selection_259](https://cloud.githubusercontent.com/assets/1882892/4984768/d0a0fff0-6926-11e4-8260-a799c6f5f054.png)
