### PR TITLE
InstantAnswer.pm - use another syntax for the OR in the where clause inside ialist_json

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -53,14 +53,8 @@ sub ialist_json :Chained('base') :PathPart('json') :Args() {
     my $rs = $c->d->rs('InstantAnswer');
 
     my @ial = $rs->search(
-        {-or => [
-            'topic.name' => { '!=' => 'test' },
-            'topic' => { '=' => ''},
-        ],
-         -or => [
-            'me.dev_milestone' => { '=' => 'live'},
-            'me.dev_milestone' => { '=' => 'ready'},
-         ],
+        {'topic.name' => [{ '!=' => 'test' }, { '=' => undef}],
+         'me.dev_milestone' => { '=' => ['live', 'ready']},
         },
         {
             columns => [ qw/ name id repo src_name dev_milestone description template / ],


### PR DESCRIPTION
So the IsAwesome goodies don't show up anymore and we can specify to show IAs without topics as well. Urgent, merging right away