### PR TITLE
Allow hiding of redundant help pages

### DIFF
--- a/lib/DDGC/DB/Result/Help.pm
+++ b/lib/DDGC/DB/Result/Help.pm
@@ -24,10 +24,10 @@ unique_column key => {
 
 column help_category_id => {
 	data_type => 'bigint',
-	is_nullable => 0,
+	is_nullable => 1,
 };
 
-belongs_to 'help_category', 'DDGC::DB::Result::Help::Category', 'help_category_id';
+belongs_to 'help_category', 'DDGC::DB::Result::Help::Category', 'help_category_id', { join_type => 'left' };;
 sub category { shift->help_category(@_) }
 
 column data => {

--- a/lib/DDGC/Web/Controller/Admin/Help.pm
+++ b/lib/DDGC/Web/Controller/Admin/Help.pm
@@ -46,6 +46,7 @@ sub index :Chained('base') :PathPart('') :Args(0) {
 			if ($id > 0) {
 				$help = $c->d->rs('Help')->find($id);
 				die "help id ".$_." not found" unless $help;
+				$help_values{help_category_id} ||= undef;
 				for (keys %help_values) {
 					$help->$_($help_values{$_});
 				}

--- a/sql/1.012/nullable_help_category.sql
+++ b/sql/1.012/nullable_help_category.sql
@@ -1,0 +1,7 @@
+
+BEGIN;
+
+ALTER TABLE help ALTER COLUMN help_category_id DROP NOT NULL;
+
+COMMIT;
+

--- a/templates/admin/help/index.tx
+++ b/templates/admin/help/index.tx
@@ -6,7 +6,7 @@
   <form method="POST" action="<: $u('Admin::Help','index') :>">
     <div class="content-box content-box-toggleclick only">
       <div id="help_<: $help.id :>_clicker" class="head">
-        <h4>#<: $help.id :> [<: $help.category.key :>] <: $help.key :></h4>
+        <h4>#<: $help.id :> [<: $help.category.key || 'HIDDEN' :>] <: $help.key :></h4>
 		<: include 'i/head_icons.tx' :>
       </div>
       <div class="body  column-form">


### PR DESCRIPTION
Set category to '-' to hide a help page. Content remains intact should we want to re-publish it later.

@zekiel thanks!