### PR TITLE
Stop dezi crashing / corrupting index when indexing threads.

### DIFF
--- a/lib/DDGC/Forum.pm
+++ b/lib/DDGC/Forum.pm
@@ -202,11 +202,11 @@ sub add_thread {
 		});
 
 		$self->index(
+			title => $thread->title,
 			uri => $thread->id,
 			body => $content,
 			id => $thread->id,
 			is_markup => 1,
-			%params,
 		);
 	});
 


### PR DESCRIPTION
Sending all the thread params is confusing libswish. Once dezi goes down with this issue, it's not going to come back up until the index has been rebuilt.

@malbin @zekiel 
