### PR TITLE
Automatically create an IA page from a PR

### DIFF
--- a/lib/DDGC/DB/Result/InstantAnswer.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer.pm
@@ -377,6 +377,11 @@ column created_date => {
     for_endpt => 1
 };
 
+column forum_link => {
+    data_type => 'text',
+    is_nullable => 1
+};
+
 has_many 'issues', 'DDGC::DB::Result::InstantAnswer::Issues', 'instant_answer_id';
 has_many 'blocks', 'DDGC::DB::Result::InstantAnswer::Blocks', 'instant_answer_id';
 has_many 'updates', 'DDGC::DB::Result::InstantAnswer::Updates', 'instant_answer_id';

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -134,7 +134,6 @@ sub getIssues{
                         id => $data->{name},
                         meta_id => $data->{name},
                         name => ucfirst $name,
-                        status => 'development',
                         dev_milestone => 'development',
                         description => $description || '',
                         created_date => $date,

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -46,7 +46,7 @@ map{ $pr_hash{$_->{issue_id}.$_->{repo}} = $_ } @pull_requests;
 sub getIssues{
     foreach my $repo (@repos){
         my @issues = $gh->issue->repos_issues('duckduckgo', $repo, {state => 'open'});
-        
+
         while($gh->issue->has_next_page){
             push(@issues, $gh->issue->next_page)
         }
@@ -82,42 +82,81 @@ sub getIssues{
 			);
 			push(@results, \%entry);
             delete $pr_hash{$issue->{'number'}.$issue->{repo}};
+            
+            my $create_page = sub {
+                my $data = \%entry;
+                return unless $data->{name};
+                my $ia = $d->rs('InstantAnswer')->find($data->{name});
+                return if $ia;
+
+                my @time = localtime(time);
+                my $date = "$time[4]/$time[3]/".($time[5]+1900);
+
+                $data->{body} =~ s/\n|\r//g;
+
+                # try to get a description from the PR text
+                my ($description) = $data->{body} =~ /What does your Instant Answer do\?\*\*(.*?)(?:\*|$)/i;
+                
+                # api documentation
+                my ($api_link) = $data->{body} =~ /What is the data source.*?\*\*.*?(https?:\/\/.*?)?(?:\>|\)|\*|$)/i;
+
+                # api documentation
+                my ($forum_link) = $data->{body} =~ /Is this instant answer connected.*?\*\*.*?(https?:\/\/.*?)?(?:\>|\)|\*|$)/i;
+                
+                # get the file info for the pr
+                $gh->set_default_user_repo('duckduckgo', "zeroclickinfo-$data->{repo}");
+                my $pr = $gh->pull_request->pull($data->{issue_id});
+                my @files_data = $gh->pull_request->files($data->{issue_id});
+
+                my $pm;
+                # look for the perl module
+                for my $file (@files_data){
+                    my $tmp_repo = ucfirst $data->{repo};
+                    $tmp_repo =~ s/s$//g;
+
+                    if(my ($name) = $file->{filename} =~ /lib\/DDG\/$tmp_repo\/(.+)\.pm/i ){
+                        $pm = "DDG::".$tmp_repo."::$name";
+                        last;
+                    }
+                }
+
+                my $developer = [{
+                        name => $data->{author},
+                        type => 'github',
+                        url => "https://github.com/$data->{author}"
+                    }];
+                $developer = to_json $developer;
+
+                $d->rs('InstantAnswer')->create({
+                        id => $data->{name},
+                        meta_id => $data->{name},
+                        name => $data->{name},
+                        status => 'development',
+                        dev_milestone => 'development',
+                        description => $description || '',
+                        created_date => $date,
+                        repo => $data->{repo},
+                        perl_module => $pm,
+                        forum_link => $forum_link,
+                        src_api_documentation => $api_link,
+                        developer => $developer,
+                });
+            };
 
             # check for an existing IA page.  Create one if none are found
-            create_page(\%entry) if $is_pr;
+            try {
+                $d->db->txn_do($create_page) if $is_pr;
+            } catch {
+                print "Update error $_ \n rolling back\n";
+                $d->errorlog("Error updating ghIssues: '$_'...");
+            }
+
 		}
 	}
     # warn Dumper @results;
     # warn Dumper %pr_hash;
 }
 
-sub create_page {
-    my($data) = @_;
-    return unless $data->{name};
-    my $ia = $d->rs('InstantAnswer')->find($data->{name});
-    return if $ia;
-
-    my @time = localtime(time);
-    my $date = "$time[4]/$time[3]/".($time[5]+1900);
-
-    # try to get a description from the PR text
-    my ($description) = $data->{body} =~ /What does your Instant Answer do\?\*\*(.+)\*\*What problem/msi;
-    $description =~ s/\n\r\t\v\f//g;
-
-    # try to find the perl module in file list
-
-
-    $d->rs('InstantAnswer')->create({
-            id => $data->{name},
-            meta_id => $data->{name},
-            name => $data->{name},
-            status => 'development',
-            dev_milestone => 'development',
-            description => $description || '',
-            created_date => $date,
-            repo => $data->{repo}
-    });
-}
 
 # check the status of PRs in $pr_hash.  If they were merged
 # then update the file paths in the db

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -127,10 +127,13 @@ sub getIssues{
                     }];
                 $developer = to_json $developer;
 
+                my $name = $data->{name};
+                $name =~ s/_/ /g;
+                
                 $d->rs('InstantAnswer')->create({
                         id => $data->{name},
                         meta_id => $data->{name},
-                        name => $data->{name},
+                        name => ucfirst $name,
                         status => 'development',
                         dev_milestone => 'development',
                         description => $description || '',

--- a/sql/1.040/forum_link.sql
+++ b/sql/1.040/forum_link.sql
@@ -1,0 +1,3 @@
+BEGIN;
+    ALTER TABLE instant_answer ADD COLUMN forum_link text;
+COMMIT;


### PR DESCRIPTION
This will create a new IA page and automatically try to find the following data
```
id => from the duck.co link
meta_id => from the duck.co link
name => from the duck.co link
status => set to "development"
dev_milestone => set to "development"
description => parsed from comment in PR
created_date => current date
perl_module => from lib/DDG/<repo>/ file if one is found
forum_link => parsed from comment in PR
api_docs => parsed from comment in PR
developer => from github api data
```

I have it set to skip any IA that is already exists so that we don't overwrite any of our current data. 
**To test:** 
`./scripts/ghIssues.pl`
then check the pipeline page.

![selection_056](https://cloud.githubusercontent.com/assets/1882892/7941806/c017bec0-0927-11e5-8c2a-739802f99b2f.png)
![selection_057](https://cloud.githubusercontent.com/assets/1882892/7941814/c9d44ab4-0927-11e5-8b64-249f536a6a5b.png)
![selection_058](https://cloud.githubusercontent.com/assets/1882892/7941815/ce7dacd6-0927-11e5-9955-b1c5f05af209.png)

@MariagraziaAlastra @russellholt 