### PR TITLE
Gruntfile.js: Modifying .handlebars with grunt watch doesn't work.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -223,7 +223,7 @@ module.exports = function(grunt) {
             },
             templates: {
                 files: ['src/templates/*.handlebars'],
-                tasks: ['concat']
+                tasks: ['handlebars', 'concat']
             },
             scss: {
                 files: ['src/scss/ia/*.scss', 'src/scss/ddgc/*.scss', 'src/scss/content/*.scss'],


### PR DESCRIPTION
This will actually make `grunt watch` compile the Handlebars files.