### PR TITLE
additions to /ia/repo

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -87,18 +87,27 @@ sub iarepo_json :Chained('iarepo') :PathPart('json') :Args(0) {
     for my $ia (@x) {
         my $topics = $ia->topic;
 
-        if ($ia->example_query) {
-            $iah{$ia->id} = {
-                    name => $ia->name,
-                    id => $ia->id,
-                    example_query => $ia->example_query,
-                    repo => $ia->repo,
-                    perl_module => $ia->perl_module,
-                    tab => $ia->tab,
-                    description => $ia->description,
-                    status => $ia->status
-            };
+
+        $iah{$ia->id} = {
+                name => $ia->name,
+                id => $ia->id,
+                example_query => $ia->example_query,
+                repo => $ia->repo,
+                perl_module => $ia->perl_module,
+                tab => $ia->tab,
+                description => $ia->description,
+                status => $ia->status
+        };
+
+        # fathead specific
+        # TODO: do we need src_domain ?
+
+        my $src_options = $ia->src_options;
+        if ($src_options ) {
+            $iah{$ia->id}{src_options} = decode_json($src_options);
         }
+
+        $iah{$ia->id}{src_id} = $ia->src_id if $ia->src_id;
     }
 
     $c->stash->{x} = \%iah;

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -84,16 +84,19 @@ sub iarepo_json :Chained('iarepo') :PathPart('json') :Args(0) {
 
     my %iah;
 
-    for (@x) {
-        my $topics = $_->topic;
+    for my $ia (@x) {
+        my $topics = $ia->topic;
 
-        if ($_->example_query) {
-            $iah{$_->id} = {
-                    name => $_->name,
-                    id => $_->id,
-                    example_query => $_->example_query,
-                    repo => $_->repo,
-                    perl_module => $_->perl_module
+        if ($ia->example_query) {
+            $iah{$ia->id} = {
+                    name => $ia->name,
+                    id => $ia->id,
+                    example_query => $ia->example_query,
+                    repo => $ia->repo,
+                    perl_module => $ia->perl_module,
+                    tab => $ia->tab,
+                    description => $ia->description,
+                    status => $ia->status
             };
         }
     }


### PR DESCRIPTION
add some necessary data to this endpoint to be used in the metadata publishing. it's structured slightly differently than /ia/json in that this one is a hash of ia data by id.

`/ia/repo/goodies/json` entries look like

```
"loan": {
    "perl_module": "DDG::Goodie::Loan",
    "status": "live",
    "name": "Loan",
    "example_query": "loan $500000 at 4.5% with 20% down",
    "description": "Calculate monthly payment and total interest for conventional mortgage",
    "repo": "goodies",
    "tab": null,
    "id": "loan"
},
```

and an entry from `/ia/repo/fathead/json` looks like

```
"muppet_wiki": {
    "perl_module": "DDG::Fathead::MuppetWiki",
    "status": null,
    "name": "MuppetWiki",
    "example_query": "elmo muppets",
    "description": "Muppets reference",
    "src_id": 10,
    "src_options":  {
        "skip_abstract_paren": "",
        "skip_end": "",
        "skip_abstract": "",
        "skip_qr": "Muppet Wiki",
        "skip_icon": "",
        "skip_image_name": "",
        "is_mediawiki": "1"
    },
    "repo": "fathead",
    "tab": null,
    "id": "muppet_wiki"
}
```
