### PR TITLE
IA Pages - show the description in the dev page

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -190,7 +190,7 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
     my $other_queries = $ia->other_queries? decode_json($ia->other_queries) : undef;
 
     # Need to get the lowercase tab name and remove spaces for the example links
-    my $tab = lc($ia->tab);
+    my $tab = $ia->tab? lc($ia->tab) : '';
     $tab =~ s/\s//g;
 
     $ia_data{live} =  {

--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -357,6 +357,7 @@
         },
 
         field_order: [
+            'topic',
             'description',
             'github',
             'examples',
@@ -434,6 +435,7 @@
                     }
                 } else {
                     $(".ia-single").append(templates.live.name);
+                    $(".ia-single").append(templates.live.description);
                     for (var i = 0; i < this.dev_milestones_order.length; i++) {
                         $(".ia-single").append(templates[this.dev_milestones_order[i]]);
                     }

--- a/src/templates/description.handlebars
+++ b/src/templates/description.handlebars
@@ -1,7 +1,4 @@
-<div class="big-description">
-  {{#each topic}}
-    <span class="btn--wire topic ia-single--topic">{{this}}</span>
-  {{/each}}
+<div id="big-description">
   {{#if description}}
     <p>{{description}}</p>
   {{/if}}

--- a/src/templates/topic.handlebars
+++ b/src/templates/topic.handlebars
@@ -1,9 +1,5 @@
-<div id="topics">
-    {{#each topic}}
-        <div class="button ia_topic">
-            <a href="/ia/topic/{{encodeURIComponent this}}" title="See all IAs with the same topic">
-                {{this}}
-            </a>
-        </div> 
-    {{/each}}
+<div class="topic-labels">
+  {{#each topic}}
+    <span class="btn--wire topic ia-single--topic">{{this}}</span>
+  {{/each}}
 </div>


### PR DESCRIPTION
@russellholt @jagtalon The description will be added alongside with name and id when a new IA page will be created, so we want to show the description not only when the IA is deployed and live, but also during the development process, in the dev page.

In order to accomplish this I had to separate topics and description, which were previously in the same Handlebars template.
I also fixed a little bug in InstantAnswer.pm - not all the IAs have a defined tab name, so it's necessary to check before trying to transform it to lowercase.