### PR TITLE
IA Pages Index - sort topics alphabetically in the topics filtering section

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -34,6 +34,7 @@ sub index :Chained('base') :PathPart('') :Args() {
         {'name' => { '!=' => 'test' }},
         {
             columns => [ qw/ name id /],
+            order_by => [ qw/ name /],
             result_class => 'DBIx::Class::ResultClass::HashRefInflator',
         }
     )->all;


### PR DESCRIPTION
@russellholt @jagtalon I don't have the latest metadata yet, but I believe you can see that the list is sorted anyway :)
![screen shot 2015-02-19 at 17 35 30](https://cloud.githubusercontent.com/assets/3652195/6271094/bcafdc96-b85e-11e4-988d-18ad1b17297f.png)
