### PR TITLE
IA Pages - don't modify the IA tab string if dev milestone !== live

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -211,15 +211,11 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
 
     my $other_queries = $ia->other_queries? decode_json($ia->other_queries) : undef;
 
-    # Need to get the lowercase tab name and remove spaces for the example links
-    my $tab = $ia->tab? lc($ia->tab) : '';
-    $tab =~ s/\s//g;
-
     $ia_data{live} =  {
                 id => $ia->id,
                 name => $ia->name,
                 description => $ia->description,
-                tab => $tab,
+                tab => $ia->tab,
                 status => $ia->status,
                 repo => $ia->repo,
                 dev_milestone => $ia->dev_milestone,

--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -46,14 +46,6 @@
 
                 $.getJSON("/ia/view/" + DDH_iaid + "/json", function(ia_data) {
 
-                    // Show latest edits for admins and users with edit permissions
-                    var latest_edits_data = {};
-                    if (ia_data.edited) {
-                        latest_edits_data = page.updateData(ia_data, latest_edits_data, true);
-                    } else {
-                        latest_edits_data = ia_data.live;
-                    }
-
                     if (ia_data.live.dev_milestone !== "live") {
                         if ($(".special-permissions").length) {
                             $(".special-permissions, .special-permissions__toggle-view").hide();
@@ -75,6 +67,19 @@
                         }
 
                         ia_data.future = future;
+                    } else {
+                        if (ia_data.live.tab) {
+                            // On the live static page we use the tab name for the example links
+                            ia_data.live.tab = ia_data.live.tab.toLowerCase().replace(/\s/g, "");
+                        }
+
+                        // Show latest edits for admins and users with edit permissions
+                        var latest_edits_data = {};
+                        if (ia_data.edited) {
+                            latest_edits_data = page.updateData(ia_data, latest_edits_data, true);
+                        } else {
+                            latest_edits_data = ia_data.live;
+                        }
                     }
 
                     // Readonly mode templates


### PR DESCRIPTION
As said in the comments for #506. Now the tab name is modified (lowercase + spaces removed) inside IAPage.js, and only if the dev milestone is "live", since in that case we need to use it for the example links (the "&ia=[tab name]" bit).