### PR TITLE
IA Dev Page - don't make example query a link when test machine is not set

### DIFF
--- a/src/templates/base_info_content.handlebars
+++ b/src/templates/base_info_content.handlebars
@@ -116,9 +116,13 @@
               <input data-panel="base_info" type="text" class="frm__input example_query dev_milestone-container__body__input js-autocommit" id="example_query-input" value="{{live.example_query}}" />
               {{else}}
               {{#if live.example_query}}
-                <a href="{{#if live.test_machine}}https://{{live.test_machine}}.duckduckgo.com/?q={{encodeURIComponent live.example_query}}{{tab_url live.tab}}{{/if}}" class="dev_milestone-container__body__readonly" id="example_query-a">
-                  {{live.example_query}}
-                </a>
+                {{#if live.test_machine}}
+                    <a href="{{#if live.test_machine}}https://{{live.test_machine}}.duckduckgo.com/?q={{encodeURIComponent live.example_query}}{{tab_url live.tab}}{{/if}}" class="dev_milestone-container__body__readonly" id="example_query-a">
+                    {{live.example_query}}
+                    </a>
+                {{else}}
+                    {{live.example_query}}
+                {{/if}}
               {{else}}
                 none
               {{/if}}


### PR DESCRIPTION
Avoids having a link with no href set.