### PR TITLE
InstantAnswer.pm - select live IAs for the repo JSON endpoint

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -84,15 +84,15 @@ sub iarepo_json :Chained('iarepo') :PathPart('json') :Args(0) {
     my ( $self, $c ) = @_;
 
     my $repo = $c->stash->{ia_repo};
-    my @x = $c->d->rs('InstantAnswer')->search({repo => $repo});
+    my @x = $c->d->rs('InstantAnswer')->search({
+        repo => $repo,
+        dev_milestone => 'live',
+    });
 
     my %iah;
 
 IA:
     for my $ia (@x) {
-
-        next IA unless $ia->dev_milestone eq 'live'; # or ready?
-
         my @topics = map { $_->name} $ia->topics;
 
         $iah{$ia->id} = {


### PR DESCRIPTION
@russellholt a little modification so we just select live IAs and we don't have to skim through in development ones, as suggested by @jbarrett.

Didn't use the HashRefInflator thing because we have to retrieve columns which need to be decoded from JSON, I think it's fine and fast enough for now anyway