### PR TITLE
Use bower to pull in the other SCSS dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ root/static/css/ia.css
 root/static/js/ddgc.js
 root/static/js/ia.js
 src/templates/handlebars_tmp
-build/*
+build/
+bower_components/

--- a/src/scss/ddgc/main.scss
+++ b/src/scss/ddgc/main.scss
@@ -1,4 +1,4 @@
-@import "../../../node_modules/duckduckgo-colors/_colors";
+@import '../../../bower_components/duckduckgo-colors/_colors';
 @import "_account";
 @import "_ddgc";
 @import "_help";

--- a/src/scss/ia/main.scss
+++ b/src/scss/ia/main.scss
@@ -1,3 +1,3 @@
-@import "../../../node_modules/duckduckgo-colors/_colors";
+@import '../../../bower_components/duckduckgo-colors/_colors';
 @import "_fonts";
 @import "_ia";


### PR DESCRIPTION
Run `sudo npm install && bower install && grunt` to test. You need to install bower first `sudo npm install -g bower`.

I can't add `bower` to `package.json` because it's a cli program, unfortunately, and needs to be installed globally.