### PR TITLE
IAPage.js - trigger focus event on input type number on value change

### DIFF
--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -185,6 +185,12 @@
                         }
                     });
 
+                    $("body").on("change", 'input[type="number"].js-autocommit', function(evt) {
+                        if (!$(this).hasClass("js-autocommit-focused")) {
+                            $(this).focus();
+                        }
+                    });
+
                     $("body").on("focusin", "textarea.js-autocommit, input.js-autocommit", function(evt) {
                         if (!$(this).hasClass("js-autocommit-focused")) {
                             $(this).addClass("js-autocommit-focused");


### PR DESCRIPTION
@russellholt Previously when clicking on the up/down arrows on the input[type="number"] fields the focus event wasn't triggered, so in order to save the value you needed either to change the value using the keyboard or to click on the input and outside (or hit the return button) to save.

Minor change, merging right away.