### PR TITLE
IA Page - show latest edits if the user has the right permissions

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -182,9 +182,9 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
         }
     }
 
-    $ia->other_queries = $ia->other_queries? decode_json($ia->other_queries) : undef;
+    my $other_queries = $ia->other_queries? decode_json($ia->other_queries) : undef;
 
-    $ia_data{live} =  (
+    $ia_data{live} =  {
                 id => $ia->id,
                 name => $ia->name,
                 description => $ia->description,
@@ -194,20 +194,20 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
                 dev_milestone => $ia->dev_milestone,
                 perl_module => $ia->perl_module,
                 example_query => $ia->example_query,
-                other_queries => $ia->other_queries,
+                other_queries => $other_queries,
                 code => $ia->code? decode_json($ia->code) : undef,
                 topic => \@topics,
                 attribution => $ia->attribution? decode_json($ia->attribution) : undef,
                 issues => \@ia_issues,
                 template => $ia->template,
-    );
+    };
 
     if ($c->user) {
         $is_admin = $c->user->admin;
 
         if ($is_admin) {
             $edited = current_ia($c->d, $ia);
-            $ia_data{edited} = (
+            $ia_data{edited} = {
                 id => $ia->id,
                 name => defined $edited->{name}? $edited->{name} : $ia->name,
                 description => defined $edited->{description}? $edited->{description} : $ia->description,
@@ -217,13 +217,13 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
                 dev_milestone => $ia->dev_milestone,
                 perl_module => $ia->perl_module,
                 example_query => defined $edited->{example_query}? $edited->{example_query} : $ia->example_query,
-                other_queries => defined $edited->{other_queries}->{value}? $edited->{other_queries}->{edited} : $ia->other_queries,
+                other_queries => defined $edited->{other_queries}->{value}? $edited->{other_queries}->{edited} : $other_queries,
                 code => $ia->code? decode_json($ia->code) : undef,
                 topic => defined $edited->{topic}? $edited->{topic} : \@topics,
                 attribution => $ia->attribution? decode_json($ia->attribution) : undef,
                 issues => \@ia_issues,
                 template => $ia->template,
-            );
+            };
         }
     }
 

--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -45,9 +45,11 @@
                 $.getJSON("/ia/view/" + DDH_iaid + "/json", function(x) {
 
                     // Show latest edits for admins and users with edit permissions
-                    this.ia_data = x;
-                    if (this.ia_data.edited) {
-                        x = this.ia_data.edited;
+                    var ia_data = x;
+                    if (ia_data.edited) {
+                        x = ia_data.edited;
+                    } else {
+                        x = ia_data.live;
                     }
 
                     // Readonly mode templates

--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -43,6 +43,13 @@
                 //console.log("for ia id '%s'", DDH_iaid);
 
                 $.getJSON("/ia/view/" + DDH_iaid + "/json", function(x) {
+
+                    // Show latest edits for admins and users with edit permissions
+                    this.ia_data = x;
+                    if (this.ia_data.edited) {
+                        x = this.ia_data.edited;
+                    }
+
                     // Readonly mode templates
                     var readonly_templates = {
                         name : Handlebars.templates.name(x),


### PR DESCRIPTION
... If not, show the live version instead.

Overview of the changes: the JSON endpoint for the single page now is composed of two hashes: `live` and `edited` (this last one only if the user has edit permissions or is an admin).
The `live` hash has, of course, the live version for each field, while the `edited` hash has the latest edit for each field, or, in case that field wasn't edited, the live version.

In IAPage.js the response from the JSON endpoint gets memorized in a variable, `ia_data`, and if this variable contains the `edited` hash then it means the user is either admin or has edit permissions, so we set `x` to `ia_data.edited`; otherwise we set it to `ia_data.live`. 

//cc @russellholt @jdorweiler @jagtalon @jbarrett 