### PR TITLE
IA Pages - Handlebars helper for appending the tab name to the example queries

### DIFF
--- a/src/ia/js/Helpers.js
+++ b/src/ia/js/Helpers.js
@@ -15,4 +15,10 @@
         }
     });
 
+    Handlebars.registerHelper('tab_url', function(tab) {
+        if (tab.length) {
+            return '&ia=' + tab.toLowerCase().replace(/\s/g, "");
+        }
+    });
+
 })(DDH);

--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -75,11 +75,6 @@
                         }
 
                         ia_data.future = future;
-                    } else {
-                        if (ia_data.live.tab) {
-                            // On the live static page we use the tab name for the example links
-                            ia_data.live.tab = ia_data.live.tab.toLowerCase().replace(/\s/g, "");
-                        }
                     }
 
                     // Readonly mode templates

--- a/src/templates/examples.handlebars
+++ b/src/templates/examples.handlebars
@@ -3,12 +3,12 @@
     <div class="ia-single--header">EXAMPLES</div>
     <ul>
       <li>
-        <a class="one-line" href="https://duckduckgo.com/?q={{encodeURIComponent example_query}}{{#if tab}}&ia={{tab}}{{/if}}" title="try this example on DuckDuckGo">{{example_query}}</a>
+        <a class="one-line" href="https://duckduckgo.com/?q={{encodeURIComponent example_query}}{{tab_url tab}}" title="try this example on DuckDuckGo">{{example_query}}</a>
       </li>
       {{#if other_queries}}
         {{#each other_queries}}
           <li>
-            <a class="one-line" href="https://duckduckgo.com/?q={{encodeURIComponent this}}{{#if ../tab}}&ia={{../../tab}}{{/if}}" title="try this example on DuckDuckGo">{{this}}</a>
+            <a class="one-line" href="https://duckduckgo.com/?q={{encodeURIComponent this}}{{tab_url ../tab}}" title="try this example on DuckDuckGo">{{this}}</a>
           </li>
         {{/each}}
       {{/if}}

--- a/src/templates/qa.handlebars
+++ b/src/templates/qa.handlebars
@@ -26,7 +26,7 @@
             {{#if permissions.can_edit}}
                 <input type="text" class="dev_milestone-container__body__input js-autocommit" id="example_query-input" value="{{live.example_query}}" />
             {{else}}
-                <a href="https://{{live.test_machine}}.duckduckgo.com/?q={{encodeURIComponent live.example_query}}{{tab_url live.tab}}" class="dev_milestone-container__body__readonly" id="example_query-a">
+                <a href="{{#if live.test_machine}}https://{{live.test_machine}}.duckduckgo.com/?q={{encodeURIComponent live.example_query}}{{tab_url live.tab}}{{/if}}" class="dev_milestone-container__body__readonly" id="example_query-a">
                     {{live.example_query}}
                 </a>
             {{/if}}

--- a/src/templates/qa.handlebars
+++ b/src/templates/qa.handlebars
@@ -26,7 +26,7 @@
             {{#if permissions.can_edit}}
                 <input type="text" class="dev_milestone-container__body__input js-autocommit" id="example_query-input" value="{{live.example_query}}" />
             {{else}}
-                <a href="https://{{live.test_machine}}.duckduckgo.com/?q={{encodeURIComponent live.example_query}}" class="dev_milestone-container__body__readonly" id="example_query-a">
+                <a href="https://{{live.test_machine}}.duckduckgo.com/?q={{encodeURIComponent live.example_query}}{{tab_url live.tab}}" class="dev_milestone-container__body__readonly" id="example_query-a">
                     {{live.example_query}}
                 </a>
             {{/if}}


### PR DESCRIPTION
@jagtalon @russellholt So now we can have the tab name appended on the dev page example query, too!