### PR TITLE
Dev Page - make description editable

### DIFF
--- a/src/ia/css/ia.css
+++ b/src/ia/css/ia.css
@@ -1362,3 +1362,7 @@ body.texture {
     -moz-border-radius: 3px;
     -o-border-radius: 3px;
 }
+
+.metafield {
+    margin-bottom: 1em;
+}

--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -89,6 +89,7 @@
                             devinfo : Handlebars.templates.devinfo(latest_edits_data),
                             github: Handlebars.templates.github(latest_edits_data)
                         },
+                        metafields : Handlebars.templates.metafields(ia_data),
                         planning : Handlebars.templates.planning(ia_data),
                         in_development : Handlebars.templates.in_development(ia_data),
                         qa : Handlebars.templates.qa(ia_data),
@@ -173,7 +174,7 @@
                         }
                     });
 
-                    $("body").on("focusin", ".dev_milestone-container__body__input.js-autocommit", function(evt) {
+                    $("body").on("focusin", "input.js-autocommit", function(evt) {
                         if (!$(this).hasClass("js-autocommit-focused")) {
                             $(this).addClass("js-autocommit-focused");
                         }
@@ -208,7 +209,7 @@
                         }
                     });
 
-                    $("body").on('keypress focusout', ".dev_milestone-container__body__input.js-autocommit-focused", function(evt) {
+                    $("body").on('keypress focusout', "input.js-autocommit-focused", function(evt) {
                         if ((evt.type === 'keypress' && evt.which === 13) || (evt.type === "focusout")) {
                             var field = $.trim($(this).attr("id").replace("-input", ""));
                             var value = $.trim($(this).val());
@@ -545,6 +546,7 @@
                     templates.live[this.field_order[i]] = Handlebars.templates[this.field_order[i]](ia_data);
                 }
             } else {
+                templates.metafields = Handlebars.templates.metafields(ia_data);
                 for (var i = 0; i < this.dev_milestones_order.length; i++) {
                     templates[this.dev_milestones_order[i]] = Handlebars.templates[this.dev_milestones_order[i]](ia_data);
                 }
@@ -608,7 +610,7 @@
                 } else {
                     $(".ia-single").empty();
                     $(".ia-single").append(templates.live.name);
-                    $(".ia-single").append(templates.live.description);
+                    $(".ia-single").append(templates.metafields);
                     for (var i = 0; i < this.dev_milestones_order.length; i++) {
                         $(".ia-single").append(templates[this.dev_milestones_order[i]]);
                     }

--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -116,6 +116,9 @@
 
                             page.updateHandlebars(readonly_templates, ia_data);
                             page.updateAll(readonly_templates, ia_data.live.dev_milestone, false);
+
+                            $(".button-nav-current").removeClass("disabled").removeClass("button-nav-current");
+                            $(this).addClass("disabled").addClass("button-nav-current");
                         }
                     });
 
@@ -126,6 +129,9 @@
 
                             page.updateHandlebars(readonly_templates, ia_data);
                             page.updateAll(readonly_templates, ia_data.live.dev_milestone, false);
+
+                            $(".button-nav-current").removeClass("disabled").removeClass("button-nav-current");
+                            $(this).addClass("disabled").addClass("button-nav-current");
                         }
                     });
 
@@ -174,7 +180,7 @@
                         }
                     });
 
-                    $("body").on("focusin", "input.js-autocommit", function(evt) {
+                    $("body").on("focusin", "textarea.js-autocommit, input.js-autocommit", function(evt) {
                         if (!$(this).hasClass("js-autocommit-focused")) {
                             $(this).addClass("js-autocommit-focused");
                         }
@@ -209,24 +215,25 @@
                         }
                     });
 
-                    $("body").on('keypress focusout', "input.js-autocommit-focused", function(evt) {
+                    $("body").on('keypress focusout', "textarea.js-autocommit-focused, input.js-autocommit-focused", function(evt) {
                         if ((evt.type === 'keypress' && evt.which === 13) || (evt.type === "focusout")) {
-                            var field = $.trim($(this).attr("id").replace("-input", ""));
+                            var field;
                             var value = $.trim($(this).val());
+                            var id = $.trim($(this).attr("id"));
                             var is_json = false;
+
+                            if (id.match(/.*-input/)) {
+                                field = id.replace("-input", "");
+                            } else {
+                                field = id.replace("-textarea", "");
+                            }
 
                             if ($(this).hasClass("comma-separated") && value.length) {
                                 value = value.split(/\s*,\s*/);
                                 value = JSON.stringify(value);
                                 is_json = true;
                             }
-
-                            if (evt.type === 'keypress') {
-                                $(this).blur();
-                            }
-
-                            $(this).removeClass("js-autocommit-focused");
-
+                            
                             if (field.length && value !== ia_data.live[field]) {
                                 if ($(this).hasClass("section-group__item")) {
                                     var parent_field = $.trim($(this).parent().parent().attr("id"));
@@ -240,6 +247,12 @@
                                 
                                 autocommit(field, value, DDH_iaid, is_json);
                             }
+
+                            if (evt.type === 'keypress') {
+                                $(this).blur();
+                            }
+
+                            $(this).removeClass("js-autocommit-focused");
                         }
                     });
 

--- a/src/templates/metafields.handlebars
+++ b/src/templates/metafields.handlebars
@@ -1,6 +1,6 @@
 <div id="big-description">
     {{#if permissions.can_edit}}
-        <input class="js-autocommit metafield" id="description-input" value="{{live.description}}" />
+        <textarea rows="2" cols="55" class="js-autocommit metafield" id="description-textarea">{{live.description}}</textarea>
     {{else}}
         {{#if live.description}}
             <p>{{live.description}}</p>

--- a/src/templates/metafields.handlebars
+++ b/src/templates/metafields.handlebars
@@ -1,0 +1,9 @@
+<div id="big-description">
+    {{#if permissions.can_edit}}
+        <input class="js-autocommit metafield" id="description-input" value="{{live.description}}" />
+    {{else}}
+        {{#if live.description}}
+            <p>{{live.description}}</p>
+        {{/if}}
+    {{/if}}
+</div>

--- a/templates/instantanswer/ia.tx
+++ b/templates/instantanswer/ia.tx
@@ -21,13 +21,13 @@
             </div>
         </div>
     <: } else { :>
-        <div class="special-permissions__toggle-view right" id="toggle-devpage-view">
+        <div class="dev-special-permissions__toggle-view right" id="toggle-devpage-view">
             <div class="pager-wrap">
                 <span class="button-group  button-group--paging">
-                    <span class="button special-permissions__toggle-view__button" id="toggle-devpage-static">
+                    <span class="button dev-special-permissions__toggle-view__button" id="toggle-devpage-static">
                         Static
                     </span>
-                    <span class="button special-permissions__toggle-view__button button-nav-current disabled" id="toggle-devpage-editable">
+                    <span class="button dev-special-permissions__toggle-view__button button-nav-current disabled" id="toggle-devpage-editable">
                         Editable
                     </span>
                 </span>


### PR DESCRIPTION
@russellholt a 'metafields' Handlebars template is now appended to the dev page before the dev milestone panels. 
Right now it only contains the description, but its purpose is more generally to contain all the meta fields, aka fields which don't necessarily belong to a specific dev milestone, such as tab name and topics.
![schermata 2015-03-12 alle 20 21 15](https://cloud.githubusercontent.com/assets/3652195/6626244/82179716-c8f5-11e4-8798-967ff1db77f6.png)
