### PR TITLE
Fix some deployment warnings

### DIFF
--- a/lib/DDGC/DB/Result/Topic.pm
+++ b/lib/DDGC/DB/Result/Topic.pm
@@ -30,7 +30,7 @@ unique_column name => {
         is_nullable => 0,
 };
 
-has_many 'instant_answer_topics', 'DDGC::DB::Result::InstantAnswer::Topics', 'topics_id', {on_delete => 'cascade'};
+has_many 'instant_answer_topics', 'DDGC::DB::Result::InstantAnswer::Topics', 'topics_id';
 many_to_many 'instant_answers', 'instant_answer_topics', 'instant_answer';
 
 no Moose;

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -1,5 +1,6 @@
 package DDGC::Web::Controller::InstantAnswer;
 # ABSTRACT: Instant Answer Pages
+
 use Data::Dumper;
 use Moose;
 use namespace::autoclean;


### PR DESCRIPTION
- `[PkgVersion] no blank line for $VERSION after package DDGC::Web::Controller::InstantAnswer statement on line 1`
- `SQL::Translator::Parser::DBIx::Class::parse(): SQLT attribute 'on_delete' was supplied for relationship 'Topic/instant_answer_topics', which does not appear to be a foreign constraint. If you are sure that SQLT must generate a constraint for this relationship, add 'is_foreign_key_constraint => 1' to the attributes.`