### PR TITLE
Stop crashing when the IA idea no longer exists.

### DIFF
--- a/lib/DDGC/Web/Controller/Forum.pm
+++ b/lib/DDGC/Web/Controller/Forum.pm
@@ -221,10 +221,6 @@ sub thread_id : Chained('thread_view') PathPart('thread') CaptureArgs(1) {
     return $c->detach;
   }
 
-  if ($c->stash->{thread}->migrated_to_idea) {
-    $c->response->redirect($c->chained_uri('Ideas','idea',$c->stash->{thread}->migrated_to_idea));
-    return $c->detach;
-  }
   if ($c->stash->{thread}->ghosted &&
      ($c->stash->{thread}->checked || $c->stash->{thread}->comment->checked) &&
      (!$c->user || (!$c->user->admin && $c->stash->{thread}->users_id != $c->user->id))) {
@@ -245,6 +241,10 @@ sub thread_id : Chained('thread_view') PathPart('thread') CaptureArgs(1) {
       $c->response->redirect($c->chained_uri('Forum','general',{ thread_notallowed => 1 }));
       return $c->detach;
     }
+  }
+  if ($c->stash->{thread}->migrated_to_idea) {
+    $c->response->redirect($c->chained_uri('Ideas','idea',$c->stash->{thread}->migrated_to_idea));
+    return $c->detach;
   }
   $c->stash->{title} = $c->stash->{thread}->title;
   $self->get_sticky_threads($c);

--- a/lib/DDGC/Web/Controller/Ideas.pm
+++ b/lib/DDGC/Web/Controller/Ideas.pm
@@ -131,10 +131,6 @@ sub idea_id : Chained('base') PathPart('idea') CaptureArgs(1) {
 	my ( $self, $c, $id ) = @_;
 	$c->stash->{idea} = $c->d->rs('Idea')->find($id);
 
-	if ($c->stash->{idea}->migrated_to_thread) {
-		$c->response->redirect($c->chained_uri('Forum','thread',$c->stash->{idea}->migrated_to_thread));
-		return $c->detach;
-	}
 	unless ($c->stash->{idea}) {
 		$c->response->redirect($c->chained_uri('Ideas','index',{ idea_notfound => 1 }));
 		return $c->detach;
@@ -145,6 +141,10 @@ sub idea_id : Chained('base') PathPart('idea') CaptureArgs(1) {
 		$c->response->redirect($c->chained_uri('Ideas','index',{ idea_notfound => 1 }));
 	}
 
+	if ($c->stash->{idea}->migrated_to_thread) {
+		$c->response->redirect($c->chained_uri('Forum','thread',$c->stash->{idea}->migrated_to_thread));
+		return $c->detach;
+	}
 
 	$c->add_bc($c->stash->{idea}->title,$c->chained_uri(@{$c->stash->{idea}->u}));
 	$self->add_latest_ideas($c);


### PR DESCRIPTION
I made a mistake when programming the migrated to thread redirect.
This rectifies it by moving the migrated check to after the exists /
ghosted check.

This also moves the thread -> idea migrated check to after the
permissions checks. There's no interface element exposed to migrate
non-general threads to IA ideas, but I think belts look smashing with
braces.
