### PR TITLE
Dev Pipeline - add filters on the dev view

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -142,6 +142,7 @@ sub dev_pipeline_base :Chained('base') :PathPart('pipeline') :CaptureArgs(1) {
     $c->stash->{title} = "Dev Pipeline";
    
     if ($view eq 'dev') {
+        $c->stash->{logged_in} = $c->user;
         $c->stash->{is_admin} = $c->user? $c->user->admin : 0;
     }
     

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -140,6 +140,11 @@ sub dev_pipeline_base :Chained('base') :PathPart('pipeline') :CaptureArgs(1) {
     $c->stash->{view} = $view;
     $c->stash->{ia_page} = "IADevPipeline";
     $c->stash->{title} = "Dev Pipeline";
+   
+    if ($view eq 'dev') {
+        $c->stash->{is_admin} = $c->user? $c->user->admin : 0;
+    }
+    
     $c->add_bc('Instant Answers', $c->chained_uri('InstantAnswer','index'));
     $c->add_bc('Dev Pipeline', $c->chained_uri('InstantAnswer', 'dev_pipeline', $view));
 }

--- a/src/ia/css/ia.css
+++ b/src/ia/css/ia.css
@@ -1266,6 +1266,10 @@ body.texture {
     padding-left: 1em;
 }
 
+#pipeline_toggle-view {
+    margin-bottom: 1em;
+}
+
 #pipeline_toggle-view .pager-wrap {
     height: 4em;
     width: 17.7em;
@@ -1299,4 +1303,9 @@ body.texture {
 
 #pipeline-live-container .list-container--right {
     margin-left: 5em;
+}
+
+.icon-check,
+.icon-check-empty {
+    cursor: pointer;
 }

--- a/src/ia/css/ia.css
+++ b/src/ia/css/ia.css
@@ -1272,7 +1272,7 @@ body.texture {
 
 #pipeline_toggle-view .pager-wrap {
     height: 4em;
-    width: 17.7em;
+    width: 17.95em;
 }
 
 #pipeline-live-container .list-container--left {

--- a/src/ia/js/IADevPipeline.js
+++ b/src/ia/js/IADevPipeline.js
@@ -46,6 +46,15 @@
                 }
             });
 
+            $("#select-teamrole").change(function(evt) {
+                if ($("#filter-team_checkbox").hasClass("icon-check")) {
+                    $(".dev_pipeline-column__list li").hide();
+
+                    var teamrole = $(this).find("option:selected").text();
+                    $(".dev_pipeline-column__list li." + teamrole + "-" + username).show();
+                }
+            });
+
             $("#pipeline_toggle-dev").click(function(evt) {
                 if (!$(this).hasClass("disabled")) {
                     window.location = "/ia/pipeline/dev";

--- a/src/ia/js/IADevPipeline.js
+++ b/src/ia/js/IADevPipeline.js
@@ -9,7 +9,7 @@
         init: function() {
             // console.log("IADevPipeline init()");
             var dev_p = this;
-            var url = window.location.pathname + "json";
+            var url = window.location.pathname.replace(/\/$/, '') + "/json";
             var username = $(".user-name").text();
 
             $.getJSON(url, function(data) { 

--- a/src/ia/js/IADevPipeline.js
+++ b/src/ia/js/IADevPipeline.js
@@ -7,12 +7,13 @@
     DDH.IADevPipeline.prototype = {
 
         init: function() {
-            //console.log("IADevPipeline init()");
+            // console.log("IADevPipeline init()");
             var dev_p = this;
-            var url = window.location.pathname + "/json";
+            var url = window.location.pathname + "json";
+            var username = $(".user-name").text();
 
             $.getJSON(url, function(data) { 
-                console.log(window.location.pathname);
+                // console.log(window.location.pathname);
                 var iadp;
 
                 if (data.hasOwnProperty("planning")) {
@@ -22,6 +23,27 @@
                 }
 
                 $("#dev_pipeline").html(iadp);
+            });
+
+            $("#filter-team_checkbox").click(function(evt) {
+                $(this).toggleClass("icon-check");
+                $(this).toggleClass("icon-check-empty");
+
+                if ($(this).hasClass("icon-check-empty")) {
+                    $(".dev_pipeline-column__list li").show();
+                } else {
+                    $(".dev_pipeline-column__list li").hide();
+
+                    if ($("#select-teamrole").length) {
+                        var teamrole = $("#select-teamrole option:selected").text();
+                        $(".dev_pipeline-column__list li." + teamrole + "-" + username).show();
+                    } else {
+                        // If the select elements doesn't exist
+                        // then the user isn't an admin
+                        // and therefore the only role he can fulfill is the developer
+                        $(".dev_pipeline-column__list li.designer-" + username).show();
+                    }
+                }
             });
 
             $("#pipeline_toggle-dev").click(function(evt) {

--- a/templates/instantanswer/dev_pipeline.tx
+++ b/templates/instantanswer/dev_pipeline.tx
@@ -10,7 +10,7 @@
         </span>
     </div>
 
-    <: if $view == 'dev' { :>
+    <: if $view == 'dev' && $logged_in { :>
         <div class="filter-team">
             <i class="filter-team__checkbox icon-check-empty" id="filter-team_checkbox"></i>
             <span class="filter-team__span">

--- a/templates/instantanswer/dev_pipeline.tx
+++ b/templates/instantanswer/dev_pipeline.tx
@@ -9,6 +9,24 @@
             </span>
         </span>
     </div>
+
+    <: if $view == 'dev' { :>
+        <div class="filter-team">
+            <i class="filter-team__checkbox icon-check-empty" id="filter-team_checkbox"></i>
+            <span class="filter-team__span">
+                Show IAs of which I am the 
+                <: if $is_admin { :>
+                    <select class="filter-team__span__select" id="select-teamrole">
+                        <option value="0">producer</option>
+                        <option value="1">designer</option>
+                        <option value="2">developer</option>
+                    </select>
+                <: } else { :>
+                    developer
+                <: } :>
+            </span> 
+        </div>
+    <: } :>
 </div>
 
 <div id="dev_pipeline">


### PR DESCRIPTION
@russellholt @jagtalon if you're an admin you can choose to see all IAs in development of which you're the producer, or the designer, or the developer.
A regular user (doesn't matter if he has permissions or not) can see all the IAs which he's developing. 
The filtering is done via CSS classes, like we do in the IA Pages Index.

[Screencast](http://gfycat.com/ColorfulAnguishedChameleon) - on my instance TestOne, which is an admin, is producer of "Another IA in development", designer of "Test" and developer of none.

Screenshot (checkbox is unchecked, so we display all the IAs in development):
![schermata 2015-03-03 alle 20 55 29](https://cloud.githubusercontent.com/assets/3652195/6470947/a8ca4abc-c1e7-11e4-98d9-dc80921a9f21.png)
