### PR TITLE
IA Pages creation - replace underscore with space for the status field

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -498,11 +498,18 @@ sub create_ia :Chained('base') :PathPart('create') :Args() {
        $is_admin = $c->user->admin;
 
         if ($is_admin) {
+            my $dev_milestone = $c->req->params->{dev_milestone};
+            my $status = $dev_milestone;
+            
+            if ($dev_milestone eq 'in_development') {
+                $status =~ s/_/ /g;
+            }
+
             my $new_ia = $c->d->rs('InstantAnswer')->create({
                 lc id => $c->req->params->{id},
                 name => $c->req->params->{name},
-                status => $c->req->params->{dev_milestone},
-                dev_milestone => $c->req->params->{dev_milestone},
+                status => $status,
+                dev_milestone => $dev_milestone,
                 description => $c->req->params->{description},
             });
 


### PR DESCRIPTION
Before (look at the status): 
![screen shot 2015-02-19 at 20 41 34](https://cloud.githubusercontent.com/assets/3652195/6274543/8e85ae94-b878-11e4-891b-56d5bf6f067c.png)

After:
![screen shot 2015-02-19 at 20 40 15](https://cloud.githubusercontent.com/assets/3652195/6274553/9d9f5ce0-b878-11e4-8a7b-5c8af0d7956c.png)
