### PR TITLE
'Active' flag on domains to remove expired domains from translation interface.

### DIFF
--- a/lib/DDGC/DB/Result/Token/Domain.pm
+++ b/lib/DDGC/DB/Result/Token/Domain.pm
@@ -52,6 +52,12 @@ column sorting => {
 	default_value => 0,
 };
 
+column active => {
+	data_type => 'tinyint',
+	is_nullable => 0,
+	default_value => 1,
+};
+
 column source_language_id => {
 	data_type => 'int',
 	is_nullable => 0,

--- a/lib/DDGC/DB/ResultSet/Token/Language.pm
+++ b/lib/DDGC/DB/ResultSet/Token/Language.pm
@@ -42,6 +42,7 @@ sub untranslated_all {
 	$self->search({
 		'token_language_translations.id' => undef,
 		'token_domain_language.language_id' => { -in => \@language_ids},
+		'token_domain.active' => 1,
 		($self->me.'id') => { -not_in => \@ignore_ids },
 		$self->result_source->schema->ddgc->is_live ? ( 'token_domain.key' => { -like => 'duckduckgo-%' } ) : (),
 	},{
@@ -63,6 +64,7 @@ sub unvoted_all {
 	$self->search({
 		'token_language_translations.id' => { -not => undef },
 		'token_domain_language.language_id' => { -in => \@language_ids},
+		'token_domain.active' => 1,
 		$token_domain_id ? ( 'token_domain_language.token_domain_id' => $token_domain_id ) : (),
 		-and => [
 			($self->me.'id') => { -not_in => \@ignore_ids },

--- a/lib/DDGC/Web/Controller/Translate.pm
+++ b/lib/DDGC/Web/Controller/Translate.pm
@@ -31,7 +31,9 @@ sub base :Chained('/base') :PathPart('translate') :CaptureArgs(0) {
 sub index :Chained('base') :PathPart('') :Args(0) {
     my ( $self, $c ) = @_;
 	$c->stash->{headline_template} = 'headline/translate.tt';
-	$c->stash->{token_domains} = $c->d->rs('Token::Domain')->search({},{
+	$c->stash->{token_domains} = $c->d->rs('Token::Domain')->search({
+			active => 1,
+		},{
 		'+columns' => {
 			token_count => $c->d->rs('Token')->search({
 				'token_domain_id' => { -ident => 'me.id' },

--- a/lib/DDGC/Web/Controller/Translate.pm
+++ b/lib/DDGC/Web/Controller/Translate.pm
@@ -187,7 +187,7 @@ sub domain :Chained('logged_in') :PathPart('') :CaptureArgs(1) {
 	$c->stash->{locale} = $c->req->params->{locale} ? $c->req->params->{locale} :
 		$c->session->{cur_locale}->{$token_domain_key} ? $c->session->{cur_locale}->{$token_domain_key} : undef;
 	$c->stash->{token_domain} = $c->d->rs('Token::Domain')->find({ key => $token_domain_key });
-	return $c->go($c->controller('Root'),'default') unless $c->stash->{token_domain};
+	return $c->go($c->controller('Root'),'default') unless ($c->stash->{token_domain} && $c->stash->{token_domain}->active);
 	$c->stash->{locales} = {};
 	my $token_domain_language_rs = $c->stash->{token_domain}->token_domain_languages->search({});
 	$c->stash->{token_domain_languages_rs} = $token_domain_language_rs->search({},{

--- a/lib/DDGC/Web/Controller/Translate.pm
+++ b/lib/DDGC/Web/Controller/Translate.pm
@@ -123,7 +123,7 @@ sub tokenlanguage :Chained('logged_in') :Args(1) {
 		$c->wiz_step;
 	} else {
 		$c->stash->{token_language} = $c->d->rs('Token::Language')->find({ id => $token_language_id });
-		if (!defined $c->stash->{token_language} or !$c->stash->{token_language}) {
+		if (!defined $c->stash->{token_language} or !$c->stash->{token_language} or !$c->stash->{token_language}->token->token_domain->active) {
 			$c->response->redirect($c->chained_uri('Translate','index'));
 			return $c->detach;
 		}

--- a/sql/1.014/active_flag_for_domain.sql
+++ b/sql/1.014/active_flag_for_domain.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE token_domain ADD COLUMN active smallint DEFAULT 1 NOT NULL;
+
+COMMIT;
+

--- a/templates/i/token_domain/form.tx
+++ b/templates/i/token_domain/form.tx
@@ -6,6 +6,14 @@
   form_row_value => $_.key,
 } :>
 <: include form::row {
+  form_row_id => 'token_domain_' ~ ( $_.id || 0 ) ~ '_active',
+  form_row_label => 'Domain is Active:',
+  form_row_left => 'third',
+  form_row_right => 'twothird',
+  form_row_type => 'yesno',
+  form_row_value => $_.active,
+} :>
+<: include form::row {
   form_row_id => 'token_domain_' ~ ( $_.id || 0 ) ~ '_name',
   form_row_label => 'Name/Title:',
   form_row_left => 'third',


### PR DESCRIPTION
- Admin interface for domains has an 'Active' option - set to 'No' to hide this domain in the translation interface.

@zekiel @yegg Thanks.