### PR TITLE
Activity feed

### DIFF
--- a/lib/DDGC/Config.pm
+++ b/lib/DDGC/Config.pm
@@ -112,6 +112,8 @@ has_conf smtp_ssl => DDGC_SMTP_SSL => 0;
 has_conf smtp_sasl_username => DDGC_SMTP_SASL_USERNAME => undef;
 has_conf smtp_sasl_password => DDGC_SMTP_SASL_PASSWORD => undef;
 
+has_conf shared_secret => DDGC_SHARED_SECRET => undef;
+
 has_conf templatedir => DDGC_TEMPLATEDIR => sub { dir( Catalyst::Utils::home('DDGC'), 'templates' )->resolve->absolute->stringify };
 
 has_conf duckpan_url => DDGC_DUCKPAN_URL => 'http://duckpan.org/';

--- a/lib/DDGC/Schema/Result/ActivityFeed.pm
+++ b/lib/DDGC/Schema/Result/ActivityFeed.pm
@@ -1,0 +1,61 @@
+package DDGC::Schema::Result::ActivityFeed;
+# ABSTRACT: Activity feed reault class
+
+use Moo;
+extends 'DDGC::Schema::Result';
+use DBIx::Class::Candy;
+use DDGC::Util::Markup;
+
+table 'activity_feed';
+
+column id => {
+    data_type => 'bigint',
+    is_auto_increment => 1,
+};
+primary_key 'id';
+
+column created => {
+    data_type => 'timestamp with time zone',
+    set_on_create => 1,
+};
+
+column type => {
+    data_type => 'text',
+    is_nullable => 0,
+};
+
+column description => {
+    data_type => 'text',
+    is_nullable => 0,
+};
+
+column format => {
+    data_type => 'text',
+    default_value => 'markdown',
+};
+
+has renderer => (
+    is => 'ro',
+    lazy => 1,
+    builder => '_build_renderer',
+);
+sub _build_renderer {
+    DDGC::Util::Markup->new;
+}
+
+sub render_description{
+    my ( $self ) = @_;
+    my $format = $self->format || 'markdown';
+    $self->renderer->$format( $self->description );
+}
+
+sub TO_JSON {
+    my ( $self ) = @_;
+    +{
+        id          => $self->id,
+        type        => $self->type,
+        description => $self->render_description
+    }
+}
+
+1;

--- a/lib/DDGC/Schema/Result/ActivityFeed.pm
+++ b/lib/DDGC/Schema/Result/ActivityFeed.pm
@@ -54,7 +54,9 @@ sub TO_JSON {
     +{
         id          => $self->id,
         type        => $self->type,
-        description => $self->render_description
+        created     => $self->created->epoch,
+        description => $self->render_description,
+        raw_description => $self->description,
     }
 }
 

--- a/lib/DDGC/Web/Service/ActivityFeed.pm
+++ b/lib/DDGC/Web/Service/ActivityFeed.pm
@@ -1,0 +1,78 @@
+package DDGC::Web::Service::ActivityFeed;
+
+# ABSTRACT: Community Activity JSON service
+
+=pod
+
+=head1 NAME
+
+DDGC::Web::Service::ActivityFeed - Log / retrieve Community Activity.
+
+=head1 DESCRIPTION
+
+This service logs any activity you care to generate and allows subscription
+to these activities via a key of your choosing.
+
+=head1 MOUNT POINT
+
+This service is expected to be mounted on '/activityfeed.json'
+
+=head1 REQUEST HANDLERS
+
+=cut
+
+use DDGC::Base::Web::Service;
+use Try::Tiny;
+
+sub pagesize { 40 }
+
+sub activity_page {
+    my ( $params ) = @_;
+    $params->{page} //= 1;
+    $params->{pagesize} //= pagesize;
+    rset('ActivityFeed')->search_rs({
+        ( $params->{filter} )
+            ? ( type => { -like => $params->{filter} =~ s/\*/%/gr } )
+            : (),
+    }, {
+        order_by => { -desc => 'me.id' },
+        rows     => $params->{pagesize},
+        page     => $params->{page},
+    });
+}
+
+get '/' => sub {
+    +{
+        activity => [
+            activity_page(params_hmv)->all,
+        ]
+    };
+};
+
+post '/new' => sub {
+    my $params = params_hmv;
+    if ($params->{secret} ne config->{ddgc_config}->shared_secret) {
+        bailout( 401, 'Unauthorized request' );
+    }
+    my $error = 0;
+    my $result;
+
+    try {
+        $result = rset('ActivityFeed')->create({
+            type => $params->{type},
+            description => $params->{description},
+            ( $params->{format} )
+                ? { format => $params->{format} }
+                : (),
+        });
+    } catch {
+        $error = 1;
+    };
+
+    bailout( 500, "Something went wrong" ) if ( $error );
+
+    use DDP; p $result;
+    return { ok => 1, result => $result };
+};
+
+1;

