### PR TITLE
Dev Page - no need to reload when changing type or team values

### DIFF
--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -441,6 +441,10 @@
                             if (data.result) {
                                 if (field === "dev_milestone") {
                                     location.reload();
+                                } else if (field === "repo") {
+                                    ia_data.live.repo = data.result.repo;
+                                    readonly_templates.planning =  Handlebars.templates.planning(ia_data);
+                                    page.updateAll(readonly_templates, ia_data.live.dev_milestone, false);
                                 } else if (field === "producer" || field === "designer" || field === "developer") {
                                     $("#" + field + "-input.js-autocommit").val(data.result[field]);
                                 }
@@ -561,6 +565,7 @@
                         $(".ia-single--edits").append(templates.dev_milestone);
                     }
                 } else {
+                    $(".ia-single").empty();
                     $(".ia-single").append(templates.live.name);
                     $(".ia-single").append(templates.live.description);
                     for (var i = 0; i < this.dev_milestones_order.length; i++) {

--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -441,13 +441,12 @@
                             if (data.result) {
                                 if (field === "dev_milestone") {
                                     location.reload();
-                                } else if (field === "repo") {
-                                    ia_data.live.repo = data.result.repo;
+                                } else if (field === "repo" || field === "producer"
+                                           || field === "designer" || field === "developer") {
+                                    ia_data.live[field] = data.result[field];
                                     readonly_templates.planning =  Handlebars.templates.planning(ia_data);
                                     page.updateAll(readonly_templates, ia_data.live.dev_milestone, false);
-                                } else if (field === "producer" || field === "designer" || field === "developer") {
-                                    $("#" + field + "-input.js-autocommit").val(data.result[field]);
-                                }
+                                } 
                             }
                         });
                     }


### PR DESCRIPTION
@russellholt 
[Screencast for the type change](http://gfycat.com/BruisedOrneryCobra)
[Screencast for producer name change](http://gfycat.com/PeacefulThirdCougar) - here the difference with the live version is that if you change a team name from yours to some other user (or if you remove it), the "assign to me" button is shown again without having to reload.