### PR TITLE
IA Pages - add '&ia=[tab name]' to the example links

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -189,11 +189,15 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
 
     my $other_queries = $ia->other_queries? decode_json($ia->other_queries) : undef;
 
+    # Need to get the lowercase tab name and remove spaces for the example links
+    my $tab = lc($ia->tab);
+    $tab =~ s/\s//g;
+
     $ia_data{live} =  {
                 id => $ia->id,
                 name => $ia->name,
                 description => $ia->description,
-                tab => $ia->tab,
+                tab => $tab,
                 status => $ia->status,
                 repo => $ia->repo,
                 dev_milestone => $ia->dev_milestone,
@@ -207,8 +211,7 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
                 template => $ia->template,
                 unsafe => $ia->unsafe,
                 src_api_documentation => $ia->src_api_documentation,
-                assignee => $ia->assignee,
-                tab => $ia->tab
+                assignee => $ia->assignee
     };
 
     if ($c->user) {
@@ -225,6 +228,7 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
                     other_queries => $edited->{other_queries}->{value},
                     topic => $edited->{topic},
                     dev_milestone => $edited->{dev_milestone},
+                    tab => $edited->{tab}
             };
         }
     }

--- a/src/templates/examples.handlebars
+++ b/src/templates/examples.handlebars
@@ -3,12 +3,12 @@
     <div class="ia-single--header">EXAMPLES</div>
     <ul>
       <li>
-        <a class="one-line" href="https://duckduckgo.com/?q={{encodeURIComponent example_query}}" title="try this example on DuckDuckGo">{{example_query}}</a>
+        <a class="one-line" href="https://duckduckgo.com/?q={{encodeURIComponent example_query}}{{#if tab}}&ia={{tab}}{{/if}}" title="try this example on DuckDuckGo">{{example_query}}</a>
       </li>
       {{#if other_queries}}
         {{#each other_queries}}
           <li>
-            <a class="one-line" href="https://duckduckgo.com/?q={{encodeURIComponent this}}" title="try this example on DuckDuckGo">{{this}}</a>
+            <a class="one-line" href="https://duckduckgo.com/?q={{encodeURIComponent this}}{{#if tab}}&ia={{tab}}{{/if}}" title="try this example on DuckDuckGo">{{this}}</a>
           </li>
         {{/each}}
       {{/if}}

--- a/src/templates/in_development.handlebars
+++ b/src/templates/in_development.handlebars
@@ -61,10 +61,10 @@
         </div>
         {{#unless future.in_development}}
             {{#if permissions.admin}}
-                <input type="text" class="dev_milestone-container__body__input js-autocommit" id="tab_name-input" value="{{live.tab_name}}" />
+                <input type="text" class="dev_milestone-container__body__input js-autocommit" id="tab-input" value="{{live.tab}}" />
             {{else}}
-                <div class="dev_milestone-container__body__readonly" id="tab_name-txt">
-                   {{live.tab_name}} 
+                <div class="dev_milestone-container__body__readonly" id="tab-txt">
+                   {{live.tab}} 
                 </div>
             {{/if}}
         {{/unless}}


### PR DESCRIPTION
Not a big change, really. 
Just making sure that when a user clicks on an example link on the static page he gets the intended IA tab for that query.