### PR TITLE
IA Pages - add cancel button for edit mode

### DIFF
--- a/js/ia_pages/IAPage.js
+++ b/js/ia_pages/IAPage.js
@@ -104,10 +104,17 @@
                         $("#new_topic").parent().parent().removeClass("hide");
                     });
 
+                    $("body").on('click', '.button.cancel', function(evt) {
+                        var $obj = $(this).parent();
+                        var name = $(this).attr('name');
+
+                        $obj.replaceWith(Handlebars.templates['pre_edit_' + name](x));
+                    });
+
                     $("body").on('focusout keypress', '.editable input', function(evt) {
                         if (evt.type === 'focusout' || (evt.type === 'keypress' && evt.which === 13)) {
-                            var $obj = $(this).parent();
-                            var field = $obj.attr('name');
+                            var $obj = $(this).parent().parent();
+                            var field = $(this).parent().attr('name');
                             var value = $(this).val();
 
                             if ($obj.attr('id') === 'input_example') {

--- a/js/ia_pages/edit_description.handlebars
+++ b/js/ia_pages/edit_description.handlebars
@@ -1,1 +1,7 @@
-<p id="desc" class="editable clearfix" name="description"><input type="text" value="{{description}}" /></p>
+<div>
+    <p id="desc" class="editable left" name="description">
+        <input type="text" value="{{description}}" />
+    </p>
+    <div class="button cancel left" name="description">Cancel</div>
+    <span class="clearfix"></span>
+</div>

--- a/js/ia_pages/edit_devinfo.handlebars
+++ b/js/ia_pages/edit_devinfo.handlebars
@@ -31,5 +31,6 @@
         </tr>
     </table>
 
-    <div class="button end">OK</div>
+    <div class="button end left">OK</div>
+    <div class="button cancel left" name="devinfo">Cancel</div>
 </div>

--- a/js/ia_pages/edit_examples.handlebars
+++ b/js/ia_pages/edit_examples.handlebars
@@ -28,5 +28,7 @@
         <li class="editpage"><div class="button listbutton" id="add_example" title="Add example"><span>+</span></div></li>
     </ul>
 
-    <div class="button end">OK</div>
+    <div class="button end left">OK</div>
+    <div class="button cancel left" name="examples">Cancel</div>
+    <span class="clearfix"></span>
 </div>

--- a/js/ia_pages/edit_name.handlebars
+++ b/js/ia_pages/edit_name.handlebars
@@ -1,1 +1,4 @@
-<h2 class="left editable" id="name" name="name"><input type="text" value="{{name}}" /></h2>
+<div class="left">
+    <h2 class="left editable" id="name" name="name"><input type="text" value="{{name}}" /></h2>
+    <div class="button left cancel" name="name">Cancel</div>
+</div>

--- a/js/ia_pages/edit_status.handlebars
+++ b/js/ia_pages/edit_status.handlebars
@@ -1,1 +1,5 @@
-<div class="right tag editable status {{status}}" name="status"><input type="text" value="{{status}}" /></div>
+<div class="right">
+    <div class="left tag editable status {{status}}" name="status"><input type="text" value="{{status}}" /></div>
+    <div class="right cancel button" name="status">Cancel</div>
+</div>
+<span class="clearfix"></span>

--- a/js/ia_pages/edit_topic.handlebars
+++ b/js/ia_pages/edit_topic.handlebars
@@ -24,4 +24,5 @@
     </div>
     <div class="button listbutton" id="add_topic" title="Add topic"><span>+</span></div>
     <div class="button end">OK</div>
+    <div class="button cancel" name="topic">Cancel</div>
 </div>

--- a/root/static/css/ia.css
+++ b/root/static/css/ia.css
@@ -65,7 +65,8 @@
 .ia-single ul li.editpage {
     list-style: none;
 }
-.ia-single ul li.editpage .newentry {
+.ia-single ul li.editpage .newentry,
+.ia-single .button.cancel {
     margin-left: 0.25em;
 }
 .ia-single .button#cancel {


### PR DESCRIPTION
@russellholt Clicking on the cancel button will redraw the section with the proper pre-edit template without saving the changes.

[Screencast](http://gfycat.com/SilentPleasantDwarfrabbit#?speed=2)

Screenshot:
![screen shot 2014-11-03 at 16 07 02](https://cloud.githubusercontent.com/assets/3652195/5089882/619960a2-6f3e-11e4-8b52-b82ec3fa3dbf.png)
