### PR TITLE
Switch order of plain text / html mail parts

### DIFF
--- a/lib/DDGC/Postman.pm
+++ b/lib/DDGC/Postman.pm
@@ -101,17 +101,17 @@ sub html_mail {
 		parts => [
 			Email::MIME->create(
 				attributes => {
-					content_type => 'text/html; charset="UTF-8"',
-					content_transfer_encoding => '8bit',
-				},
-				body => $body,
-			),
-			Email::MIME->create(
-				attributes => {
 					content_type => 'text/plain; charset="UTF-8"',
 					content_transfer_encoding => '8bit',
 				},
 				body => $self->plaintext_formatter->parse($body),
+			),
+			Email::MIME->create(
+				attributes => {
+					content_type => 'text/html; charset="UTF-8"',
+					content_transfer_encoding => '8bit',
+				},
+				body => $body,
 			),
 			map {
 				Email::MIME->create(%{$_});


### PR DESCRIPTION
- text/plain first is what RFC 1521 describes.
- Some HTML capable clients are not rendering HTML part by default with other ordering.