### PR TITLE
IA Pages - add dev milestone row in edit mode if user is an admin

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -219,6 +219,7 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
                 example_query => $edited->{example_query},
                 other_queries => $edited->{other_queries}->{value},
                 topic => $edited->{topic},
+                dev_milestone => $edited->{dev_milestone},
             };
         }
     }
@@ -264,7 +265,8 @@ sub commit_json :Chained('commit_base') :PathPart('json') :Args(0) {
             status => $ia->status,
             topic => \@topics,
             example_query => $ia->example_query,
-            other_queries => $ia->other_queries? decode_json($ia->other_queries) : undef
+            other_queries => $ia->other_queries? decode_json($ia->other_queries) : undef,
+            dev_milestone => $ia->dev_milestone
         );
 
         $edited->{original} = \%original;
@@ -394,6 +396,7 @@ sub current_ia {
     my @topic = $edits->{'topic'};
     my @example_query = $edits->{'example_query'};
     my @other_queries = $edits->{'other_queries'};
+    my @dev_milestone = $edits->{'dev_milestone'};
     my %x;
 
     if (ref $edits eq 'HASH') {
@@ -417,7 +420,8 @@ sub current_ia {
             status => $status[0][@status]{'value'},
             topic => $topic_val? decode_json($topic_val) : undef,
             example_query => $example_query[0][@example_query]{'value'},
-            other_queries => \%other_q
+            other_queries => \%other_q,
+            dev_milestone => $dev_milestone[0][@dev_milestone]{'value'}
         );
     }
 

--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -72,7 +72,8 @@
                         description : Handlebars.templates.pre_edit_description(ia_data),
                         topic : Handlebars.templates.pre_edit_topic(ia_data),
                         example_query : Handlebars.templates.pre_edit_example_query(ia_data),
-                        other_queries : Handlebars.templates.pre_edit_other_queries(ia_data)
+                        other_queries : Handlebars.templates.pre_edit_other_queries(ia_data),
+                        dev_milestone : Handlebars.templates.pre_edit_dev_milestone(ia_data)
                     };
 
                     DDH.IAPage.prototype.updateAll(readonly_templates, false);
@@ -171,8 +172,14 @@
                             if ($(this).hasClass("js-input")) {
                                 value = $.trim($(this).val());
                             } else {
-                                var $input = $obj.find("input.js-input,#description textarea");
-                                value = $.trim($input.val());
+                                var input;
+                                if (field === "dev_milestone") {
+                                     $input = $obj.find(".available_dev_milestones option:selected");
+                                     value = $.trim($input.text());
+                                } else {
+                                    $input = $obj.find("input.js-input,#description textarea");
+                                    value = $.trim($input.val());
+                                }
                             }
                             
                             if (evt.type === "click" && (field === "topic" || field === "other_queries")) {
@@ -307,6 +314,11 @@
                 for (var i = 0; i < this.edit_field_order.length; i++) {
                     $(".ia-single--edits").append(templates[this.edit_field_order[i]]);
                 }
+
+                // Only admins can edit the dev milestone
+                if ($("#view_commits").length) {
+                    $(".ia-single--edits").append(templates.dev_milestone);
+                } 
             }
         }    
     };

--- a/src/templates/commit_page.handlebars
+++ b/src/templates/commit_page.handlebars
@@ -91,6 +91,19 @@
                 </td>
             </tr>
         {{/if}}
+
+        {{#if dev_milestone}}
+            <tr class="updates_list">
+                <th>Dev Milestone</th>
+
+                <td name="dev_milestone" class="item_selected" id="dev_milestone_original">
+                    {{original.dev_milestone}}
+                </td>
+                <td name="dev_milestone">
+                    {{dev_milestone}}
+                </td>
+            </tr>
+        {{/if}}
     </tbody>
 </table>
 

--- a/src/templates/edit_dev_milestone.handlebars
+++ b/src/templates/edit_dev_milestone.handlebars
@@ -1,0 +1,18 @@
+<div class="column-right-edits left" id="column-edits-dev_milestone">
+    <div class="column-right-edits__child js-editable" id="dev_milestone" dev_milestone="dev_milestone">
+        <div class="ia_dev_milestone left">
+            <span class="editable left" name="dev_milestone">
+                <select class="available_dev_milestones" tabindex="-1">
+                    <option value="0">{{dev_milestone}}</option>
+                    <option value="1">planning</option>
+                    <option value="2">alpha</option>
+                    <option value="3">beta</option>
+                    <option value="4">qa</option>
+                    <option value="5">ready</option>
+                    <option value="6">live</option>
+                </select>
+            </span>
+        </div>
+    </div>
+</div>
+

--- a/src/templates/pre_edit_dev_milestone.handlebars
+++ b/src/templates/pre_edit_dev_milestone.handlebars
@@ -1,0 +1,33 @@
+<div class="row-diff" id="row-diff-dev_milestone">
+    <div class="column-left-labels left">
+        <div class="column-left-labels__child">
+            <p class="column-left-labels__child__p">
+                Dev Milestone
+            </p>
+        </div>
+    </div>
+    <div class="column-center-live left">
+        <div class="column-center-live__child">
+            <p class="column-center-live__child__p">
+                {{live.dev_milestone}}
+            </p>
+        </div>
+    </div>
+    <div class="column-right-edits left" id="column-edits-dev_milestone">
+        <div class="column-right-edits__child">
+            <p class="column-right-edits__child__p">
+                {{edited.dev_milestone}}
+            </p>
+        </div>
+    </div>
+
+    <div class="button js-pre-editable" name="dev_milestone">
+        <i class="js-pre-editable__icon icon-edit"></i>
+        <span class="js-pre-editable__text">Edit</span>
+    </div>
+
+    <div class="button hide js-editable" name="dev_milestone">
+        <i class="js-editable__icon icon-check"></i>
+        <span class="js-editable__text">Done</span>
+    </div>
+</div>


### PR DESCRIPTION
The dev milestone value can be edited using a dropdown (the available options are hardcoded in the Handlebars template for now, until we are sure about what they should be), and, since the commit page has been updated as well, the edits to this field can be committed.

//cc @russellholt @jagtalon 
![screen shot 2015-02-03 at 15 31 15](https://cloud.githubusercontent.com/assets/3652195/6022175/60ca58ac-abbb-11e4-8074-220aef9b1fc0.png)
![screen shot 2015-02-03 at 15 37 33](https://cloud.githubusercontent.com/assets/3652195/6022177/669afc78-abbb-11e4-9040-db246ce91b61.png)
