### PR TITLE
IA Pages - get pull request on the JSON endpoint

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -183,6 +183,7 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
     my $edited;
     my @issues = $c->d->rs('InstantAnswer::Issues')->search({instant_answer_id => $ia->id});
     my @ia_issues;
+    my %pull_request;
     my @ia_pr;
     my %ia_data;
     my $permissions;
@@ -190,12 +191,21 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
 
     for my $issue (@issues) {
         if ($issue) {
-            push(@ia_issues, {
+            if ($issue->is_pr) {
+               %pull_request = (
                     issue_id => $issue->issue_id,
                     title => $issue->title,
                     body => $issue->body,
                     tags => $issue->tags? decode_json($issue->tags) : undef
-            });
+               );
+            } else {
+                push(@ia_issues, {
+                    issue_id => $issue->issue_id,
+                    title => $issue->title,
+                    body => $issue->body,
+                    tags => $issue->tags? decode_json($issue->tags) : undef
+                });
+            }
         }
     }
 
@@ -220,6 +230,7 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
                 topic => \@topics,
                 attribution => $ia->attribution? decode_json($ia->attribution) : undef,
                 issues => \@ia_issues,
+                pr => \%pull_request,
                 template => $ia->template,
                 unsafe => $ia->unsafe,
                 src_api_documentation => $ia->src_api_documentation,

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -193,7 +193,7 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
         if ($issue) {
             if ($issue->is_pr) {
                %pull_request = (
-                    issue_id => $issue->issue_id,
+                    id => $issue->issue_id,
                     title => $issue->title,
                     body => $issue->body,
                     tags => $issue->tags? decode_json($issue->tags) : undef

--- a/src/templates/in_development.handlebars
+++ b/src/templates/in_development.handlebars
@@ -11,7 +11,7 @@
         </div>
         {{#if live.pr}}
             <div class="dev_milestone-container__body__readonly" id="pr-txt">
-                <a href="{{live.pr.url}}" class="dev_milestone-container__body__readonly__a" id="pr">
+                <a href="https://github.com/duckduckgo/zeroclickinfo-{{live.repo}}/issues/{{live.pr.id}}" class="dev_milestone-container__body__readonly__a" id="pr">
                     {{live.pr.title}}
                 </a>
             </div>


### PR DESCRIPTION
Now that we have the is_pr column inside InstantAnswer::Issues we can distinguish between issues and pull requests, and get the id, title, body and tags of a PR on the JSON endpoint.

It will be used in the dev IA page, inside the "in development" dev milestone, to see if a PR has been opened :)