### PR TITLE
IAPage: Hide the image's red bar, and create one in HTML.

### DIFF
--- a/src/ia/css/ia.css
+++ b/src/ia/css/ia.css
@@ -689,6 +689,14 @@ body.texture {
     border: 1px solid #DBDBDB;
     border-top-style: none;
     border-bottom-style: none;
+    position: relative;
+    top: -4px;
+    z-index: -1;
+}
+
+.ia-single--red-bar {
+    height: 3px;
+    background-color: #DE5833;
 }
 
 .ia-single--serp {

--- a/src/templates/screens.handlebars
+++ b/src/templates/screens.handlebars
@@ -15,6 +15,7 @@
     <span class="circle"></span>
   </div>
   <div class="ia-single--screenshots-top"></div>
+  <div class="ia-single--red-bar"></div>
   <div class="ia-single--image-container">
     <img src="https://images.duckduckgo.com/iu/?u={{encodeURIComponent 'https://ia-screenshots.s3.amazonaws.com/'}}{{id}}_index.png&f=1">
     <div class="ia-single--serp">


### PR DESCRIPTION
Here's how it looked:
![screen shot 2015-01-08 at 4 20 01 pm](https://cloud.githubusercontent.com/assets/81969/5670915/3af0c24c-9752-11e4-85c6-43dea93ec98d.png)

Here's how it looks now:
![screen shot 2015-01-08 at 4 20 19 pm](https://cloud.githubusercontent.com/assets/81969/5670921/42eb9468-9752-11e4-9c67-4ff1afc2ba2f.png)

What I did is hide the top 4px of the image, and replaced it with a `div` with the same color. Now it looks a little better.