### PR TITLE
Gruntfile.js: Compass now compiles SASS files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ local-lib
 *.log
 *.index
 node_modules/*
+.sass-cache
+root/static/css/ddgc.css
+root/static/css/ia.css
+root/static/js/ddgc.js
+root/static/js/ia.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -183,6 +183,10 @@ module.exports = function(grunt) {
          * not used yet
          */
         compass: {
+            options: {
+                sassDir: 'src/ia/css',
+                cssDir: 'src/ddgc/css'
+            },
             dist: {
                 options: {
                     ia: {


### PR DESCRIPTION
Adding a .scss file in `src/ia/css` (this directory could be changed to `src/ia/scss` but we can do that in the future) will now get compiled and minified when we run `grunt`.