### PR TITLE
Campaign lang detect changes

### DIFF
--- a/lib/DDGC/Web/Controller/Campaign/SubmitResponse.pm
+++ b/lib/DDGC/Web/Controller/Campaign/SubmitResponse.pm
@@ -91,7 +91,7 @@ sub respond : Chained('base') : PathPart('respond') : Args(0) {
 
 	my $subject_extra = '';
 	if ($campaign_name eq 'share') {
-		($language ne "en" || $confidence < 0.62) && ($subject_extra = '** POSSIBLE SPAM ** ');
+		($language ne "en" || $confidence < 0.57) && ($subject_extra = '** POSSIBLE SPAM ** ');
 		($flag_response) && ($subject_extra = '** SHORT RESPONSE ** ');
 		my $report_url = $c->chained_uri( 'Admin::Campaign', 'bad_user_response', { user => $username, campaign => $campaign_name} );
 		$c->stash->{'extra'} = <<"BAD_RESPONSE_LINK"

--- a/lib/DDGC/Web/Controller/Campaign/SubmitResponse.pm
+++ b/lib/DDGC/Web/Controller/Campaign/SubmitResponse.pm
@@ -64,7 +64,7 @@ sub respond : Chained('base') : PathPart('respond') : Args(0) {
 	my $confidence = confidence(@languages);
 
 
-	if ( $response_length < $campaign->{min_length} + 10 ) {
+	if ( $response_length < $campaign->{min_length} + 20 ) {
 		$flag_response = 1;
 		if ( $response_length < $campaign->{min_length} ) {
 			$short_response = 1;

--- a/lib/DDGC/Web/Controller/Campaign/SubmitResponse.pm
+++ b/lib/DDGC/Web/Controller/Campaign/SubmitResponse.pm
@@ -89,7 +89,10 @@ sub respond : Chained('base') : PathPart('respond') : Args(0) {
 		return $c->detach;
 	}
 
+	my $subject_extra = '';
 	if ($campaign_name eq 'share') {
+		($language ne "en" || $confidence < 0.62) && ($subject_extra = '** POSSIBLE SPAM ** ');
+		($flag_response) && ($subject_extra = '** SHORT RESPONSE ** ');
 		my $report_url = $c->chained_uri( 'Admin::Campaign', 'bad_user_response', { user => $username, campaign => $campaign_name} );
 		$c->stash->{'extra'} = <<"BAD_RESPONSE_LINK"
 		Language: $language, Confidence: $confidence<br />
@@ -99,10 +102,7 @@ sub respond : Chained('base') : PathPart('respond') : Args(0) {
 BAD_RESPONSE_LINK
 	}
 
-	my $subject =
-		(($flag_response)? "** SHORT RESPONSE ** " : "" ) .
-		(($language ne "en" || $confidence < 0.65)? "** POSSIBLE SPAM ** " : "") .
-		"$campaign_name response from $username";
+	my $subject = "${subject_extra}$campaign_name response from $username";
 	my $error = 0;
 	try {
 		$c->d->postman->template_mail(


### PR DESCRIPTION
@zekiel This change makes the following changes:

- Increases the char count by 10 for a short flag
- Only adds one flag to the email header
- Lowers the confidence threshold for language flagging slightly (65% -> 62%)