### PR TITLE
IE 8 and IE 9 don't support the placeholder attribute

### DIFF
--- a/templates/instantanswer/index.tx
+++ b/templates/instantanswer/index.tx
@@ -18,7 +18,14 @@
 <div id="filters" class="right hide-small">
     <span class="ddgsi-close-grid hide"></span>
     <div class="one-field clearfix">
-        <input type="text" class="text filters--search" placeholder="Filter Instant Answers" name="query" value="" autocorrect="off" autocapitalize="off" autocomplete="off">
+        <!--[if lt IE 10]> 
+            <input type="text" class="text filters--search" name="query" 
+            value="" autocorrect="off" autocapitalize="off" autocomplete="off">
+        <![endif]-->
+        <!--[if gt IE 9]><!--> 
+             <input type="text" class="text filters--search" placeholder="Filter Instant Answers" name="query"
+             value="" autocorrect="off" autocapitalize="off" autocomplete="off">
+        <!--<![endif]-->
         <div class="filters--search-button">
           <span class="ddgsi-loupe"></span>
         </div>


### PR DESCRIPTION
@jagtalon see my latest comment on #453.

Screen:
![image](https://cloud.githubusercontent.com/assets/3652195/5743608/b3a8cdf2-9c1a-11e4-8377-3382f30b18be.png)
