### PR TITLE
dist.ini : Adding Test::EOL replacing EOLTests and GithubMeta replacing Repository

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -34,6 +34,7 @@ exclude_filename=script/ddgc_release.sh
 [ExecDir]
 [ShareDir]
 [MakeMaker]
+[Test::EOL]
 trailing_whitespace = 0
 [Manifest]
 [TestRelease]
@@ -52,7 +53,9 @@ directory = inc/
 version_regexp = ^(.+)$
 [PkgVersion]
 [PodSyntaxTests]
-[Repository]
+[GithubMeta]
+homepage = https://duck.co/
+issues = 1
 
 [Git::ExcludeUntracked]
 


### PR DESCRIPTION
Previously, #381 

Thanks to @moollaza for tracking down source of conflict and suggesting a cleaner solution.
