### PR TITLE
Do not delete existing 0-vote translations when inserting new translation

### DIFF
--- a/lib/DDGC/DB/Result/Token/Language.pm
+++ b/lib/DDGC/DB/Result/Token/Language.pm
@@ -191,11 +191,6 @@ sub add_user_translation {
 			username => $user->username,
 		})->first;
 		unless ($found) {
-			$self->search_related('token_language_translations',{
-				'token_language_translation_votes.id' => undef,
-			},{
-				join => [qw( token_language_translation_votes )]
-			})->delete;
 			my $plurals=$self->max_msgstr_index;
 			for (my $i = $plurals; $i > -1; $i--) {
 				return 0 unless $translation->{'msgstr'.$i};


### PR DESCRIPTION
Issue  #162

When locales are published, this acts the same way as if both translations had 100 votes - the latest translation from user who has declared more experience in their profile is the one which is chosen.