### PR TITLE
Move to using bower when fetching 3rd-party SCSS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ po-files/*
 *.sw*
 *.csv
 local-lib
-*.json
 *.log
 *.index
 node_modules/*

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "duckduckgo-frontend",
+  "version": "0.0.1",
+  "authors": [
+    "Brian <brian@duckduckgo.com>"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "duckduckgo-colors": "*"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
     "node": ">=0.10.0"
   },
   "repository": "duckduckgo/community-platform",
-  "dependencies": {
-    "duckduckgo-colors": "0.0.1"
-  },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-available-tasks": "^0.5.7",

--- a/src/scss/ddgc/main.scss
+++ b/src/scss/ddgc/main.scss
@@ -1,4 +1,4 @@
-@import "../../../node_modules/duckduckgo-colors/_colors";
+@import "../../../bower_components/duckduckgo-colors/_colors";
 @import "_account";
 @import "_ddgc";
 @import "_help";

--- a/src/scss/ia/_vars.scss
+++ b/src/scss/ia/_vars.scss
@@ -34,7 +34,7 @@ $serp-spacing: 10px;
 	Color Palette
 */
 
-@import "../../../node_modules/duckduckgo-colors/_colors";
+@import "../../../bower_components/duckduckgo-colors/_colors";
 
 $divider-gray: $platinum-dark;
 

--- a/src/scss/ia/main.scss
+++ b/src/scss/ia/main.scss
@@ -3,7 +3,7 @@
 @import "compass/css3/transition";
 @import "compass/css3/box-sizing";
 @import "compass/css3/appearance";
-@import "../../../node_modules/duckduckgo-colors/_colors";
+@import "../../../bower_components/duckduckgo-colors/_colors";
 @import "vars";
 @import "mixins";
 @import "buttons";

--- a/src/scss/ia/overview.scss
+++ b/src/scss/ia/overview.scss
@@ -1,4 +1,4 @@
-@import "../../../node_modules/duckduckgo-colors/_colors";
+@import "../../../bower_components/duckduckgo-colors/_colors";
 @import "compass/css3/border-radius";
 @import "compass/css3/text-shadow";
 


### PR DESCRIPTION
Run `sudo npm install && bower install && grunt` to test. You need to install bower first `sudo npm install -g bower`.

I can't add `bower` to `package.json` because it's a cli program, unfortunately, and needs to be installed globally.

For @MariagraziaAlastra 