### PR TITLE
Fix legacy help redirect

### DIFF
--- a/lib/DDGC/Web/Controller/Help.pm
+++ b/lib/DDGC/Web/Controller/Help.pm
@@ -21,7 +21,7 @@ sub base :Chained('/base') :PathPart('help') :CaptureArgs(0) {
 
 sub legacy_redirect :Chained('base') :PathPart('en_US') :Args {
   my ( $self, $c, @args ) = @_;
-  $c->response->redirect('https://duck.co/help/'.join('/',@args));
+  $c->response->redirect('/help/'.join('/',@args));
 }
 
 # sub language :Chained('base') :PathPart('') :CaptureArgs(1) {

--- a/lib/DDGC/Web/Controller/Help.pm
+++ b/lib/DDGC/Web/Controller/Help.pm
@@ -24,6 +24,11 @@ sub legacy_redirect :Chained('base') :PathPart('en_US') :Args {
   $c->response->redirect('/help/'.join('/',@args));
 }
 
+sub old_url_redirect :Chained('base') :PathPart('customer/portal/articles/') :Args {
+  my ( $self, $c, $article ) = @_;
+  $c->response->redirect("/help/$article");
+}
+
 # sub language :Chained('base') :PathPart('') :CaptureArgs(1) {
 #   my ( $self, $c, $locale ) = @_;
 #   my $oldurl_help = $c->d->rs('Help')->search({


### PR DESCRIPTION
This was handled by nginx, but a serious of deprecations in other areas has broken it.

Let's just fix it in the help controller.