### PR TITLE
Dev Pages - multiple selection for topics

### DIFF
--- a/src/ia/css/ia.css
+++ b/src/ia/css/ia.css
@@ -81,6 +81,7 @@
     padding-left: 0.2em;
 }
 .ia-single .row-diff .available_topics,
+.ia-single .topic-group,
 .ia-single .row-diff .editpage span input {
     border-top-left-radius: 0;
     -moz-border-top-left-radius: 0;
@@ -94,10 +95,16 @@
 
     margin-bottom: 0.3em;
 }
-.ia-single .row-diff .available_topics {
-    height: 1.76em;
+.ia-single .row-diff .available_topics,
+.ia-single .topic-group {
     min-width: 5em;
     width: 9em;
+}
+.ia-single .row-diff .available_topics {
+    height: 1.76em;
+}
+.ia-single .topic-group {
+    height: 2.21em;
 }
 .ia-single .row-diff .editpage span input {
     height: 1.52em;
@@ -337,7 +344,7 @@
 .ia-single ul li {
     list-style-position: inside;
 }
-.ia-single .row-diff .column-right-edits .button.listbutton {
+.ia-single .button.listbutton {
     padding: 0;
     width: 1.6em;
     height: 1.9em;
@@ -345,7 +352,7 @@
     font-size: 14px;
     background-color: #dbdbdb;
 }
-.ia-single .row-diff .column-right-edits .button.delete {
+.ia-single .button.delete {
     border-right: 0;
     border-bottom-right-radius: 0;
     -moz-border-bottom-right-radius: 0;

--- a/src/ia/js/Helpers.js
+++ b/src/ia/js/Helpers.js
@@ -8,4 +8,11 @@
         }
     });
 
+    // Return the array value at the specified index
+    Handlebars.registerHelper('index', function(array, idx) {
+        if (array[idx]) {
+            return array[idx];
+        }
+    });
+
 })(DDH);

