### PR TITLE
IA Pages - add 'answerbar' column to the InstantAnswer table and display the field on the Dev Page

### DIFF
--- a/lib/DDGC/DB/Result/InstantAnswer.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer.pm
@@ -28,6 +28,13 @@ column description => {
 	is_nullable => 1,
 };
 
+# JSON string cointaining parameters such as
+# fallback_timeout, for IAs with slow upstream providers
+column answerbar => {
+    data_type => 'text',
+    is_nullable => 1,
+};
+
 # eg DDG::Goodie::Calculator
 column perl_module => {
 	data_type => 'text',

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -418,7 +418,8 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
                 tested_relevancy => $ia->tested_relevancy,
                 tested_staging => $ia->tested_staging,
                 is_live => $ia->is_live,
-                src_options => $ia->src_options? from_json($ia->src_options) : undef
+                src_options => $ia->src_options? from_json($ia->src_options) : undef,
+                answerbar => $ia->answerbar? from_json($ia->answerbar) : undef
     };
 
     if ($c->user) {

--- a/sql/1.018/answerbar_fallback_timeout.sql
+++ b/sql/1.018/answerbar_fallback_timeout.sql
@@ -1,0 +1,3 @@
+BEGIN;
+ALTER TABLE instant_answer ADD COLUMN answerbar text;
+COMMIT;

--- a/src/templates/planning.handlebars
+++ b/src/templates/planning.handlebars
@@ -65,7 +65,7 @@
             <div class="dev_milestone-container__body__div">
                 <ul class="section-group" id="answerbar-group">
                     <li>
-                        <label class="left">Fallback Timeout (seconds):</label>
+                        <label class="left">Fallback Timeout (ms):</label>
                         {{#unless future.planning}}
                             {{#if permissions.admin}}
                                 <input type="number" class="clearfix section-group__item dev_milestone-container__body__input js-autocommit" id="fallback_timeout-input" value="{{live.answerbar.fallback_timeout}}" />

--- a/src/templates/planning.handlebars
+++ b/src/templates/planning.handlebars
@@ -58,6 +58,26 @@
                     </div>
                 {{/if}}
             {{/unless}}
+
+            <div class="dev_milestone-container__body__label ia-single--header">
+                ANSWERBAR
+            </div>
+            <div class="dev_milestone-container__body__div">
+                <ul class="section-group" id="answerbar-group">
+                    <li>
+                        <label class="left">Fallback Timeout (seconds):</label>
+                        {{#unless future.planning}}
+                            {{#if permissions.admin}}
+                                <input type="number" class="clearfix section-group__item dev_milestone-container__body__input js-autocommit" id="fallback_timeout-input" value="{{live.answerbar.fallback_timeout}}" />
+                            {{else}}
+                                <div class="clearfix dev_milestone-container__body__readonly" id="fallback_timeout-txt">
+                                    {{live.answerbar.fallback_timeout}}
+                                </div>
+                            {{/if}}
+                        {{/unless}}
+                    </li>
+                </ul>
+            </div>
         {{/eq}}
 
         {{#eq live.repo 'fathead'}}
@@ -114,7 +134,7 @@
                             {{#if permissions.can_edit}}
                                 <input type="text" class="clearfix section-group__item dev_milestone-container__body__input js-autocommit" id="skip_qr-input" value="{{live.src_options.skip_qr}}" />
                             {{else}}
-                                <div class="clearfix dev_milestone-container__body__readonly" id="directory-txt">
+                                <div class="clearfix dev_milestone-container__body__readonly" id="skip_qr-txt">
                                     {{live.src_options.skip_qr}}
                                 </div>
                             {{/if}}


### PR DESCRIPTION
@russellholt @bsstoner @tommytommytommy @nilnilnil 
Please let me know if I got this right: the column 'answerbar' is a JSON string which, for now, only contains fallback_timeout, but it can easily contain any other value you might need.

You should be able to set the fallback_value for any Spice not yet live inside the Planning panel of the dev page (screenshots below):
![schermata 2015-03-10 alle 21 26 28](https://cloud.githubusercontent.com/assets/3652195/6585220/c07ca4be-c770-11e4-9826-8424bb03566a.png)
![schermata 2015-03-10 alle 21 26 33](https://cloud.githubusercontent.com/assets/3652195/6585222/c3edd6cc-c770-11e4-9ee5-b2207e10ad2a.png)

JSON data returned:
![schermata 2015-03-10 alle 22 05 43](https://cloud.githubusercontent.com/assets/3652195/6585354/a59a32f0-c771-11e4-9e6c-b07c07cde965.png)


