### PR TITLE
Campaign page changes

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -67,6 +67,7 @@ requires 'IO::All', '0.50';
 requires 'IO::Socket::SSL', '1.955';
 requires 'IPC::Run', '0.92';
 requires 'JSON::MaybeXS', '1.000000';
+requires 'Lingua::Identify', '0.56';
 requires 'List::MoreUtils', '0.33';
 requires 'Locale::Country', '3.27';
 requires 'Locale::PO::Callback', '0.04';

--- a/lib/DDGC/Config.pm
+++ b/lib/DDGC/Config.pm
@@ -317,6 +317,7 @@ sub id_for_campaign {
 	my ($self, $campaign) = @_;
 	return $self->campaigns->{$campaign}->{id};
 }
+has_conf campaign_response_min_length => DDGC_CAMPAIGN_RESPONSE_MIN_LENGTH => 5; # '1 day'
 
 has_conf feedback_email => DDGC_FEEDBACK_EMAIL => 'support@duckduckgo.com';
 has_conf error_email => DDGC_ERROR_EMAIL => 'ddgc@duckduckgo.com';

--- a/lib/DDGC/Config.pm
+++ b/lib/DDGC/Config.pm
@@ -317,6 +317,11 @@ sub id_for_campaign {
 	my ($self, $campaign) = @_;
 	return $self->campaigns->{$campaign}->{id};
 }
+sub first_active_campaign {
+	my ($self) = @_;
+	my $c = $self->campaigns;
+	(sort { $c->{$a}->{id} <=> $c->{$b}->{id} } grep { $c->{$_}->{active} } keys $c)[0];
+}
 has_conf campaign_response_min_length => DDGC_CAMPAIGN_RESPONSE_MIN_LENGTH => 5; # '1 day'
 
 has_conf feedback_email => DDGC_FEEDBACK_EMAIL => 'support@duckduckgo.com';

