### PR TITLE
IAPage.js - use getGroupVals() when adding or changing topic, too

### DIFF
--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -338,21 +338,11 @@
                         var $selected = $(this).find("option:selected");
 
                         if ($(this).hasClass("topic-group")) {
-                            value = [];
-                            var temp;
-                            $("select.js-autocommit.topic-group").each(function(idx) {
-                                $selected = $(this).find("option:selected");
-
-                                if ($selected.attr("value").length) {
-                                    temp = $.trim($selected.text());
-                                } else {
-                                    temp = '';
-                                }
-
-                                value.push(temp);
-                            });
-
+                           var $selector = $("select.js-autocommit.topic-group option:selected");
+                           
+                           value = [];
                            field = "topic";
+                           value = getGroupVals(field, $selector);
                            value = JSON.stringify(value);
                            is_json = true;
                         } else {


### PR DESCRIPTION
Prevents empty topic values from being included in the JSON string sent to the endpoint.