### PR TITLE
add file paths when a pr is merged

### DIFF
--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -78,14 +78,13 @@ sub getIssues{
 				tags => $issue->{'labels'} || '',
 				date => $issue->{'created_at'} || '',
                 is_pr => $is_pr,
-                code => '',
 			);
 			push(@results, \%entry);
             delete $pr_hash{$issue->{'number'}.$issue->{repo}};
 		}
 	}
     # warn Dumper @results;
-    #warn Dumper %pr_hash;
+    # warn Dumper %pr_hash;
 }
 
 # check the status of PRs in $pr_hash.  If they were merged

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -81,7 +81,7 @@ sub getIssues{
                 code => '',
 			);
 			push(@results, \%entry);
-            delete $pr_hash{$issue->{'number'}.$issue->{repo}} unless $issue->{'number'} =~ /'1574'/;
+            delete $pr_hash{$issue->{'number'}.$issue->{repo}};
 		}
 	}
     # warn Dumper @results;


### PR DESCRIPTION
This is kinda hard to test since a PR needs to be merged to test it.  I tested it out my flipping some of the data from the github api to make it look like a pr was merged and it worked fine.

I'll explain the idea since it's difficult to test.
1. First go to our db and get all of the issues marked at being a pr
2. build a hash of pull requests.  pull_request_number+repo => { pull request data }
3. Get the current issues for the repo
4. When we get a new issue from the API we delete it from the pr hash.  The idea being that anything that is still live hasn't been merged/closed
5. If there's anything left in the pr hash at the end of checking the current issues then it has either been merged or closed.  Run the merge_files sub

merge_files sub
1. get detailed data on the issue
2. check if it has a merged_at data
3. get the detailed file info for the pr
4. update code column in our db.

@russellholt @MariagraziaAlastra 
