### PR TITLE
Increased contrast in header text to pass WCAG 2

### DIFF
--- a/share/docroot_duckpan/duckpan.css
+++ b/share/docroot_duckpan/duckpan.css
@@ -367,8 +367,8 @@ Buttons
 		}
 		.header-logo h2, .header-logo h3 { line-height: 1; margin: 0; text-align: left; position: relative; float: left; }
 		.header-logo h2 { color: #4c4c4c; font-weight: bold; font-size: 21px; padding-top: 10px; left: -1px; }
-			.header-logo h2 i { font-style: normal; color: #48af04; }
-		.header-logo h3 { color: #a2a2a2; font-weight: normal; padding-top: 4px; font-size: 12px; }
+			.header-logo h2 i { font-style: normal; color: #419503; }
+		.header-logo h3 { color: #606060; font-weight: normal; padding-top: 4px; font-size: 12px; }
 	
 	
 	.header-nav { float: left; text-align: center; }

--- a/share/perldoc/duckpan.css
+++ b/share/perldoc/duckpan.css
@@ -359,8 +359,8 @@ Buttons
 		}
 		.header-logo h2, .header-logo h3 { line-height: 1; margin: 0; text-align: left; position: relative; float: left; }
 		.header-logo h2 { color: #4c4c4c; font-weight: bold; font-size: 21px; padding-top: 10px; left: -1px; }
-			.header-logo h2 i { font-style: normal; color: #48af04; }
-		.header-logo h3 { color: #a2a2a2; font-weight: normal; padding-top: 4px; font-size: 12px; }
+			.header-logo h2 i { font-style: normal; color: #419f03; }
+		.header-logo h3 { color: #606060; font-weight: normal; padding-top: 4px; font-size: 12px; }
 	
 	
 	.header-nav { float: left; text-align: center; }


### PR DESCRIPTION
Slightly increased the contrast ratios of header text to above 4.5:1 for smaller text and above 3:1 for larger text.

This makes the text pass level AA of the [Web Content Accessiility Guidelines](http://www.w3.org/TR/WCAG20/).