### PR TITLE
Jd/iameta fixes

### DIFF
--- a/lib/DDGC/DB/Result/InstantAnswer/Topics.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer/Topics.pm
@@ -21,7 +21,7 @@ column topics_id => {
 primary_key (qw/instant_answer_id topics_id/);
 
 belongs_to 'instant_answer', 'DDGC::DB::Result::InstantAnswer', 'instant_answer_id', {on_delete => 'cascade'};
-belongs_to 'topic', 'DDGC::DB::Result::Topic', 'topics_id';
+belongs_to 'topic', 'DDGC::DB::Result::Topic', 'topics_id', {on_delete => 'cascade'};
 
 no Moose;
 __PACKAGE__->meta->make_immutable;

--- a/lib/DDGC/DB/Result/Topic.pm
+++ b/lib/DDGC/DB/Result/Topic.pm
@@ -30,7 +30,7 @@ unique_column name => {
         is_nullable => 0,
 };
 
-has_many 'instant_answer_topics', 'DDGC::DB::Result::InstantAnswer::Topics', 'topics_id',  {cascade_delete => 1};
+has_many 'instant_answer_topics', 'DDGC::DB::Result::InstantAnswer::Topics', 'topics_id', {on_delete => 'cascade'};
 many_to_many 'instant_answers', 'instant_answer_topics', 'instant_answer';
 
 no Moose;

--- a/lib/DDGC/DB/Result/Topic.pm
+++ b/lib/DDGC/DB/Result/Topic.pm
@@ -30,7 +30,7 @@ unique_column name => {
         is_nullable => 0,
 };
 
-has_many 'instant_answer_topics', 'DDGC::DB::Result::InstantAnswer::Topics', 'topics_id';
+has_many 'instant_answer_topics', 'DDGC::DB::Result::InstantAnswer::Topics', 'topics_id',  {cascade_delete => 1};
 many_to_many 'instant_answers', 'instant_answer_topics', 'instant_answer';
 
 no Moose;

--- a/script/iameta.pl
+++ b/script/iameta.pl
@@ -44,7 +44,6 @@ catch {
 };
 
 my $update = sub { 
-   
     if($nuke_tables){
         print "Deleting all tables before updating\n";
         $d->rs('InstantAnswer')->delete;
@@ -86,8 +85,6 @@ my $update = sub {
         if ($ia->{src_options}) {
             $ia->{src_options} = JSON->new->ascii(1)->encode($ia->{src_options});
         }
-
-        $ia->{example_query} = encode("UCS-2BE", $ia->{example_query});
 
         $d->rs('InstantAnswer')->update_or_create($ia);
 

--- a/script/iameta.pl
+++ b/script/iameta.pl
@@ -43,7 +43,9 @@ catch {
 };
 
 my $update = sub { 
-    
+   
+    $d->rs('Topic')->delete;
+
     if($nuke_tables){
         print "Deleting all tables before updating\n";
         $d->rs('InstantAnswer')->delete;

--- a/script/iameta.pl
+++ b/script/iameta.pl
@@ -7,7 +7,6 @@ use feature "say";
 use Data::Dumper;
 use Try::Tiny;
 use File::Copy qw( move );
-use Encode qw(encode);
 
 sub debug { 0 };
 
@@ -46,9 +45,6 @@ catch {
 
 my $update = sub { 
    
-    #
-    #need to reset seq here
-    #
     if($nuke_tables){
         print "Deleting all tables before updating\n";
         $d->rs('InstantAnswer')->delete;


### PR DESCRIPTION
Added a cascade delete for topics table when you run `iameta.pl delete`.  Switched from `decode_json` to `from_json` since it was causing problems with reading the metadata file. 

@russellholt @MariagraziaAlastra @jbarrett 