--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -155,8 +155,23 @@
                     });
 
                     $("body").on('change', ".dev_milestone-container__body__select.js-autocommit", function(evt) {
-                        var field = $.trim($(this).attr("id").replace("-select", ""));
-                        var value = $.trim($(this).find("option:selected").text());
+                        var field;
+                        var value;
+
+                        if ($(this).hasClass("topic-group")) {
+                            var this_topic = $(this);
+                            var arr = [value];
+                            $(".dev_milestone-container__body__select.js-autocommit.topic-group").each(functionn(idx) {
+                                if ($(this) !== this_topic) {
+                                    arr.push($.trim($(this).find("option:selected").text()));
+                                }
+                            });
+
+                           value = JSON.stringify(arr); 
+                        } else {
+                           field = $.trim($(this).attr("id").replace("-select", "");
+                           value = $.trim($(this).find("option:selected").text());
+                        }
 
                         if (field.length && value.length) {
                              autocommit(field, value, DDH_iaid);

--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -157,17 +157,20 @@
                     $("body").on('change', ".dev_milestone-container__body__select.js-autocommit", function(evt) {
                         var field;
                         var value;
-
+                    
                         if ($(this).hasClass("topic-group")) {
-                            var this_topic = $(this);
-                            var arr = [value];
+                            value = [];
+                            var temp;
                             $(".dev_milestone-container__body__select.js-autocommit.topic-group").each(function(idx) {
-                                if ($(this) !== this_topic) {
-                                    arr.push($.trim($(this).find("option:selected").text()));
+                                temp = $.trim($(this).find("option:selected").text());
+
+                                if (temp.length) {
+                                    value.push(temp);
                                 }
                             });
 
-                           value = JSON.stringify(arr); 
+                           field = "topic";
+                           value = JSON.stringify(value); 
                         } else {
                            field = $.trim($(this).attr("id").replace("-select", ""));
                            value = $.trim($(this).find("option:selected").text());
@@ -305,8 +308,13 @@
                             if ($(this).hasClass("js-autocommit")) {
                                 var field = "topic";
                                 var value = [];
+                                var temp;
                                 $(".dev_milestone-container__body__select.js-autocommit.topic-group").each(function(idx) {
-                                    value.push($.trim($(this).find("option:selected").text()));
+                                    temp = $.trim($(this).find("option:selected").text());
+
+                                    if (temp.length) {
+                                        value.push(temp);
+                                    }
                                 });
 
                                 value = JSON.stringify(value); 
@@ -531,6 +539,10 @@
                             $("#" + $.trim($(this).attr("id").replace("-input", "")) + "-button").hide();
                         }
                     });
+
+                    if ($(".topic-group").length) {
+                        $(".topic-group").append($("#allowed_topics").html());
+                    }
                 } 
             }
         }    

--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -161,7 +161,7 @@
                         if ($(this).hasClass("topic-group")) {
                             var this_topic = $(this);
                             var arr = [value];
-                            $(".dev_milestone-container__body__select.js-autocommit.topic-group").each(functionn(idx) {
+                            $(".dev_milestone-container__body__select.js-autocommit.topic-group").each(function(idx) {
                                 if ($(this) !== this_topic) {
                                     arr.push($.trim($(this).find("option:selected").text()));
                                 }
@@ -169,7 +169,7 @@
 
                            value = JSON.stringify(arr); 
                         } else {
-                           field = $.trim($(this).attr("id").replace("-select", "");
+                           field = $.trim($(this).attr("id").replace("-select", ""));
                            value = $.trim($(this).find("option:selected").text());
                         }
 
@@ -282,22 +282,41 @@
                     });
 
                     $("body").on("click", ".button.delete", function(evt) {
-                        var field = $(this).parent().find(".js-editable").attr('name');
-                        if (field === 'example_query') {
-                            var $new_primary = $('a.other-examples input').first();
-                            if ($new_primary.length) {
-                                $new_primary.parent().removeClass('other-examples');
-                                $new_primary.parent().attr('name', 'example_query');
-                                $new_primary.parent().attr('id', 'primary');
-                            }
-                        }
-
                         $(this).parent().remove();
 
-                        if (!$("#examples .other-examples").length && $("#primary").length) {
-                            $("#primary").parent().find(".button.delete").addClass("hide");
+                        if (ia_data.live.dev_milestone === "live") {
+                            var field = $(this).parent().find(".js-editable").attr('name');
+                            if (field === 'example_query') {
+                                var $new_primary = $('a.other-examples input').first();
+                                if ($new_primary.length) {
+                                    $new_primary.parent().removeClass('other-examples');
+                                    $new_primary.parent().attr('name', 'example_query');
+                                    $new_primary.parent().attr('id', 'primary');
+                                }
+                            }
+
+                            if (!$("#examples .other-examples").length && $("#primary").length) {
+                                $("#primary").parent().find(".button.delete").addClass("hide");
+                            }
+                        } else {
+                            // If dev milestone is not 'live' it means we are in the dev page
+                            // and a topic has been deleted (it's the only field having a delete button in the dev page
+                            // so far) - so we must save
+                            if ($(this).hasClass("js-autocommit")) {
+                                var field = "topic";
+                                var value = [];
+                                $(".dev_milestone-container__body__select.js-autocommit.topic-group").each(function(idx) {
+                                    value.push($.trim($(this).find("option:selected").text()));
+                                });
+
+                                value = JSON.stringify(value); 
+
+                                if (field.length && value.length) {
+                                    autocommit(field, value, DDH_iaid);
+                                }
+                            }
                         }
-                    });
+                   });
 
                     $("body").on('keypress click', '.js-input, .button.js-editable', function(evt) {
                         if ((evt.type === 'keypress' && (evt.which === 13 && $(this).hasClass("js-input")))

--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -285,9 +285,8 @@
                     });
 
                     $("body").on("click", ".button.delete", function(evt) {
-                        $(this).parent().remove();
-
                         if (ia_data.live.dev_milestone === "live") {
+                            $(this).parent().remove();
                             var field = $(this).parent().find(".js-editable").attr('name');
                             if (field === 'example_query') {
                                 var $new_primary = $('a.other-examples input').first();
@@ -309,6 +308,9 @@
                                 var field = "topic";
                                 var value = [];
                                 var temp;
+                                var $parent = $(this).parent();
+                                $parent.find('.topic-group option[value="0"]').empty();
+                                $parent.find('.topic-group').val('0');
                                 $(".dev_milestone-container__body__select.js-autocommit.topic-group").each(function(idx) {
                                     temp = $.trim($(this).find("option:selected").text());
 

--- a/src/templates/in_development.handlebars
+++ b/src/templates/in_development.handlebars
@@ -48,7 +48,15 @@
         </div>
         {{#unless future.in_development}}
             {{#if permissions.can_edit}}
-                <input type="text" class="dev_milestone-container__body__input js-autocommit comma-separated" id="topic-input" value="{{live.topic}}" />
+                <select class="dev_milestone-container__body__select js-autocommit topic-group" id="first-topic-select">
+                    <option value="0">{{live.topic}}</option>
+                </select>
+                <select class="dev_milestone-container__body__select js-autocommit topic-group" id="second-topic-select">
+                    <option value="0">{{live.topic}}</option>
+                </select>
+                <select class="dev_milestone-container__body__select js-autocommit topic-group" id="third-topic-select">
+                    <option value="0">{{live.topic}}</option>
+                </select>
             {{else}}
                 <div class="dev_milestone-container__body__readonly" id="topic-txt">
                    {{live.topic}} 

--- a/src/templates/in_development.handlebars
+++ b/src/templates/in_development.handlebars
@@ -48,15 +48,33 @@
         </div>
         {{#unless future.in_development}}
             {{#if permissions.can_edit}}
-                <select class="dev_milestone-container__body__select js-autocommit topic-group" id="first-topic-select">
-                    <option value="0">{{live.topic}}</option>
-                </select>
-                <select class="dev_milestone-container__body__select js-autocommit topic-group" id="second-topic-select">
-                    <option value="0">{{live.topic}}</option>
-                </select>
-                <select class="dev_milestone-container__body__select js-autocommit topic-group" id="third-topic-select">
-                    <option value="0">{{live.topic}}</option>
-                </select>
+                <div class="separator">
+                    <div class="button delete listbutton left js-autocommit" name="topic" title="Remove this topic">
+                        <i class="icon-remove" />
+                    </div>
+                    <select class="dev_milestone-container__body__select js-autocommit topic-group left" id="first-topic-select">
+                        <option value="0">{{index live.topic 0}}</option>
+                    </select>
+                    <span class="clearfix"></span>
+                </div>
+                <div class="separator">
+                    <div class="button delete listbutton left js-autocommit" name="topic" title="Remove this topic">
+                        <i class="icon-remove" />
+                    </div>
+                    <select class="dev_milestone-container__body__select js-autocommit topic-group left" id="second-topic-select">
+                        <option value="0">{{index live.topic 1}}</option>
+                    </select>
+                    <span class="clearfix"></span>
+                </div>
+                <div class="separator">
+                    <div class="button delete listbutton left js-autocommit" name="topic" title="Remove this topic">
+                        <i class="icon-remove" />
+                    </div>
+                    <select class="dev_milestone-container__body__select js-autocommit topic-group left" id="third-topic-select">
+                        <option value="0">{{index live.topic 2}}</option>
+                    </select>
+                    <span class="clearfix"></span>
+                </div>
             {{else}}
                 <div class="dev_milestone-container__body__readonly" id="topic-txt">
                    {{live.topic}} 


### PR DESCRIPTION
@russellholt @jagtalon 
I think three topics should be more than enough for an IA:
![schermata 2015-02-24 alle 21 31 39](https://cloud.githubusercontent.com/assets/3652195/6358512/890175a0-bc6c-11e4-8fe6-b43d982bdb9f.png)

Removing a topic doesn't actually remove the select element, it just empties the first option value and sets that one as selected, and then saves the new list of topics:
![schermata 2015-02-24 alle 21 31 51](https://cloud.githubusercontent.com/assets/3652195/6358540/bdf3de6a-bc6c-11e4-8af0-270b24eeaa8b.png)


