### PR TITLE
Dev IA Pages - refresh panels height on autocommit to prevent content from overflowing

### DIFF
--- a/src/ia/css/ia.css
+++ b/src/ia/css/ia.css
@@ -1434,7 +1434,7 @@ body.texture {
 }
 
 .ia-single--left--wide .dev_milestone-container {
-    width: 22%;
+    width: 22.6%;
     float: left;
 }
 

--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -174,16 +174,9 @@
                             $(".dev_milestone-container__body").removeClass("hide");
 
                             // Set the panels height to the tallest one's height
-                            var max_height = 0;
-                            $(".dev_milestone-container").each(function(idx) {
-                                if ($(this).height() > max_height) {
-                                    max_height = $(this).height();
-                                }
-                            });
-
-                            $(".dev_milestone-container").height(max_height);
-
+                            page.setMaxHeight($(".milestone-panel"));
                             page.imgHide = true;
+                            $(".button.js-expand").hide();
                         }
                     });
                     
@@ -577,6 +570,9 @@
                                     var $panel_body = $("#" + panel + " .dev_milestone-container__body");
                                     $panel_body.html(readonly_templates[panel + "_content"]);
 
+                                    $("#" + panel).height($panel_body.height() + 50);
+                                    page.setMaxHeight($(".milestone-panel"));
+
                                     page.appendTopics();
                                     page.hideAssignToMe();
                                 } 
@@ -654,6 +650,17 @@
             'qa',
             'ready'
         ],
+
+        setMaxHeight: function($obj_set) {
+            var max_height = 0;
+            $obj_set.each(function(idx) {
+                if ($(this).height() > max_height) {
+                    max_height = $(this).height();
+                }
+            });
+
+            $obj_set.height(max_height);
+        },
 
         updateHandlebars: function(templates, ia_data, dev_milestone) {
             if (dev_milestone === 'live') {
@@ -736,6 +743,8 @@
 
                 if (!this.imgHide) {
                     $(".ia-single--right").append(templates.live.screens);
+                } else {
+                    $(".button.js-expand").hide();
                 }
 
                 $(".show-more").click(function(e) {

--- a/src/templates/in_development.handlebars
+++ b/src/templates/in_development.handlebars
@@ -1,4 +1,4 @@
-<div class="dev_milestone-container {{#if current.in_development}}current-container{{/if}} {{#if future.in_development}}future-container{{/if}} container-in_development" id="in_development">
+<div class="dev_milestone-container milestone-panel {{#if current.in_development}}current-container{{/if}} {{#if future.in_development}}future-container{{/if}} container-in_development" id="in_development">
     <div class="dev_milestone-container__header container-in_development__header">
         <h3 class="dev_milestone-container__header__title left">
             In Development

--- a/src/templates/planning.handlebars
+++ b/src/templates/planning.handlebars
@@ -1,4 +1,4 @@
-<div class="dev_milestone-container {{#if current.planning}}current-container{{/if}} {{#if future.planning}}future-container{{/if}} container-planning" id="planning">
+<div class="dev_milestone-container milestone-panel {{#if current.planning}}current-container{{/if}} {{#if future.planning}}future-container{{/if}} container-planning" id="planning">
     <div class="dev_milestone-container__header container-planning__header">
         <h3 class="dev_milestone-container__header__title left">
             Planning

--- a/src/templates/qa.handlebars
+++ b/src/templates/qa.handlebars
@@ -1,4 +1,4 @@
-<div class="dev_milestone-container {{#if current.qa}}current-container{{/if}} {{#if future.qa}}future-container{{/if}} container-qa" id="qa">
+<div class="dev_milestone-container milestone-panel {{#if current.qa}}current-container{{/if}} {{#if future.qa}}future-container{{/if}} container-qa" id="qa">
     <div class="dev_milestone-container__header container-qa__header">
         <h3 class="dev_milestone-container__header__title left">
             QA

--- a/src/templates/ready.handlebars
+++ b/src/templates/ready.handlebars
@@ -1,4 +1,4 @@
-<div class="dev_milestone-container {{#if current.ready}}current-container{{/if}} {{#if future.ready}}future-container{{/if}} container-ready" id="ready">
+<div class="dev_milestone-container milestone-panel {{#if current.ready}}current-container{{/if}} {{#if future.ready}}future-container{{/if}} container-ready" id="ready">
     <div class="dev_milestone-container__header container-ready__header">
         <h3 class="dev_milestone-container__header__title left">
             Ready


### PR DESCRIPTION
@russellholt previously the content overflowed when setting the type to "fathead"