### PR TITLE
Manual decoding of the urlencoded parameter is not necessary.

### DIFF
--- a/lib/DDGC/Web/Controller/Root.pm
+++ b/lib/DDGC/Web/Controller/Root.pm
@@ -5,7 +5,6 @@ use Moose;
 use Path::Class;
 use DateTime;
 use DateTime::Duration;
-use URL::Encode 'url_decode_utf8';
 
 use namespace::autoclean;
 
@@ -215,7 +214,7 @@ sub redirect_duckco :Chained('base') :PathPart('topic') :Args(1) {
 sub redir :Chained('base') :PathPart('redir') :Args(0) {
 	my ( $self, $c ) = @_;
 	$c->stash->{not_last_url} = 1;
-	$c->session->{r_url} = url_decode_utf8($c->req->param('u'));
+	$c->session->{r_url} = $c->req->param('u');
 	$c->session->{r_referer_validated} = (index($c->req->headers->referer, $c->req->base->as_string) == 0) ? 1 : 0;
 	$c->response->redirect($c->chained_uri('Root','r'));
 	return $c->detach;


### PR DESCRIPTION
This is taken care of by Catalyst.

#446 