### PR TITLE
For Comment: Integrated Applications / Services experiment

### DIFF
--- a/lib/DDGC/Web.pm
+++ b/lib/DDGC/Web.pm
@@ -8,10 +8,10 @@ use Catalyst::Runtime 5.90;
 
 use Catalyst qw/
     ConfigLoader
+    Session
+    Session::State::PSGI
+    Session::Store::PSGI
     Static::Simple
-	Session
-	Session::Store::File
-	Session::State::Cookie
 	Authentication
 	Authorization::Roles
 	ChainedURI
@@ -82,12 +82,6 @@ __PACKAGE__->config(
 		'content-type' => 'text/html; charset=utf-8',
 		'view-name' => 'Xslate',
 		'response-status' => 500,
-	},
-	'Plugin::Session' => {
-		cookie_secure   => 2,
-		cookie_httponly => 1,
-		expires => 21600,
-		defined $ENV{DDGC_TMP} ? ( storage => $ENV{DDGC_TMP} ) : (),
 	},
 	'Plugin::Captcha' => {
 		session_name => 'captcha_string',

--- a/lib/DDGC/Web/App/UserLoggedIn.pm
+++ b/lib/DDGC/Web/App/UserLoggedIn.pm
@@ -1,0 +1,43 @@
+package DDGC::Web::App::UserLoggedIn;
+
+use Dancer2;
+use Dancer2::Plugin::DBIC;
+use DDGC;
+use DDGC::Web;
+
+my $d = DDGC->new;
+my $c = DDGC::Web->new;
+my $config = $d->config;
+my $xslate = $d->xslate;
+
+set plugins => {
+    DBIC => {
+        default => {
+            dsn         => $config->db_dsn,
+            user        => $config->db_user,
+            password    => $config->db_password,
+        }
+    },
+};
+
+set session => 'PSGI';
+
+get '/' => sub {
+    my $user = schema->resultset('User')->find({ username => session('__user') });
+    return 'None' if !$user;
+    my @templates = ( qw/base.tx loggedinuser.tx/ );
+    $xslate->{functions}->{next_template} = sub {
+        shift @templates;
+    };
+    $xslate->{functions}->{u} = sub {
+        '/';
+    };
+    return $xslate->render(shift @templates, {
+        user => $user,
+        c => { d => $d, user => $user },
+        next_template => sub { shift @templates; },
+        u => sub { $c->chained_uri(map { (ref $_ eq 'ARRAY') ? @{$_} : $_ } @_) },
+    });
+};
+
+1;

--- a/lib/DDGC/Web/Service/UserLoggedIn.pm
+++ b/lib/DDGC/Web/Service/UserLoggedIn.pm
@@ -1,0 +1,32 @@
+package DDGC::Web::Service::UserLoggedIn;
+
+use Dancer2;
+use Dancer2::Plugin::DBIC;
+use DDGC::Config;
+
+my $config = DDGC::Config->new;
+
+set plugins => {
+    DBIC => {
+        default => {
+            dsn         => $config->db_dsn,
+            user        => $config->db_user,
+            password    => $config->db_password,
+        }
+    },
+};
+
+set serializer => 'JSON';
+
+set session => 'PSGI';
+
+get '/' => sub {
+    schema->resultset('User')->find(
+        { username => session('__user') },
+        { result_class => 'DBIx::Class::ResultClass::HashRefInflator',
+          columns => [ qw/ id username /],
+        }
+    );
+};
+
+1;

--- a/script/ddgc_dev_server.psgi
+++ b/script/ddgc_dev_server.psgi
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use FindBin;
+use lib $FindBin::Dir . "/../lib";
+
+use Plack::Builder;
+use DDGC::Web;
+use DDGC::Web::App::UserLoggedIn;
+use DDGC::Web::Service::UserLoggedIn;
+
+builder {
+    enable 'Session', store => 'File', state => 'Cookie', secure => 2, httponly => 1, expires => 21600;
+
+    mount '/userloggedin' => DDGC::Web::App::UserLoggedIn->to_app;
+    mount '/userloggedin/json' => DDGC::Web::Service::UserLoggedIn->to_app;
+    mount '/' => DDGC::Web->new->psgi_app;
+};
+

--- a/templates/loggedinuser.tx
+++ b/templates/loggedinuser.tx
@@ -1,0 +1,3 @@
+<pre>
+  Username : <: $user.username :>
+  User ID  : <: $user.id :>


### PR DESCRIPTION
@nilnilnil @zekiel 

- Dancer2 for easy Plack routing and plugin ecosystem
- PSGI Session used by Catalyst and other apps
- Existing XSlate member of DDGC used to render
  - Shim functions for essential (i.e. prevent crashing) catalyst context, view functionality
  - Some stuff not working, like `chained_uri`
- Serializer used for "API" service

Pretty crusty, but it's a jumping off point for discussion I suppose.

"App" Screenie - avatars, links not working since they rely on chained_uri:

![Links not working](http://jbrt.org/ddg/integrated_app.png)