### PR TITLE
IAPage: Don't automatically add periods.

### DIFF
--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -2,14 +2,6 @@
     // Handlebars helpers
     Handlebars.registerHelper('encodeURIComponent', encodeURIComponent);
 
-    Handlebars.registerHelper('addPeriod', function(description) {
-        if(!/\.$/.test(description)) {
-            return description + ".";
-        }
-
-        return description;
-    });
-
     // placeholder
 
     DDH.IAPage = function(ops) {

--- a/src/templates/description.handlebars
+++ b/src/templates/description.handlebars
@@ -4,6 +4,6 @@
     <span class="btn--wire topic ia-single--topic">{{this}}</span>
   {{/each}}
   {{#if description}}
-    <p>{{addPeriod description}}</p>
+    <p>{{description}}</p>
   {{/if}}
 </div>

--- a/src/templates/screens.handlebars
+++ b/src/templates/screens.handlebars
@@ -4,7 +4,7 @@
     <span class="btn--wire topic ia-single--topic">{{this}}</span>
   {{/each}}
   {{#if description}}
-    <p>{{addPeriod description}}</p>
+    <p>{{description}}</p>
   {{/if}}
 </div>
 <a href="/edit" class="hide ia-single--edit btn--primary topic right ia-single--topic">Edit Page</a>


### PR DESCRIPTION
Let's just depend on the metadata instead of adding a period automatically in the description.