--- a/lib/DDGC/Config.pm
+++ b/lib/DDGC/Config.pm
@@ -295,6 +295,7 @@ sub campaigns {
 			id => 1,
 			active => 1,
 			notification_active => 0,
+			min_length => 20,
 			url => '/wear/',
 			notification => "Help share DuckDuckGo! Find out more...",
 			question1 => "How did you hear about DuckDuckGo?",
@@ -305,6 +306,7 @@ sub campaigns {
 			id => 2,
 			active => 1,
 			notification_active => 1,
+			min_length => 50,
 			url => '/wear/',
 			notification => "You've been sharing DuckDuckGo for 30 days. Ready to answer your final questions?",
 			question1 => "How did you get your friend to switch to DuckDuckGo?",
@@ -322,7 +324,6 @@ sub first_active_campaign {
 	my $c = $self->campaigns;
 	(sort { $c->{$a}->{id} <=> $c->{$b}->{id} } grep { $c->{$_}->{active} } keys $c)[0];
 }
-has_conf campaign_response_min_length => DDGC_CAMPAIGN_RESPONSE_MIN_LENGTH => 5; # '1 day'
 
 has_conf feedback_email => DDGC_FEEDBACK_EMAIL => 'support@duckduckgo.com';
 has_conf error_email => DDGC_ERROR_EMAIL => 'ddgc@duckduckgo.com';

--- a/lib/DDGC/Web/Controller/Admin.pm
+++ b/lib/DDGC/Web/Controller/Admin.pm
@@ -10,7 +10,13 @@ BEGIN {extends 'Catalyst::Controller'; }
 
 sub base :Chained('/base') :PathPart('admin') :CaptureArgs(0) {
     my ( $self, $c ) = @_;
-	if (!$c->user || !$c->user->admin) {
+	if (!$c->user) {
+		$c->response->redirect($c->chained_uri('My','login',{ admin_required => 1 }));
+		return $c->detach;
+	}
+
+
+	if (!$c->user->admin) {
 		$c->response->redirect($c->chained_uri('Root','index',{ admin_required => 1 }));
 		return $c->detach;
 	}

--- a/lib/DDGC/Web/Controller/Admin/Campaign.pm
+++ b/lib/DDGC/Web/Controller/Admin/Campaign.pm
@@ -4,8 +4,7 @@ package DDGC::Web::Controller::Admin::Campaign;
 
 use Moose;
 BEGIN { extends 'Catalyst::Controller'; }
-use List::MoreUtils qw/ each_array /;
-use Try::Tiny;
+use List::MoreUtils qw/ uniq /;
 use namespace::autoclean;
 
 sub base : Chained('/admin/base') : PathPart('campaign') : CaptureArgs(0) {
@@ -21,31 +20,44 @@ sub index : Chained('base') : PathPart('') : Args(0) {
 sub bad_user_response : Chained('base') : PathPart('bad_user_response') : Args(0) {
     my ( $self, $c ) = @_;
     $c->add_bc('Bad response');
-    ($c->stash->{user}, $c->stash->{campaign}) = ($c->req->params->{user}, $c->req->params->{campaign});
+    $c->stash->{user} = $c->req->params->{user};
+    $c->stash->{multi_user} = $c->req->params->{multi_user};
+    $c->stash->{campaign} = $c->req->params->{campaign} // $c->d->config->first_active_campaign;
 
-    $c->stash->{campaign_options} = [ map { {
-            value => $_,
-            text  => $c->d->config->campaigns->{$_}->{id} . ' - ' . $c->d->config->campaigns->{$_}->{name},
-        } } keys $c->d->config->campaigns ];
-
+    if (!$c->stash->{user}) {
+        $c->stash->{no_user} = 1;
+    }
+    if (!$c->stash->{campaign}) {
+        $c->stash->{no_campaign} = 1;
+        return $c->detach;
+    }
     if ($c->req->params->{save_bad_response}) {
-        if (!$c->req->params->{user}) {
-            $c->stash->{user_not_supplied} = 1;
-            return $c->detach;
-        }
-        if (!$c->req->params->{campaign}) {
-            $c->stash->{campaign_not_selected} = 1;
-            return $c->detach;
-        }
-        my $user = $c->d->find_user($c->req->params->{user});
-        if (!$user) {
-            $c->stash->{user_not_found} = 1;
-            return $c->detach;
+        my @usernames = uniq grep { $_ } split /[^a-zA-Z0-9_\.]+/, $c->req->params->{multi_user};
+        ($c->req->params->{user}) && push @usernames, $c->req->params->{user};
+
+        for my $username (@usernames) {
+            my $user = $c->d->find_user($username);
+            if (!$user) {
+                push @{ $c->stash->{ users_not_found } }, $username;
+            }
+            else {
+                if ($user->responded_campaign( $c->stash->{campaign} )) {
+                    $user->set_bad_response($c->stash->{campaign});
+                }
+                else {
+                    push @{ $c->stash->{ users_not_responded } }, $username;
+                }
+            }
         }
 
-        if ($user->set_bad_response($c->stash->{campaign})) {
+        if (!$c->stash->{ users_not_found } && !$c->stash->{ users_not_responded }) {
             $c->stash->{bad_response_success} = 1;
         }
+        $c->stash->{ multi_user } = join ', ',
+            (( $c->stash->{ users_not_responded } ) ?
+                @{ $c->stash->{ users_not_responded } } : (),
+            ( $c->stash->{ users_not_found } ) ?
+                @{ $c->stash->{ users_not_found } } : ())
     }
 }
 

--- a/lib/DDGC/Web/Controller/Campaign/SubmitResponse.pm
+++ b/lib/DDGC/Web/Controller/Campaign/SubmitResponse.pm
@@ -54,22 +54,36 @@ sub respond : Chained('base') : PathPart('respond') : Args(0) {
 	my $from = 'noreply@dukgo.com';
 	my $username = $c->user->username;
 	my $campaign_name = $c->req->param('campaign_name');;
-	my $subject = "$campaign_name response from $username";
 	my $campaign = $c->d->config->campaigns->{ $campaign_name };
+	my $short_response = 0;
+	my $flag_response = 0;
+
+	my $response_length = length($c->req->param( 'question1' ) . $c->req->param( 'question2' ) . $c->req->param( 'question3' ));
+
+
+	if ( $response_length < $campaign->{min_length} + 10 ) {
+		$flag_response = 1;
+		if ( $response_length < $campaign->{min_length} ) {
+			$short_response = 1;
+		}
+	}
 
 	for (1..3) {
-		if (length($c->req->param( 'question' . $_ )) < $c->d->config->campaign_response_min_length) {
-			$c->response->status(500);
-			$c->stash->{x} = {
-				ok => 0, fields_empty => 1,
-				errstr => "You'll need to try a little harder than that!"
-			};
-			$c->forward( $c->view('JSON') );
-			return $c->detach;
+		if (!$c->req->param( 'question' . $_ )) {
+			$short_response = 1;
 		}
-
 		$c->stash->{ 'question' . $_ } = $campaign->{ 'question' . $_ };
 		$c->stash->{ 'answer' . $_ } = $c->req->param( 'question' . $_ );
+	}
+
+	if ($short_response) {
+		$c->response->status(500);
+		$c->stash->{x} = {
+			ok => 0, fields_empty => 1,
+			errstr => "Your responses are too short. Please add more explanation.",
+		};
+		$c->forward( $c->view('JSON') );
+		return $c->detach;
 	}
 
 	if ($campaign_name eq 'share') {
@@ -81,6 +95,8 @@ sub respond : Chained('base') : PathPart('respond') : Args(0) {
 BAD_RESPONSE_LINK
 	}
 
+	my $subject = (($flag_response)? "** SHORT RESPONSE ** " : "" ) .
+	"$campaign_name response from $username";
 	my $error = 0;
 	try {
 		$c->d->postman->template_mail(

--- a/lib/DDGC/Web/Controller/Campaign/SubmitResponse.pm
+++ b/lib/DDGC/Web/Controller/Campaign/SubmitResponse.pm
@@ -58,11 +58,11 @@ sub respond : Chained('base') : PathPart('respond') : Args(0) {
 	my $campaign = $c->d->config->campaigns->{ $campaign_name };
 
 	for (1..3) {
-		if (!$c->req->param( 'question' . $_ )) {
+		if (length($c->req->param( 'question' . $_ )) < $c->d->config->campaign_response_min_length) {
 			$c->response->status(500);
 			$c->stash->{x} = {
 				ok => 0, fields_empty => 1,
-				errstr => "Please fill all fields before submitting. Thanks."
+				errstr => "You'll need to try a little harder than that!"
 			};
 			$c->forward( $c->view('JSON') );
 			return $c->detach;

--- a/lib/DDGC/Web/Controller/My.pm
+++ b/lib/DDGC/Web/Controller/My.pm
@@ -597,7 +597,7 @@ sub register :Chained('logged_out') :Args(0) {
 		my $user = $c->d->create_user($username,$password);
 
 		if ($user) {
-			$c->authenticate({ username => $username, password => $password, }, 'users');
+			$user->check_password($password);
 			if ($email) {
 				$user->data({}) if !$user->data;
 				my $data = $user->data();

--- a/templates/admin/campaign/bad_user_response.tx
+++ b/templates/admin/campaign/bad_user_response.tx
@@ -1,28 +1,42 @@
 <: if !$bad_response_success { :>
-	<h3>Mark bad response:</h3>
+	<h3>Mark bad response</h3>
 	<form action="<: $u('Admin::Campaign', 'bad_user_response') :>" method="post">
-		<: if $user_not_found { :>
+
+		<: if $users_not_found { :>
 			<p class="notice error">
-				<i class="icn icon-warning-sign"></i>User "<: $user :>" not found.
+				<i class="icn icon-warning-sign"></i>Users not found:
+				<: for $users_not_found -> $username { :>
+					<br/><: $username :>
+				<: } :>
 			</p>
 		<: } :>
-		<: if $user_not_supplied { :>
+
+		<: if $users_not_responded { :>
 			<p class="notice error">
-				<i class="icn icon-warning-sign"></i>You must specify a username.
+				<i class="icn icon-warning-sign"></i>These users nave not responded:
+				<: for $users_not_responded -> $username { :>
+					<br/><: $username :>
+				<: } :>
 			</p>
 		<: } :>
-		<: if $campaign_not_selected { :>
+
+		<: if $no_campaign { :>
 			<p class="notice error">
 				<i class="icn icon-warning-sign"></i>You must specify a campaign.
 			</p>
 		<: } :>
+
+		<: if !$user { :>
+			Enter usernames:<br/>
+			<textarea rows=10 name='multi_user'><: $multi_user :></textarea>
+		<: } :>
 		<input type="hidden" name="user" value="<: $user :>">
 		<input type="hidden" name="campaign" value="<: $campaign :>">
-		<p>Responses from <: $user :> for campaign <: $campaign :> were bad?</p>
-		<input type="submit" class="button blue big" name="save_bad_response" value="Yes" />
+		<p>Responses <: if $user { :> from user <strong><: $user :></strong> <: } :> for campaign <: $campaign :> were bad?</p>
+		<input type="submit" class="button red big" name="save_bad_response" value="Mark responses as bad" />
 	</form>
 <: } else { :>
-	Thanks for reporting...
+	Thanks for reporting.
 <: } :>
 
 


### PR DESCRIPTION
Wear page:
- Enforce (a very short) minimum answer length.

Admin page:
- Go through login page before dumping non-admins to landing page
- Default campaign = first active campaign when not specified
- Present a textarea for usernames when user not specified