### PR TITLE
IA Pages index - replace "this is an alpha prototype of the full index to Instant Answers" with a description of the page.

### DIFF
--- a/js/ia_pages/IAIndex.js
+++ b/js/ia_pages/IAIndex.js
@@ -14,7 +14,15 @@
             var ind = this;
             var field = $("#ia_index").attr("field");
             var value = $("#ia_index").attr("value");
-            var url = ((field && value) && (field !== "topic"))? "/ia/json/" + field + "/" + value : "/ia/json";
+            var url = "/ia/json";
+            
+            if (field && value) {
+               $(".breadcrumbs").append(field + ': <span class="idx_filter">' + value + '</span>');
+
+               if (field !== "topic") {
+                  url += "/" + field + "/" + value;
+               }
+            }
 
             $("#sort_name").on('click',   DDH.IAIndex.prototype.sort.bind(this, 'name'));
             $("#sort_descr").on('click',  DDH.IAIndex.prototype.sort.bind(this, 'description'));

--- a/root/static/css/ia.css
+++ b/root/static/css/ia.css
@@ -94,3 +94,6 @@
 #ia_index td {
     padding-left:4px;
 }
+.idx_filter {
+    text-transform: capitalize;
+}

--- a/templates/instantanswer/index.tx
+++ b/templates/instantanswer/index.tx
@@ -1,6 +1,13 @@
 <h2>Instant Answers</h2>
 
-<p>this is an alpha prototype of the full index to Instant Answers.</p>
+<p>Showing all Instant Answers 
+   <: if ($field && $value) { :>  
+       with <: $field :>: 
+       <span class="idx_filter">
+           <: $value :> 
+       </span> 
+   <: } :>
+</p>
 
 
 <div id="ia_index" field="<: $field :>" value="<: $value :>">


### PR DESCRIPTION
@russellholt @jdorweiler @jbarrett 

Filter by topic:
![screen shot 2014-11-04 at 12 44 04](https://cloud.githubusercontent.com/assets/3652195/5009988/76193b86-6a6d-11e4-8d95-8ab9ffdeb52c.png)

Filter by status:
![screen shot 2014-11-04 at 12 44 17](https://cloud.githubusercontent.com/assets/3652195/5009956/32ecd11a-6a6d-11e4-9341-e357d113aff7.png)

No filter:
![screen shot 2014-11-04 at 12 45 41](https://cloud.githubusercontent.com/assets/3652195/5009959/370256ee-6a6d-11e4-9f9f-71ed6d23acc0.png)
