### PR TITLE
add <li> around source listing on ia page

### DIFF
--- a/src/templates/devinfo.handlebars
+++ b/src/templates/devinfo.handlebars
@@ -23,7 +23,9 @@
     <div class="ia-single--header">SOURCE</div>
     <ul>
       {{#each code}}
+        <li>
         <a class="one-line" href="https://github.com/duckduckgo/zeroclickinfo-{{../repo}}/tree/master/{{this}}">{{this}}</a>
+        </li>
       {{/each}}
     </ul>
   {{/if}}


### PR DESCRIPTION
puts the source files on separate lines.