### PR TITLE
IA Pages - display template field on static pages

### DIFF
--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -25,6 +25,7 @@
                         description : Handlebars.templates.description(x),
                         topic : Handlebars.templates.topic(x),
                         screens : Handlebars.templates.screens(x),
+                        template : Handlebars.templates.template(x),
                         examples : Handlebars.templates.examples(x),
                         devinfo : Handlebars.templates.devinfo(x)
                     };
@@ -36,8 +37,9 @@
                         description : Handlebars.templates.pre_edit_description(x),
                         topic : Handlebars.templates.pre_edit_topic(x),
                         screens : Handlebars.templates.screens(x),
+                        template : Handlebars.templates.template(x),
                         examples : Handlebars.templates.pre_edit_examples(x),
-                        devinfo : Handlebars.templates.pre_edit_devinfo(x)
+                        devinfo : Handlebars.templates.devinfo(x)
                     };
 
                     DDH.IAPage.prototype.updateAll(readonly_templates);
@@ -243,6 +245,7 @@
             'description',
             'topic',
             'screens',
+            'template',
             'examples',
             'devinfo',
             'issues'

--- a/src/templates/template.handlebars
+++ b/src/templates/template.handlebars
@@ -1,0 +1,8 @@
+{{#if template}}
+    <p>
+        <strong>Template:</strong> 
+        <a href="/ia/template/{{encodeURIComponent template}}" title="See all IAs with the same template">
+            {{template}}
+        </a>
+    </p>
+{{/if}}


### PR DESCRIPTION
@russellholt 

Thanks to @jagtalon we can now display the template field on IA Pages!
![screen shot 2014-12-07 at 15 52 29](https://cloud.githubusercontent.com/assets/3652195/5327781/e816207c-7d60-11e4-8248-892c81d86ee9.png)
