### PR TITLE
Dev Pipeline - only show issues with the right tag when filtering

### DIFF
--- a/src/ia/js/IADevPipeline.js
+++ b/src/ia/js/IADevPipeline.js
@@ -68,12 +68,19 @@
                     var issue_tag = $(this).attr("id");
 
                     $("#pipeline-live__list .pipeline-live__list__item").hide();
+                    $("#pipeline-live__list .pipeline-live__list__item .list-container--right__issues li").hide();
                     $("#pipeline-live__list .pipeline-live__list__item." + issue_tag).show();
+                    $("#pipeline-live__list .pipeline-live__list__item .list-container--right__issues li").each(function(idx) {
+                        if ($(this).find(".issues_col__tags." + issue_tag).length) {
+                            $(this).show();
+                        }
+                    });
                 } else {
                     $(this).removeClass("icon-check");
                     $(this).addClass("icon-check-empty");
 
                     $("#pipeline-live__list .pipeline-live__list__item").show();
+                    $("#pipeline-live__list .pipeline-live__list__item .list-container--right__issues li").show();
                 }
             });
 


### PR DESCRIPTION
@russellholt 
Previously (notice how Congress and Currency have issues with the "bug" tag, but the other issues are shown as well):
![schermata 2015-04-12 alle 14 33 06](https://cloud.githubusercontent.com/assets/3652195/7105598/0fc1d3cc-e121-11e4-9cad-cbb1f04f14fa.png)

Now (display only relevant issues, hide the ones without the right tag):
![schermata 2015-04-12 alle 14 33 17](https://cloud.githubusercontent.com/assets/3652195/7105599/22b9dbe6-e121-11e4-9600-fa454fc03a7f.png)