--- a/script/ddgc_dev_server.psgi
+++ b/script/ddgc_dev_server.psgi
@@ -14,6 +14,7 @@ use CHI;
 use DDGC::Web;
 use DDGC::Web::App::Blog;
 use DDGC::Web::Service::Blog;
+use DDGC::Web::Service::ActivityFeed;
 use Plack::App::File;
 use Plack::Session::State::Cookie;
 use Plack::Session::Store::File;
@@ -38,6 +39,7 @@ builder {
     }
     mount '/blog' => DDGC::Web::App::Blog->to_app;
     mount '/blog.json' => DDGC::Web::Service::Blog->to_app;
+    mount '/activityfeed.json' => DDGC::Web::Service::ActivityFeed->to_app;
     mount '/' => DDGC::Web->new->psgi_app;
     mount "/static" => Plack::App::File->new(root => $FindBin::Dir . '/../root/static')->to_app;
     mount "/media" => Plack::App::File->new(root => "$ddgc_home/media" )->to_app;

--- a/script/ddgc_dev_server.sh
+++ b/script/ddgc_dev_server.sh
@@ -6,6 +6,7 @@ LIBDIR=$SCRIPTDIR/../lib
 PORT=5001
 
 [ "$DDGC_UNSUB_KEY" == "" ]          && export DDGC_UNSUB_KEY="asdfasdf"
+[ "$DDGC_SHARED_SECRET" == "" ]      && export DDGC_SHARED_SECRET="asdfasdf"
 [ "$DDGC_COMMENT_RATE_LIMIT" == "" ] && export DDGC_COMMENT_RATE_LIMIT=0
 [ "$DDGC_DB_DSN" == "" ]             && export DDGC_DB_DSN="dbi:Pg:database=ddgc"
 [ "$DDGC_DB_USER" == "" ]            && export DDGC_DB_USER="ddgc"

--- a/sql/1.04x/activity_feed.sql
+++ b/sql/1.04x/activity_feed.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+CREATE TABLE "activity_feed" (
+  "id" serial NOT NULL,
+  "created" timestamp with time zone NOT NULL,
+  "type" text NOT NULL,
+  "description" text NOT NULL,
+  "format" text DEFAULT 'markdown' NOT NULL,
+  PRIMARY KEY ("id")
+);
+
+COMMIT;


### PR DESCRIPTION
Examples:

Default format is markdown. Let's generate some activity.

Where something is:

```
$ curl -H 'Content-Type: application/json' -X POST -d '{"secret":"asdfasdf", "type":"where", "description":"The index is [here](/)"}' http://127.0.0.1:5002/activityfeed.json/new 2>/dev/null | json_xs
{
   "ok" : 1,
   "status" : 200,
   "result" : {
      "created" : 1433931616,
      "raw_description" : "The index is [here](/)",
      "id" : 21,
      "type" : "where",
      "description" : "<p>The index is <a href=\"/\">here</a></p>"
   }
}
```

