### PR TITLE
IAPage: Updated create new issue link target

### DIFF
--- a/src/templates/devinfo.handlebars
+++ b/src/templates/devinfo.handlebars
@@ -11,7 +11,7 @@
   {{/if}}
 
   <div class="create-issue">
-    <a id="create-issue--link" href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/new?&title=issue+title&body=http%3A%2F%2Fduck.co%2Fia%2Fview%2F{{id}}">Create Issue</a>
+    <a id="create-issue--link" href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/new?&title=&body=%0A%0A--%20http%3A%2F%2Fduck.co%2Fia%2Fview%2F{{id}}">Create Issue</a>
     <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/new?&title=issue+title&body=http%3A%2F%2Fduck.co%2Fia%2Fview%2F{{id}}">
     <span class="ddgsi ddgsi-next right circle"></span>
     </a>


### PR DESCRIPTION
- Updated the target of create new issue link so that it looks a bit
  better and at the same time encourages writing a title.

Signed-off-by: mr.Shu mr@shu.io

---

The previous link already had a default title and so it seemed that one would not be too interested in writing one.

Moreover, I think that the link back to the IAPage should be a bit more distinguished in the issue message.
