### PR TITLE
Dev server performance tweak / plack panels option

### DIFF
--- a/script/ddgc_dev_server.psgi
+++ b/script/ddgc_dev_server.psgi
@@ -16,7 +16,7 @@ my $ddgc_home = '/home/' . (getpwuid($<))[0] . '/ddgc';
 builder {
 
     enable 'Debug', panels => [
-        qw/ Environment Response Parameters Timer Memory Session DBITrace CatalystLog /
+        qw/ Environment Response Parameters Timer Session DBITrace CatalystLog /
     ];
 
     mount '/' => DDGC::Web->new->psgi_app;

--- a/script/ddgc_dev_server.psgi
+++ b/script/ddgc_dev_server.psgi
@@ -10,14 +10,17 @@ use FindBin;
 use lib $FindBin::Dir . "/../lib";
 
 use Plack::Builder;
+use Plack::App::File;
 use DDGC::Web;
 my $ddgc_home = '/home/' . (getpwuid($<))[0] . '/ddgc';
 
 builder {
 
-    enable 'Debug', panels => [
-        qw/ Environment Response Parameters Timer Session DBITrace CatalystLog /
-    ];
+    if ( !$ENV{DDGC_NO_DEBUG_PANEL} ) {
+        enable 'Debug', panels => [
+            qw/ Environment Response Parameters Timer Session DBITrace CatalystLog /
+        ];
+    }
 
     mount '/' => DDGC::Web->new->psgi_app;
 

--- a/script/ddgc_dev_server.sh
+++ b/script/ddgc_dev_server.sh
@@ -22,17 +22,21 @@ help() {
     printf "Options:\n\n"
     printf " -p     Specify listen port. Default: 5000\n"
     printf " -m     Use local debug mail server on port 1025\n"
+    printf " -n     No Plack debug panels in rendered output\n"
     printf " -h     Show this text\n\n"
     exit 0;
 }
 
-while getopts "p:mh" o; do
+while getopts "p:mnh" o; do
     case "${o}" in
         p)
             p=${OPTARG}
             ;;
         m)
             m=1
+            ;;
+        n)
+            export DDGC_NO_DEBUG_PANEL=1
             ;;
         h)
             help


### PR DESCRIPTION
So in my experience the "memory" plack panel isn't of real use (the information isn't immediately helpful and is immediately available elsewhere) and it adds a significant performance penalty. This turns it off.

I also added a `-n` option to ddgc_dev_server.sh to not render the plack panels at all - I understand this can interfere with front end work, so you can now disable it without disabling all debug output.

cc @jagtalon @MariagraziaAlastra @jdorweiler 

Thanks!