Where an IA is:

```
$ curl -H 'Content-Type: application/json' -X POST -d '{"secret":"asdfasdf", "type":"where_ia", "description":"The airlines IA is [here](https://duck.co/ia/view/airlines)"}' http://127.0.0.1:5002/activityfeed.json/new 2>/dev/null | json_xs
{
   "ok" : 1,
   "status" : 200,
   "result" : {
      "created" : 1433931648,
      "raw_description" : "The airlines IA is [here](https://duck.co/ia/view/airlines)",
      "id" : 22,
      "type" : "where_ia",
      "description" : "<p>The airlines IA is <a href=\"https://duck.co/ia/view/airlines\">here</a></p>"
   }
}
```

An IA has gone live:

```
$ curl -H 'Content-Type: application/json' -X POST -d '{"secret":"asdfasdf", "type":"live", "description":"[Arqade is LIVE](https://duckduckgo.com/?q=defcon+strategies&ia=qa)"}' http://127.0.0.1:5002/activityfeed.json/new 2>/dev/null | json_xs
{
   "ok" : 1,
   "status" : 200,
   "result" : {
      "created" : 1433931672,
      "raw_description" : "[Arqade is LIVE](https://duckduckgo.com/?q=defcon+strategies&ia=qa)",
      "id" : 23,
      "type" : "live",
      "description" : "<p><a href=\"https://duckduckgo.com/?q=defcon+strategies&amp;ia=qa\">Arqade is LIVE</a></p>"
   }
}
```

All activity:

```
$ curl http://127.0.0.1:5002/activityfeed.json 2>/dev/null | json_xs
{
   "ok" : 1,
   "status" : 200,
   "activity" : [
      {
         "created" : 1433931672,
         "raw_description" : "[Arqade is LIVE](https://duckduckgo.com/?q=defcon+strategies&ia=qa)",
         "id" : 23,
         "type" : "live",
         "description" : "<p><a href=\"https://duckduckgo.com/?q=defcon+strategies&amp;ia=qa\">Arqade is LIVE</a></p>"
      },
      {
         "created" : 1433931648,
         "raw_description" : "The airlines IA is [here](https://duck.co/ia/view/airlines)",
         "id" : 22,
         "type" : "where_ia",
         "description" : "<p>The airlines IA is <a href=\"https://duck.co/ia/view/airlines\">here</a></p>"
      },
      {
         "created" : 1433931616,
         "raw_description" : "The index is [here](/)",
         "id" : 21,
         "type" : "where",
         "description" : "<p>The index is <a href=\"/\">here</a></p>"
      }
   ]
}
```

Filtering:

```
$ curl http://127.0.0.1:5002/activityfeed.json?filter=where 2>/dev/null | json_xs
{
   "ok" : 1,
   "status" : 200,
   "activity" : [
      {
         "created" : 1433931616,
         "raw_description" : "The index is [here](/)",
         "id" : 21,
         "type" : "where",
         "description" : "<p>The index is <a href=\"/\">here</a></p>"
      }
   ]
}
```

```
$ curl http://127.0.0.1:5002/activityfeed.json?filter=where* 2>/dev/null | json_xs
{
   "ok" : 1,
   "status" : 200,
   "activity" : [
      {
         "created" : 1433931648,
         "raw_description" : "The airlines IA is [here](https://duck.co/ia/view/airlines)",
         "id" : 22,
         "type" : "where_ia",
         "description" : "<p>The airlines IA is <a href=\"https://duck.co/ia/view/airlines\">here</a></p>"
      },
      {
         "created" : 1433931616,
         "raw_description" : "The index is [here](/)",
         "id" : 21,
         "type" : "where",
         "description" : "<p>The index is <a href=\"/\">here</a></p>"
      }
   ]
}
```

In lieu of API Keys (which we probably should have for this sort of thing) there is a shared secret used from the environment.