### PR TITLE
check for array

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -292,7 +292,7 @@ sub get_edits {
     try{
         $edits = from_json($ia_result->get_column('updates'));
     }catch{
-        return 0;
+        return;
     };
 
     return $edits;

--- a/script/ddgc_commit_edits.pl
+++ b/script/ddgc_commit_edits.pl
@@ -36,7 +36,7 @@ sub list_ia_with_edits {
 sub commit_edits {
 
     my $edits = DDGC::Web::Controller::InstantAnswer::get_edits($d, ucfirst $argv);
-    return unless ref $edits eq 'ARRAY';
+    return unless $edits;
 
     my $results = $d->rs('InstantAnswer')->search({name => ucfirst $argv});
     my $ia = $results->first();


### PR DESCRIPTION
fix for bug: Can't use string ("0") as an ARRAY ref while "strict refs" in use at script/ddgc_commit_edits.pl line 46.

@MariagraziaAlastra 
