### PR TITLE
Dev IA Pages - fix the checkboxes highlighting when saved and remove highlight from a field if it's being modified again

### DIFF
--- a/src/ia/css/ia.css
+++ b/src/ia/css/ia.css
@@ -1261,13 +1261,19 @@ body.texture {
     margin-left: 0;
 }
 
-.not_saved {
+input.not_saved, select.not_saved, .button.not_saved {
     border: 1px solid #DE5833;
+}
+
+.not_saved {
     color: #DE5833;
 }
 
-.saved {
+input.saved, select.saved, .button.saved {
     border: 1px solid #5B9E4D;
+}
+
+.saved {
     color: #5B9E4D;
 }
 

--- a/src/ia/js/IAPage.js
+++ b/src/ia/js/IAPage.js
@@ -279,6 +279,8 @@
                         var is_json = false;
                         var panel = $.trim($(this).attr("data-panel"));
 
+                        resetSaved($(this));
+
                         if ($(this).hasClass("icon-check-empty")) {
                             value = 1;
                             $(this).removeClass("icon-check-empty").addClass("icon-check");
@@ -307,12 +309,28 @@
                         if (!$(this).hasClass("js-autocommit-focused")) {
                             $(this).focus();
                         }
+
+                        resetSaved($(this));
                     });
 
                     $("body").on("focusin", "textarea.js-autocommit, input.js-autocommit", function(evt) {
                         if (!$(this).hasClass("js-autocommit-focused")) {
                             $(this).addClass("js-autocommit-focused");
                         }
+
+                        resetSaved($(this));
+                    });
+
+                    $("body").on("click", "select.js-autocommit", function(evt) {
+                        var $obj;
+
+                        if ($(this).hasClass("topic-group")) {
+                            $obj = $(".js-autocommit.topic");
+                        } else {
+                            $obj = $(this);
+                        }
+                        
+                        resetSaved($obj);
                     });
 
                     $("body").on('change', "select.js-autocommit", function(evt) {
@@ -320,7 +338,7 @@
                         var value;
                         var is_json = false;
                         var panel = $.trim($(this).attr("data-panel"));
-                    
+
                         if ($(this).hasClass("topic-group")) {
                             value = [];
                             var temp;
@@ -660,6 +678,14 @@
                         });
                         
                         return section_vals;
+                    }
+
+                    function resetSaved($obj) {
+                        if ($obj.hasClass("saved")) {
+                            $obj.removeClass("saved");
+                        } else if ($obj.hasClass("not_saved")) {
+                            $obj.removeClass("not_saved");
+                        }
                     }
 
                     function autocommit(field, value, id, is_json, panel) {

--- a/src/templates/development_content.handlebars
+++ b/src/templates/development_content.handlebars
@@ -34,7 +34,7 @@ PERL MODULE
     </span>
 </div>
 <div class="dev_milestone-container__body__div">
-    <i class="design_review dev_milestone-container__body__div__checkbox {{#unless future.development}}{{#if permissions.admin}}js-autocommit{{/if}}{{/unless}} icon-check{{#is_false live.design_review}}-empty{{/is_false}}" id="design_review-check"/>
+    <i data-panel="development" class="design_review dev_milestone-container__body__div__checkbox {{#unless future.development}}{{#if permissions.admin}}js-autocommit{{/if}}{{/unless}} icon-check{{#is_false live.design_review}}-empty{{/is_false}}" id="design_review-check"/>
     <span class="dev_milestone-container__body__readonly check-txt">
         Layout looks good
     </span>


### PR DESCRIPTION
@russellholt Right now, after saving a field, if you modify it again the highlight (green if the new value was saved, red if not) stays on. It should be removed instead, until a new attempt to save that field is performed.

Also, the checkboxes had weird highlighting, so I fixed that as well.
Checkboxes highlighting before:
![screenshot-duck co 2015-05-05 20-38-32](https://cloud.githubusercontent.com/assets/3652195/7480255/b3964764-f367-11e4-9958-5216bde7182f.png)

Checkboxes highlighting after:
![screenshot-maria duckduckgo com 5000 2015-05-05 20-32-36](https://cloud.githubusercontent.com/assets/3652195/7480273/c1a28034-f367-11e4-88a9-b7a46844f79e.png)
