### PR TITLE
GithubMeta was causing a conflict which prevented build / release.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -34,8 +34,6 @@ exclude_filename=script/ddgc_release.sh
 [ExecDir]
 [ShareDir]
 [MakeMaker]
-;[MakeMaker::SkipInstall]
-[EOLTests]
 trailing_whitespace = 0
 [Manifest]
 [TestRelease]
@@ -54,7 +52,6 @@ directory = inc/
 version_regexp = ^(.+)$
 [PkgVersion]
 [PodSyntaxTests]
-[GithubMeta]
 [Repository]
 
 [Git::ExcludeUntracked]


### PR DESCRIPTION
Nix it, it's not vital. Also losing commented out MakeMaker::SkipInstall and deprecated EOLTests.
