### PR TITLE
Fix links breaking when sessions expire.

### DIFF
--- a/lib/DDGC/Web/Controller/Root.pm
+++ b/lib/DDGC/Web/Controller/Root.pm
@@ -214,14 +214,15 @@ sub redirect_duckco :Chained('base') :PathPart('topic') :Args(1) {
 sub redir :Chained('base') :PathPart('redir') :Args(0) {
 	my ( $self, $c ) = @_;
 	$c->stash->{not_last_url} = 1;
-	$c->require_action_token;
-	$c->session->{r_url} = url_decode_utf8($c->req->param('u'));
-	$c->response->redirect($c->chained_uri('Root','r'));
+	$c->session->{r_url} = $c->req->param('url');
+	$c->stash->{x} = { ok => 1 };
+	$c->forward( $c->view('JSON') );
 	return $c->detach;
 }
 
 sub r :Chained('base') :PathPart('r') :Args(0) {
 	my ( $self, $c ) = @_;
+	sleep(5);
 	if (!$c->session->{r_url}) {
 		$c->response->redirect($c->chained_uri('Root','index'));
 		return $c->detach;

--- a/root/static/js/ddgc.js
+++ b/root/static/js/ddgc.js
@@ -52,9 +52,10 @@ $(document).ready(function() {
 		e.preventDefault();
 	});
 
-	$("a[href^='http']").mousedown(function() {
+	$("a[href^='http']").click(function(e) {
 		if (this.href.indexOf(location.hostname) === -1) {
-			set_url_to_redirect(this);
+			e.preventDefault();
+			perform_redirect(this);
 		}
 	});
 
@@ -721,8 +722,19 @@ $(document).ready(function() {
 
 /* random functions gogo */
 
-function set_url_to_redirect(link) {
-    link.href = '/redir/?u=' + encodeURIComponent(link.href) + '&action_token=' + $('meta[name="action-token"]').attr('content');
+function perform_redirect(link) {
+	$.ajax({
+		url:        '/redir',
+		data:       {url : link.href},
+		type:       'POST',
+		success:    function(data) {
+			if (link.getAttribute('target') == '_blank') {
+				window.open('/r');
+			} else {
+				window.location = '/r';
+			}
+		},
+	});
 }
 
 function showFormAddUserLanguage() {


### PR DESCRIPTION
- Do not require CSRF token to stash session URL.
- Perform actual redirect in click event handler.

This currently only works if you left-click the link - if you elect to open it in a new tab with middle / right click, no redirect happens.
#302
