### PR TITLE
Dev IA Page - check username for producer, designer and developer fields

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -408,6 +408,23 @@ sub save_edit :Chained('base') :PathPart('save') :Args(0) {
                     }
 
                     $result = {$field => $value};
+                } elsif ($field eq "producer" || $field eq "designer" || $field eq "developer") {
+                    my $complat_user = $c->d->rs('User')->find({username => $value});
+
+                    if ($complat_user) {
+                        my $complat_user_admin = $complat_user->admin;
+
+                        if ((($field eq "producer" || $field eq "designer") && ($complat_user_admin))
+                            || ($field eq "developer")) {
+                            try {
+                                $ia->update({$field => $value});
+                                $result = {$field => $value};
+                            }
+                            catch {
+                                $c->d->errorlog("Error updating the database");
+                            };
+                        }
+                    }
                 } else {
                     try {
                         $ia->update({$field => $value});


### PR DESCRIPTION
@russellholt This checks if the entered name refers to an actual complat user, and, in the case of producer and designer, if that user is also an admin.

If you want to test, an example of an admin account is TestOne.
Account without special permissions example: TestTwo.