### PR TITLE
add pr field and dev_milestone to end point

### DIFF
--- a/lib/DDGC/DB/Result/InstantAnswer.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer.pm
@@ -66,7 +66,8 @@ column perl_dependencies => {
 column dev_milestone => {
 	data_type => 'text',
 	is_nullable => 1,
-    pipeline => 1
+    pipeline => 1,
+    for_endpt => 1,
 };
 
 # is the IA live or not live?
@@ -380,6 +381,12 @@ column created_date => {
 column forum_link => {
     data_type => 'text',
     is_nullable => 1
+};
+
+column pr => {
+    data_type => 'text',
+    is_nullable => 1,
+    is_json => 1,
 };
 
 has_many 'issues', 'DDGC::DB::Result::InstantAnswer::Issues', 'instant_answer_id';

--- a/lib/DDGC/DB/Result/InstantAnswer.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer.pm
@@ -383,12 +383,6 @@ column forum_link => {
     is_nullable => 1
 };
 
-column pr => {
-    data_type => 'text',
-    is_nullable => 1,
-    is_json => 1,
-};
-
 has_many 'issues', 'DDGC::DB::Result::InstantAnswer::Issues', 'instant_answer_id';
 has_many 'blocks', 'DDGC::DB::Result::InstantAnswer::Blocks', 'instant_answer_id';
 has_many 'updates', 'DDGC::DB::Result::InstantAnswer::Updates', 'instant_answer_id';

--- a/sql/1.041/pr_field.sql
+++ b/sql/1.041/pr_field.sql
@@ -1,0 +1,3 @@
+BEGIN;
+        ALTER TABLE instant_answer ADD COLUMN pr text;
+COMMIT;

--- a/sql/1.041/pr_field.sql
+++ b/sql/1.041/pr_field.sql
@@ -1,3 +1,0 @@
-BEGIN;
-        ALTER TABLE instant_answer ADD COLUMN pr text;
-COMMIT;


### PR DESCRIPTION
Added dev_milestone to the end point so we can check the status of the IA before trying to run tests on it. 
The pr field seem to be missing too.  
@MariagraziaAlastra @russellholt 