### PR TITLE
Check but silently ignore failure of action token requirement for logout

### DIFF
--- a/lib/DDGC/Web/Controller/My.pm
+++ b/lib/DDGC/Web/Controller/My.pm
@@ -20,9 +20,11 @@ sub base :Chained('/base') :PathPart('my') :CaptureArgs(0) {
 sub logout :Chained('base') :Args(0) {
 	my ( $self, $c ) = @_;
 	$c->stash->{not_last_url} = 1;
-	$c->require_action_token;
-	$c->logout;
-	$c->delete_session;
+	try {
+		$c->require_action_token;
+		$c->logout;
+		$c->delete_session;
+	};
 	$c->response->redirect($c->chained_uri('Root','index'));
 	return $c->detach;
 }


### PR DESCRIPTION
Since the most common cause of an invalid action token in this case is an expired session, simple redirect to / and it will reflect the session invalidation.

This still prevents construction of a working '/logout' url.
