### PR TITLE
use grunt to revert dev files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -209,7 +209,8 @@ module.exports = function(grunt) {
          * revert the version number in package.json
          */
         exec: {
-            revert: "./script/revert_pkg_version.pl"
+            revert: "./script/revert_pkg_version.pl",
+            revert_release: "./script/revert_pkg_version.pl release"
         },
 
         /*
@@ -254,6 +255,8 @@ module.exports = function(grunt) {
         grunt.registerTask('default', build_tasks);
 
         grunt.registerTask('revert', ['exec:revert']);
+        
+        grunt.registerTask('revert-release', ['exec:revert_release']);
         
         // add modules here
         grunt.loadNpmTasks('grunt-contrib-concat');

--- a/script/revert_pkg_version.pl
+++ b/script/revert_pkg_version.pl
@@ -11,19 +11,30 @@ my $version;
 
 my @file_lines = $grunt_package_file->lines;
 
-for(my $i = 0; $i < scalar @file_lines; $i++){
-    if($file_lines[$i] =~ m/version": "(\d+).(\d+).(\d)/){
-        $version  = $2;
-        $version--;
-        $file_lines[$i] = qq(  "version": "$1.$version.$3",). "\n";
+my $revert_release = $ARGV[0];
+
+if($revert_release){
+    for(my $i = 0; $i < scalar @file_lines; $i++){
+        if($file_lines[$i] =~ m/version": "(\d+).(\d+).(\d)/){
+            $version  = $2;
+            $version--;
+            $file_lines[$i] = qq(  "version": "$1.$version.$3",). "\n";
+        }
     }
+
+    $grunt_package_file->spew(@file_lines);
+
+    path("root/static/css/ia0.$version.0.css")->remove;
+    path("root/static/css/ddgc0.$version.0.css")->remove;
+    path("root/static/js/ia0.$version.0.js")->remove;
+    path("root/static/js/ddgc0.$version.0.js")->remove;
+
+    print qq(Reverting to version: 0.$version.0);
 }
 
-$grunt_package_file->spew(@file_lines);
 
-path("root/static/css/ia0.$version.0.css")->remove;
-path("root/static/css/ddgc0.$version.0.css")->remove;
-path("root/static/js/ia0.$version.0.js")->remove;
-path("root/static/js/ddgc0.$version.0.js")->remove;
-
-print qq(Reverting to version: 0.$version.0);
+path("root/static/css/ia.css")->remove;
+path("root/static/css/ddgc.css")->remove;
+path("root/static/js/ia.js")->remove;
+path("root/static/js/ddgc.js")->remove;
+path("src/templates/handlebars_tmp")->remove;


### PR DESCRIPTION
@russellholt @MariagraziaAlastra @jbarrett 

Slight change to `grunt revert`

`grunt revert`: Rolls back a grunt build, removes all dev files (ia.js ddgc.js ... )
`grunt revert-release`: Rolls back a grunt release, removes all version and dev files.
