### PR TITLE
on /repo return only live

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -88,7 +88,11 @@ sub iarepo_json :Chained('iarepo') :PathPart('json') :Args(0) {
 
     my %iah;
 
+IA:
     for my $ia (@x) {
+
+        next IA unless $ia->dev_milestone eq 'live'; # or ready?
+
         my @topics = map { $_->name} $ia->topics;
 
         $iah{$ia->id} = {


### PR DESCRIPTION
late night fix
may not be the best way, but consider this a placeholder
maybe also include ready ? 

we were including metadata in the repo release for in dev IAs that don't have perl modules, causing internal issues that were addressed separately
