### PR TITLE
IA Pages - add toggle-view button to switch between live and edited data

### DIFF
--- a/src/ia/css/ia.css
+++ b/src/ia/css/ia.css
@@ -9,6 +9,10 @@
 .special-permissions #edit_activate {
     margin-right: 0.7em;
 }
+.special-permissions__toggle-view #toggle-edited {
+    position:relative;
+    margin-left: 1em;
+}
 .ia-single h3 {
     margin-top: 1em;
 }

--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -82,6 +82,7 @@
 
                         $("#edit_disable").removeClass("hide");
                         $(this).hide();
+                        $(".special-permissions__toggle-view").hide();
                     });
 
                     $(".special-permissions__toggle-view__button").on('click', function(evt) {

--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -47,9 +47,7 @@
                     // Show latest edits for admins and users with edit permissions
                     var x = {};
                     if (ia_data.edited) {
-                        $.each(ia_data.live, function(key, value) {
-                            x[key] = ia_data.edited[key]? ia_data.edited[key] : value;
-                        });
+                        x = DDH.IAPage.prototype.updateData(ia_data, x, true);
                     } else {
                         x = ia_data.live;
                     }
@@ -84,6 +82,26 @@
 
                         $("#edit_disable").removeClass("hide");
                         $(this).hide();
+                    });
+
+                    $(".special-permissions__toggle-view__button").on('click', function(evt) {
+                        if (!$(this).hasClass("disabled")) {
+                            $(".button-nav-current").removeClass("button-nav-current").removeClass("disabled");
+
+                            $(this).addClass("button-nav-current").addClass("disabled");
+
+                            if ($(this).attr("id") == "toggle-live") {
+                                 x = DDH.IAPage.prototype.updateData(ia_data, x, false);       
+                            } else {
+                                 x = DDH.IAPage.prototype.updateData(ia_data, x, true);
+                            }
+
+                            for (var i = 0; i <  DDH.IAPage.prototype.field_order.length; i++) {
+                                readonly_templates[ DDH.IAPage.prototype.field_order[i]] = Handlebars.templates[ DDH.IAPage.prototype.field_order[i]](x);
+                            }
+
+                            DDH.IAPage.prototype.updateAll(readonly_templates, false);
+                        }
                     });
 
                     $("body").on('click', '.js-pre-editable.button', function(evt) {
@@ -242,14 +260,26 @@
             'other_queries'
         ],
 
+        updateData: function(ia_data, x, edited) {
+            $.each(ia_data.live, function(key, value) {
+                if (edited) {
+                    x[key] = ia_data.edited[key]? ia_data.edited[key] : value;
+                } else {
+                    x[key] = value;
+                }
+            });
+
+            return x;
+        },
+
         updateAll: function(templates, edit) {
             if (!edit) {
-                $(".ia-single--left").show().empty();
+                $(".ia-single--left, .ia-single--right").show().empty();
                 for (var i = 0; i < this.field_order.length; i++) {
                     $(".ia-single--left").append(templates[this.field_order[i]]);
                 }
 
-                $(".ia-single--right").show().append(templates.screens);
+                $(".ia-single--right").append(templates.screens);
 
                 $(".show-more").click(function(e) {
                     e.preventDefault();

--- a/templates/instantanswer/ia.tx
+++ b/templates/instantanswer/ia.tx
@@ -7,6 +7,17 @@
 </select>
 
 <: if $can_edit { :>
+    <div class="special-permissions__toggle-view right" id="toggle-view">
+        <div class="pager-wrap">
+            <span class="button-group  button-group--paging">
+                <span class="button special-permissions__toggle-view__live" id="toggle-live">
+                    Live
+                </span>
+                <span class="button special-permissions__toggle-view__edited button-nav-current disabled" id="toggle-edited">
+                    Edited
+                </span>
+        </div>
+    </div>
     <div class="special-permissions right">
         <: if $can_commit { :>
             <div class="special-permissions__edit js-view-commits button <: $commit_class :>" id="view_commits">Commit edits</div>

--- a/templates/instantanswer/ia.tx
+++ b/templates/instantanswer/ia.tx
@@ -10,10 +10,10 @@
     <div class="special-permissions__toggle-view right" id="toggle-view">
         <div class="pager-wrap">
             <span class="button-group  button-group--paging">
-                <span class="button special-permissions__toggle-view__live" id="toggle-live">
+                <span class="button special-permissions__toggle-view__button" id="toggle-live">
                     Live
                 </span>
-                <span class="button special-permissions__toggle-view__edited button-nav-current disabled" id="toggle-edited">
+                <span class="button special-permissions__toggle-view__button button-nav-current disabled" id="toggle-edited">
                     Edited
                 </span>
         </div>


### PR DESCRIPTION
@russellholt @jagtalon 

Default view for logged in users with edit permissions:
![screen shot 2015-01-27 at 17 52 08](https://cloud.githubusercontent.com/assets/3652195/5922700/03c5dcca-a64e-11e4-88ed-631826b481f8.png)

After clicking on "live" (notice how name and description values change):
![screen shot 2015-01-27 at 17 52 12](https://cloud.githubusercontent.com/assets/3652195/5922717/1835709e-a64e-11e4-94d6-61d15e8b49cd.png)

