### PR TITLE
IA Pages - specific type-only fields (plus new Handlebars helpers file)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,6 +33,7 @@ module.exports = function(grunt) {
     var ia_page_js = [
         'handlebars_tmp',
         'DDH.js',
+        'Helpers.js',
         'IADevPipeline.js',
         'IAIndex.js',
         'IAPage.js',

--- a/src/ia/js/Helpers.js
+++ b/src/ia/js/Helpers.js
@@ -1,0 +1,11 @@
+(function(env) {
+    // Handlebars helpers for IA Pages
+
+    // Check if two values are equal
+    Handlebars.registerHelper('eq', function(value1, value2, options) {
+        if (value1 === value2) {
+            return options.fn(this);
+        }
+    });
+
+})(DDH);

--- a/src/templates/planning.handlebars
+++ b/src/templates/planning.handlebars
@@ -45,18 +45,20 @@
             {{/if}}
         {{/unless}}
 
-        <div class="dev_milestone-container__body__label ia-single--header">
-            API DOCUMENTATION
-        </div>
-        {{#unless future.planning}}
-            {{#if permissions.can_edit}}
-                <input type="text" class="dev_milestone-container__body__input js-autocommit" id="src_api_documentation-input" value="{{live.src_api_docs}}" />
-            {{else}}
-                <div class="dev_milestone-container__body__readonly" id="src_api_documentation-txt">
-                    {{live.src_api_docs}}
-                </div>
-            {{/if}}
-        {{/unless}}
+        {{#eq live.repo 'spice'}}
+            <div class="dev_milestone-container__body__label ia-single--header">
+                API DOCUMENTATION
+            </div>
+            {{#unless future.planning}}
+                {{#if permissions.can_edit}}
+                    <input type="text" class="dev_milestone-container__body__input js-autocommit" id="src_api_documentation-input" value="{{live.src_api_documentation}}" />
+                {{else}}
+                    <div class="dev_milestone-container__body__readonly" id="src_api_documentation-txt">
+                        {{live.src_api_documentation}}
+                    </div>
+                {{/if}}
+            {{/unless}}
+        {{/eq}}
 
         <div class="dev_milestone-container__body__label ia-single--header">
             SAFE SEARCH

--- a/src/templates/planning.handlebars
+++ b/src/templates/planning.handlebars
@@ -60,6 +60,21 @@
             {{/unless}}
         {{/eq}}
 
+        {{#eq live.repo 'fathead'}}
+            <div class="dev_milestone-container__body__label ia-single--header">
+                SOURCE OPTIONS
+            </div>
+            {{#unless future.planning}}
+                {{#if permissions.can_edit}}
+                    <input type="text" class="dev_milestone-container__body__input js-autocommit" id="src_options-input" value="{{live.src_options}}" />
+                {{else}}
+                    <div class="dev_milestone-container__body__readonly" id="src_options-txt">
+                        {{live.src_options}}
+                    </div>
+                {{/if}}
+            {{/unless}}
+        {{/eq}}
+
         <div class="dev_milestone-container__body__label ia-single--header">
             SAFE SEARCH
         </div>

--- a/src/templates/planning.handlebars
+++ b/src/templates/planning.handlebars
@@ -60,21 +60,6 @@
             {{/unless}}
         {{/eq}}
 
-        {{#eq live.repo 'fathead'}}
-            <div class="dev_milestone-container__body__label ia-single--header">
-                SOURCE OPTIONS
-            </div>
-            {{#unless future.planning}}
-                {{#if permissions.can_edit}}
-                    <input type="text" class="dev_milestone-container__body__input js-autocommit" id="src_options-input" value="{{live.src_options}}" />
-                {{else}}
-                    <div class="dev_milestone-container__body__readonly" id="src_options-txt">
-                        {{live.src_options}}
-                    </div>
-                {{/if}}
-            {{/unless}}
-        {{/eq}}
-
         <div class="dev_milestone-container__body__label ia-single--header">
             SAFE SEARCH
         </div>


### PR DESCRIPTION
@russellholt @jagtalon 
We needed a generic Handlebars helpers file: from now on every helper will be defined there.
In this specific case I defined a block helper checking if two values are equal - it makes much easier to check for specific repos and can be used to refactor some other parts as well. I believe in the end having more trivial helpers like this one will save us from unnecessary overheads and ugly hacks, and will boost code performance as well. Now, screenshots!

Fathead shows src options field:
![schermata 2015-02-24 alle 14 42 20](https://cloud.githubusercontent.com/assets/3652195/6350376/9cd627bc-bc33-11e4-919f-729b2a3dfba9.png)

Spice shows API docs:
![schermata 2015-02-24 alle 14 43 40](https://cloud.githubusercontent.com/assets/3652195/6350378/a07815ec-bc33-11e4-8ad8-0cf1355193b4.png)

Other types don't show neither API docs, nor src options:
![schermata 2015-02-24 alle 14 44 02](https://cloud.githubusercontent.com/assets/3652195/6350379/a24df9ea-bc33-11e4-86aa-faed75827f69.png)
