### PR TITLE
examples.handlebars - fix bug in retrieving the tab for other queries

### DIFF
--- a/src/templates/examples.handlebars
+++ b/src/templates/examples.handlebars
@@ -8,7 +8,7 @@
       {{#if other_queries}}
         {{#each other_queries}}
           <li>
-            <a class="one-line" href="https://duckduckgo.com/?q={{encodeURIComponent this}}{{#if tab}}&ia={{tab}}{{/if}}" title="try this example on DuckDuckGo">{{this}}</a>
+            <a class="one-line" href="https://duckduckgo.com/?q={{encodeURIComponent this}}{{#if ../tab}}&ia={{../../tab}}{{/if}}" title="try this example on DuckDuckGo">{{this}}</a>
           </li>
         {{/each}}
       {{/if}}


### PR DESCRIPTION
@jagtalon the "&ia=[tab name]" was already there for other queries too, just had to fix a bug with the Handlebars template: inside the loop it needs special syntax to access parent values.