### PR TITLE
InstantAnswer.pm - get meta_id as id in current_ia

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -876,7 +876,9 @@ sub current_ia {
                 $combined_edits{$edit->field} = $value->{field};
             }
         }
-        else {
+        elsif ($edit->field eq 'meta_id') {
+            $combined_edits{id} = $value->{field};
+        } else {
             $combined_edits{$edit->field} = $value->{field};
         }
     }


### PR DESCRIPTION
@jdorweiler @russellholt Fixes the issue with committing edits for the ID field 