### PR TITLE
Fixing user deletion

### DIFF
--- a/lib/DDGC.pm
+++ b/lib/DDGC.pm
@@ -745,7 +745,7 @@ sub delete_user {
 		if ($self->config->prosody_running) {
 			$self->xmpp->_prosody->_db->resultset('Prosody')->search({
 				host => $self->config->prosody_userhost,
-				user => $username,
+				user => lc($username),
 			})->delete;
 		}
 	}

--- a/lib/DDGC.pm
+++ b/lib/DDGC.pm
@@ -744,6 +744,7 @@ sub delete_user {
 		my @threads = $user->threads->search({})->all;
 		for (@threads) {
 			$_->users_id($deleted_user->id);
+			$_->ghosted(1);
 			$_->update({ 'updated' => $_->created });
 		}
 		$guard->commit;

--- a/lib/DDGC.pm
+++ b/lib/DDGC.pm
@@ -758,7 +758,7 @@ sub delete_user {
 			$_->update({ 'updated' => $_->created });
 		}
 		$guard->commit;
-		$prosody_user_rs->delete;
+		($prosody_user_rs) && $prosody_user_rs->delete;
 	}
 	return 1;
 }

--- a/lib/DDGC.pm
+++ b/lib/DDGC.pm
@@ -739,7 +739,12 @@ sub delete_user {
 		for (@comments) {
 			$_->content("This user account has been deleted.");
 			$_->users_id($deleted_user->id);
-			$_->update;
+			$_->update({ 'updated' => $_->created });
+		}
+		my @threads = $user->threads->search({})->all;
+		for (@threads) {
+			$_->users_id($deleted_user->id);
+			$_->update({ 'updated' => $_->created });
 		}
 		$guard->commit;
 		if ($self->config->prosody_running) {

--- a/templates/my/delete.tx
+++ b/templates/my/delete.tx
@@ -3,6 +3,9 @@
 
 		<h2>Delete account</h2>
 
+		<: if $delete_error { :>
+			<div class="notice error"><i class="icn icon-warning-sign"></i><: 'Sorry, there was a problem deleting this account! Please notify ddgc@duck.co.' :></div>
+		<: } :>
 		<: if $wrong_password { :>
 			<div class="notice error"><i class="icn icon-warning-sign"></i><: 'Incorrect password.' :></div>
 		<: } :>


### PR DESCRIPTION
While the robustness of our Prosody "integration" needs to be evaluated (#437), we can provide some fixes for the brokenness right now. This should address:

#363 - Deleted users not completely deleted 

Prosody usernames are made lowercase prior to storing them, so we should select on a lowercase username.

#325 - Don't bump forum posts when comments set to deleted user

Explicitly setting the updated date to equal created prevents this.