### PR TITLE
Require action token for transactions with github.com

### DIFF
--- a/lib/DDGC/Web/Controller/My/GitHub.pm
+++ b/lib/DDGC/Web/Controller/My/GitHub.pm
@@ -8,6 +8,7 @@ BEGIN {extends 'Catalyst::Controller'; }
 
 sub base :Chained('/my/logged_in') :PathPart('github') :CaptureArgs(0) {
 	my ( $self, $c ) = @_;
+	$c->require_action_token;
 	$c->stash->{title} = 'GitHub';
 	$c->add_bc($c->stash->{title}, '');
 	$c->stash->{github_client_id} = $c->d->config->github_client_id;

--- a/templates/i/github_user/repos.tx
+++ b/templates/i/github_user/repos.tx
@@ -6,7 +6,8 @@
 		<: if cur_user().id == $_.users_id { :>
 			<div class="pull-right quarter">
 				<a class="noblank button blue" href="<: $u('My::GitHub','index',{
-					update_repos => 1
+					update_repos => 1,
+					action_token => $action_token
 				}) :>">
 					Update your repositories
 				</a>

--- a/templates/my/account.tx
+++ b/templates/my/account.tx
@@ -120,7 +120,7 @@
 					</label>
 				</div>
 				<div class="third">
-					<a href="<: $u('My::GitHub','index') :>" class="button button--right">GitHub Link</a>
+					<a href="<: $u('My::GitHub','index', { action_token => $action_token }) :>" class="button button--right">GitHub Link</a>
 				</div>
 			</div>
 			<div class="row">


### PR DESCRIPTION
Should, in effect, act as a state token as described here:

http://tools.ietf.org/html/draft-ietf-oauth-v2-20#section-10.12

@zekiel @malbin @nilnilnil Thanks!