### PR TITLE
Sometime the first call to SQL::Translator::translate crashes.

### DIFF
--- a/script/ddgc_db_autoupgrade.pl
+++ b/script/ddgc_db_autoupgrade.pl
@@ -33,6 +33,8 @@ my $old_schema = DDGC::DBOld->connect($ddgc);
 my $old_translator = SQL::Translator->new( parser => 'SQL::Translator::Parser::DBIx::Class', parser_args => { dbic_schema => $old_schema, add_fk_index => 0 } );
 my $new_translator = SQL::Translator->new( parser => 'SQL::Translator::Parser::DBIx::Class', parser_args => { dbic_schema => $schema, add_fk_index => 0 } );
 
+$old_translator->translate; $new_translator->translate;
+
 my @diff = SQL::Translator::Diff::schema_diff(
 	$old_translator->translate(), $old_schema->storage->sqlt_type,
 	$new_translator->translate(), $schema->storage->sqlt_type,


### PR DESCRIPTION
This adds calls for the new and old schemas in ddgc_db_autoupgrade.pl and discards the result (yes, it's a nasty workaround).
