### PR TITLE
InstantAnswer.pm - omit 'test' topic from IA Pages Index

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -31,7 +31,7 @@ sub index :Chained('base') :PathPart('') :Args() {
     my $rs = $c->d->rs('Topic');
     
     my @topics = $rs->search(
-        {},
+        {'name' => { '!=' => 'test' }},
         {
             columns => [ qw/ name id /],
             result_class => 'DBIx::Class::ResultClass::HashRefInflator',
@@ -56,7 +56,7 @@ sub ialist_json :Chained('base') :PathPart('json') :Args() {
     }
 
     my @ial = $rs->search(
-        {},
+        {'topic.name' => { '!=' => 'test' }},
         {
             columns => [ qw/ name id repo src_name dev_milestone description template / ],
             prefetch => { instant_answer_topics => 'topic' },


### PR DESCRIPTION
@russellholt FirstGoodies and Is Awesome IAs will have the 'test' category, so that they can be easily hidden on the IA Pages Index.
I would obviously prefer to test this when the new metadata with the updated topics for those IAs will be available, but in the meantime I guarantee this at least doesn't break anything! :smile: 

Thanks @jbarrett for correcting my 'where' clause, I wouldn't have guessed the right syntax in a million years!
