### PR TITLE
Fix for double encoding in blog RSS feed.

### DIFF
--- a/lib/DDGC/Web/ControllerBase/Blog.pm
+++ b/lib/DDGC/Web/ControllerBase/Blog.pm
@@ -58,7 +58,6 @@ sub postlist_rss {
 		],
 	};
 	$c->forward('View::Feed');
-	$c->forward( $c->view('Feed') );
 }
 
 sub index_base :Chained('postlist_base') :PathPart('') :CaptureArgs(0) {

--- a/lib/DDGC/Web/ControllerBase/Blog.pm
+++ b/lib/DDGC/Web/ControllerBase/Blog.pm
@@ -53,8 +53,7 @@ sub postlist_rss {
 				link     => $c->chained_uri(@{$_->u}),
 				title    => $_->title,
 				modified => $_->updated,
-				description => $_->teaser,
-				content => $_->html,
+				content  => $_->html,
 			}} @posts
 		],
 	};

--- a/lib/DDGC/Web/ControllerBase/Blog.pm
+++ b/lib/DDGC/Web/ControllerBase/Blog.pm
@@ -40,6 +40,7 @@ sub postlist_rss {
 	my ( $self, $c ) = @_;
 	$self->postlist_resultset($c);
 	my @posts = $c->stash->{posts_resultset}->all;
+	$c->encoding(undef);
 	$c->stash->{feed} = {
 		format      => 'Atom',
 		id          => 'dukgo.com/'.$c->action,
@@ -57,7 +58,9 @@ sub postlist_rss {
 			}} @posts
 		],
 	};
-	$c->forward('View::Feed');
+	my $atom = $c->forward('View::Feed');
+	$c->response->headers->header('Content-Type' => "application/atom+xml;charset=UTF-8");
+	return $atom;
 }
 
 sub index_base :Chained('postlist_base') :PathPart('') :CaptureArgs(0) {

--- a/lib/DDGC/Web/ControllerBase/Blog.pm
+++ b/lib/DDGC/Web/ControllerBase/Blog.pm
@@ -41,6 +41,7 @@ sub postlist_rss {
 	$self->postlist_resultset($c);
 	my @posts = $c->stash->{posts_resultset}->all;
 	$c->encoding(undef);
+	use DDP; p $posts[0]->user->username;
 	$c->stash->{feed} = {
 		format      => 'Atom',
 		id          => 'dukgo.com/'.$c->action,
@@ -54,6 +55,7 @@ sub postlist_rss {
 				title    => $_->title,
 				modified => $_->updated,
 				content  => $_->html,
+				author   => $_->user->username,
 			}} @posts
 		],
 	};


### PR DESCRIPTION
This explicitly disables body encoding, then sets the encoding in the HTTP header.