### PR TITLE
Add a plaintext part to HTML mail

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -106,3 +106,4 @@ requires 'Search::Query', '0.24';
 requires 'HTML::Strip', '1.06';
 requires 'CPAN::Documentation::HTML', '0.001';
 requires 'String::Truncate', '1.100602';
+requires 'HTML::FormatText::WithLinks', '0.15';


### PR DESCRIPTION
Generated by [`HTML::FormatText::WithLinks`](https://metacpan.org/pod/HTML::FormatText::WithLinks).

Sample plaintext part for signup email:

```
--14284084110.aE39aF8dA.16636
Date: Tue, 7 Apr 2015 08:06:51 -0400
MIME-Version: 1.0
Content-Type: text/plain; charset="UTF-8"

   This is an automated email from DuckDuckGo's Community platform. DO
   NOT REPLY.


   DuckDuckGo
   ----------


   Community Platform



   Welcome to the DuckDuckGo Community!
   ====================================

   Thanks for joining duck.co, the DuckDuckGo community changing the
   future of search.

   Please click the link below to verify this email address:

   [1]Yes, I signed up for duck.co with this address

   Regards,
   The DuckDuckGo Community team.

   

   1. https://view.dukgo.com/my/email_verify/thisisabrandnewaccount/abc123qwe456zxc789abc123qwe4


--14284084110.aE39aF8dA.16636--
```

#150 #132