### PR TITLE
Remove blog post share buttons

### DIFF
--- a/templates/blog/sidebar.tx
+++ b/templates/blog/sidebar.tx
@@ -33,7 +33,6 @@
 			<h5>Feeds</h5>
 			<div class="icons">
 				<a class="icon tw" href="https://twitter.com/duckduckgo" title="DuckDuckGo on twitter">Twitter</a>
-				<a class="icon fb" href="https://facebook.com/duckduckgo" title="DuckDuckGo on Facebook">Facebook</a>
 				<a class="icon re" href="http://www.reddit.com/r/duckduckgo" title="DuckDuckGo on reddit">reddit /r/duckduckgo</a>
 				<a class="icon rss" href="<: $u('Blog','index_rss') :>" title="DuckDuckGo Blog RSS feed">RSS</a>
 			</div>

--- a/templates/feedback/thanks.tx
+++ b/templates/feedback/thanks.tx
@@ -16,7 +16,6 @@
 	<section class="sidebar-social">				
 		<div class="icons">
 			<a class="icon tw" href="https://twitter.com/duckduckgo" title="DuckDuckGo on twitter">Twitter</a>
-			<a class="icon fb" href="https://facebook.com/duckduckgo" title="DuckDuckGo on Facebook">Facebook</a>
 			<a class="icon re" href="http://www.reddit.com/r/duckduckgo" title="DuckDuckGo on reddit">reddit /r/duckduckgo</a>
 			<a class="icon rss" href="<: $u('Blog','index_rss') :>" title="DuckDuckGo Blog RSS feed">RSS</a>
 		</div>

--- a/templates/i/user_blog/actions.tx
+++ b/templates/i/user_blog/actions.tx
@@ -3,9 +3,6 @@
 		<a href="<: $u($user_blog.u) :>#comments" class="comments-link"><i class="comments-link__icon  icon-bubble"></i> <: $_.all_comments.count :></a>
 	</span>
 	<span class="action-item">
-		<a href="https://facebook.com/sharer.php?s=100&u=<: $u($user_blog.u) | uri :>&p[url]=<: $u($user_blog.u) | uri :>&p[title]=<: $user_blog.title | uri :>" class="button blue fb" target="_facebook-share"><i class="action-item__icon icon-facebook"></i> Share</a>
-	</span>
-	<span class="action-item">
 		<a href="https://twitter.com/?status=<: $user_blog.title ~ ' ' ~ $u($user_blog.u) | uri :>" class="button blue tw" target="_twitter-share"><i class="action-item__icon icon-twitter"></i> Tweet</a>
 	</span>
 	<: if $c.user && $show_follow_button { :>


### PR DESCRIPTION
@zekiel This removes the fb "share" buttons from the bottom of blog posts in the index and individual posts.

https://view.dukgo.com/blog/

Thanks!