### PR TITLE
IA Pages - Overview page should be the starting point: change URLs accordingly

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,8 +31,10 @@ module.exports = function(grunt) {
     var ia_page_js = [
         'DDH.js',
         'Helpers.js',
+        'IADeprecated.js',
         'IADevPipeline.js',
         'IAIndex.js',
+        'IAIssues.js',
         'IAOverview.js',
         'IAPage.js',
         'IAPageCommit.js',

--- a/root/static/css/content.css
+++ b/root/static/css/content.css
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 /* line 1, ../../src/scss/content/_reset.scss */
 html, body, div, span, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,

--- a/src/js/ia/IADeprecated.js
+++ b/src/js/ia/IADeprecated.js
@@ -1,0 +1,41 @@
+(function(env) {
+
+    DDH.IADeprecated = function() {
+        this.init();
+    };
+
+    DDH.IADeprecated.prototype = {
+
+        init: function() {
+            // console.log("IADeprecated init()");
+            var dev_p = this;
+            var url = window.location.pathname.replace(/\/$/, '') + "/json";
+
+            $.getJSON(url, function(data) { 
+                // console.log(window.location.pathname);
+                var ia_deprecated;
+                ia_deprecated = Handlebars.templates.dev_pipeline_deprecated(data.repos);
+                $("#deprecated").html(ia_deprecated);
+            });
+
+            $("#pipeline_toggle-dev").click(function(evt) {
+                if (!$(this).hasClass("disabled")) {
+                    window.location = "/ia/dev/pipeline";
+                }   
+            });
+
+            $("#pipeline_toggle-live").click(function(evt) {
+                if (!$(this).hasClass("disabled")) {
+                    window.location = "/ia/dev/issues";
+                }
+            });
+
+            $("#pipeline_toggle-home").click(function(evt) {
+                if (!$(this).hasClass("disabled")) {
+                    window.location = "/ia/dev";
+                }
+            });
+        }
+    };
+})(DDH);
+ 

--- a/src/js/ia/IADeprecated.js
+++ b/src/js/ia/IADeprecated.js
@@ -17,24 +17,6 @@
                 ia_deprecated = Handlebars.templates.dev_pipeline_deprecated(data.repos);
                 $("#deprecated").html(ia_deprecated);
             });
-
-            $("#pipeline_toggle-dev").click(function(evt) {
-                if (!$(this).hasClass("disabled")) {
-                    window.location = "/ia/dev/pipeline";
-                }   
-            });
-
-            $("#pipeline_toggle-live").click(function(evt) {
-                if (!$(this).hasClass("disabled")) {
-                    window.location = "/ia/dev/issues";
-                }
-            });
-
-            $("#pipeline_toggle-home").click(function(evt) {
-                if (!$(this).hasClass("disabled")) {
-                    window.location = "/ia/dev";
-                }
-            });
         }
     };
 })(DDH);

--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -15,15 +15,7 @@
             $.getJSON(url, function(data) { 
                 // console.log(window.location.pathname);
                 var iadp;
-
-                if (data.hasOwnProperty("dev_milestones")) {
-                    iadp = Handlebars.templates.dev_pipeline(data.dev_milestones);
-                } else if (data.hasOwnProperty("repos")) {
-                    iadp = Handlebars.templates.dev_pipeline_deprecated(data.repos);
-                }else {
-                    iadp = Handlebars.templates.dev_pipeline_live(data);
-                }
-
+                iadp = Handlebars.templates.dev_pipeline(data.dev_milestones);
                 $("#dev_pipeline").html(iadp);
             });
 
@@ -58,32 +50,6 @@
                 }
             });
 
-            $("body").on('click', ".filter-issues__item__checkbox", function(evt) {
-                if ($(this).hasClass("icon-check-empty")) {
-                    $(".icon-check").removeClass("icon-check").addClass("icon-check-empty");
-
-                    $(this).removeClass("icon-check-empty");
-                    $(this).addClass("icon-check");
-
-                    var issue_tag = $(this).attr("id");
-
-                    $("#pipeline-live__list .pipeline-live__list__item").hide();
-                    $("#pipeline-live__list .pipeline-live__list__item .list-container--right__issues li").hide();
-                    $("#pipeline-live__list .pipeline-live__list__item." + issue_tag).show();
-                    $("#pipeline-live__list .pipeline-live__list__item .list-container--right__issues li").each(function(idx) {
-                        if ($(this).find(".issues_col__tags." + issue_tag).length) {
-                            $(this).show();
-                        }
-                    });
-                } else {
-                    $(this).removeClass("icon-check");
-                    $(this).addClass("icon-check-empty");
-
-                    $("#pipeline-live__list .pipeline-live__list__item").show();
-                    $("#pipeline-live__list .pipeline-live__list__item .list-container--right__issues li").show();
-                }
-            });
-
             $("#filter-team_checkbox").click(function(evt) {
                 $(this).toggleClass("icon-check");
                 $(this).toggleClass("icon-check-empty");
@@ -114,21 +80,21 @@
                 }
             });
 
-            $("#pipeline_toggle-dev").click(function(evt) {
+            $("#pipeline_toggle-home").click(function(evt) {
                 if (!$(this).hasClass("disabled")) {
-                    window.location = "/ia/pipeline/dev";
+                    window.location = "/ia/dev";
                 }   
             });
 
             $("#pipeline_toggle-live").click(function(evt) {
                 if (!$(this).hasClass("disabled")) {
-                    window.location = "/ia/pipeline/live";
+                    window.location = "/ia/dev/issues";
                 }
             });
 
             $("#pipeline_toggle-deprecated").click(function(evt) {
                 if (!$(this).hasClass("disabled")) {
-                    window.location = "/ia/pipeline/deprecated";
+                    window.location = "/ia/dev/deprecated";
                 }
             });
         }

--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -79,24 +79,6 @@
                     $(".dev_pipeline-column__list li." + teamrole + "-" + username).show();
                 }
             });
-
-            $("#pipeline_toggle-home").click(function(evt) {
-                if (!$(this).hasClass("disabled")) {
-                    window.location = "/ia/dev";
-                }   
-            });
-
-            $("#pipeline_toggle-live").click(function(evt) {
-                if (!$(this).hasClass("disabled")) {
-                    window.location = "/ia/dev/issues";
-                }
-            });
-
-            $("#pipeline_toggle-deprecated").click(function(evt) {
-                if (!$(this).hasClass("disabled")) {
-                    window.location = "/ia/dev/deprecated";
-                }
-            });
         }
     };
 })(DDH);

--- a/src/js/ia/IAIssues.js
+++ b/src/js/ia/IAIssues.js
@@ -43,24 +43,6 @@
                     $("#pipeline-live__list .pipeline-live__list__item .list-container--right__issues li").show();
                 }
             });
-
-            $("#pipeline_toggle-dev").click(function(evt) {
-                if (!$(this).hasClass("disabled")) {
-                    window.location = "/ia/dev/pipeline";
-                }   
-            });
-
-            $("#pipeline_toggle-deprecated").click(function(evt) {
-                if (!$(this).hasClass("disabled")) {
-                    window.location = "/ia/dev/deprecated";
-                }
-            });
-
-            $("#pipeline_toggle-home").click(function(evt) {
-                if (!$(this).hasClass("disabled")) {
-                    window.location = "/ia/dev";
-                }
-            });
         }
     };
 })(DDH);

--- a/src/js/ia/IAIssues.js
+++ b/src/js/ia/IAIssues.js
@@ -1,0 +1,67 @@
+(function(env) {
+
+    DDH.IAIssues = function() {
+        this.init();
+    };
+
+    DDH.IAIssues.prototype = {
+
+        init: function() {
+            // console.log("IAIssues init()");
+            var dev_p = this;
+            var url = window.location.pathname.replace(/\/$/, '') + "/json";
+
+            $.getJSON(url, function(data) { 
+                // console.log(window.location.pathname);
+                var ia_issues;
+                ia_issues = Handlebars.templates.dev_pipeline_live(data);
+                $("#issues").html(ia_issues);
+            });
+
+            $("body").on('click', ".filter-issues__item__checkbox", function(evt) {
+                if ($(this).hasClass("icon-check-empty")) {
+                    $(".icon-check").removeClass("icon-check").addClass("icon-check-empty");
+
+                    $(this).removeClass("icon-check-empty");
+                    $(this).addClass("icon-check");
+
+                    var issue_tag = $(this).attr("id");
+
+                    $("#pipeline-live__list .pipeline-live__list__item").hide();
+                    $("#pipeline-live__list .pipeline-live__list__item .list-container--right__issues li").hide();
+                    $("#pipeline-live__list .pipeline-live__list__item." + issue_tag).show();
+                    $("#pipeline-live__list .pipeline-live__list__item .list-container--right__issues li").each(function(idx) {
+                        if ($(this).find(".issues_col__tags." + issue_tag).length) {
+                            $(this).show();
+                        }
+                    });
+                } else {
+                    $(this).removeClass("icon-check");
+                    $(this).addClass("icon-check-empty");
+
+                    $("#pipeline-live__list .pipeline-live__list__item").show();
+                    $("#pipeline-live__list .pipeline-live__list__item .list-container--right__issues li").show();
+                }
+            });
+
+            $("#pipeline_toggle-dev").click(function(evt) {
+                if (!$(this).hasClass("disabled")) {
+                    window.location = "/ia/dev/pipeline";
+                }   
+            });
+
+            $("#pipeline_toggle-deprecated").click(function(evt) {
+                if (!$(this).hasClass("disabled")) {
+                    window.location = "/ia/dev/deprecated";
+                }
+            });
+
+            $("#pipeline_toggle-home").click(function(evt) {
+                if (!$(this).hasClass("disabled")) {
+                    window.location = "/ia/dev";
+                }
+            });
+        }
+    };
+})(DDH);
+ 

--- a/src/js/ia/IAOverview.js
+++ b/src/js/ia/IAOverview.js
@@ -17,6 +17,25 @@
 
                 $("#ia-overview").html(template);
             });
+
+            $("#pipeline_toggle-dev").click(function(evt) {
+                if (!$(this).hasClass("disabled")) {
+                    window.location = "/ia/dev/pipeline";
+                }   
+            });
+
+            $("#pipeline_toggle-live").click(function(evt) {
+                if (!$(this).hasClass("disabled")) {
+                    window.location = "/ia/dev/issues";
+                }
+            });
+
+            $("#pipeline_toggle-deprecated").click(function(evt) {
+                if (!$(this).hasClass("disabled")) {
+                    window.location = "/ia/dev/deprecated";
+                }
+            });
+ 
         }
     };
 })(DDH); 

--- a/src/js/ia/IAOverview.js
+++ b/src/js/ia/IAOverview.js
@@ -17,25 +17,6 @@
 
                 $("#ia-overview").html(template);
             });
-
-            $("#pipeline_toggle-dev").click(function(evt) {
-                if (!$(this).hasClass("disabled")) {
-                    window.location = "/ia/dev/pipeline";
-                }   
-            });
-
-            $("#pipeline_toggle-live").click(function(evt) {
-                if (!$(this).hasClass("disabled")) {
-                    window.location = "/ia/dev/issues";
-                }
-            });
-
-            $("#pipeline_toggle-deprecated").click(function(evt) {
-                if (!$(this).hasClass("disabled")) {
-                    window.location = "/ia/dev/deprecated";
-                }
-            });
- 
         }
     };
 })(DDH); 

--- a/src/scss/ia/_dev.scss
+++ b/src/scss/ia/_dev.scss
@@ -42,8 +42,8 @@ textarea[data-panel="base_info"] {
 
 /* This is for the buttons at the top. Since they're black when they're clicked on, the text should be white. */
 
-#toggle-devpage-static.disabled, #toggle-devpage-editable.disabled, #toggle-edited.disabled, #toggle-live.disabled, #pipeline_toggle-dev.disabled, #pipeline_toggle-live.disabled, #pipeline_toggle-deprecated.disabled {
-    color: white;
+.dev-special-permissions__toggle-view__button.disabled, .special-permissions__toggle-view__button.disabled, .pipeline__toggle-view__button.disabled {
+    color: $white;
 }
 
 div[name="topic"].topic {

--- a/src/scss/ia/_ia.scss
+++ b/src/scss/ia/_ia.scss
@@ -1312,10 +1312,7 @@ input.not_saved, select.not_saved, .button.not_saved {
     font-size: 0.8em;
 }
 
-#pipeline_toggle-view,
-#pipeline-live-container {
-    padding-left: 1em;
-}
+#dev_pipeline #pipeline-planning, #deprecated #pipeline-fathead { padding-left: 0; }
 
 #pipeline-live-container {
     width: 70%;

--- a/src/scss/ia/_ia.scss
+++ b/src/scss/ia/_ia.scss
@@ -1269,37 +1269,43 @@ input.not_saved, select.not_saved, .button.not_saved {
     margin-top: 1em;
 }
 
-#dev_pipeline .dev_pipeline-column {
+#dev_pipeline .dev_pipeline-column, #deprecated .dev_pipeline-column {
     width: 21%;
     text-align: left;
     padding: 0 1em;
 }
 
-#dev_pipeline .dev_pipeline-column:not(#pipeline-planning) {
+#dev_pipeline .dev_pipeline-column:not(#pipeline-planning),
+#deprecated .dev_pipeline-column:not(#pipeline-fathead){
     margin-left: 0.5em;
 }
 
-#dev_pipeline .dev_pipeline-column__title {
+#dev_pipeline .dev_pipeline-column__title,
+#deprecated .dev_pipeline-column__title {
     font-weight: 600;
     font-size: 1.87em;
 }
 
-#dev_pipeline .dev_pipeline-column__list li {
+#dev_pipeline .dev_pipeline-column__list li,
+#deprecated .dev_pipeline-column__list li {
     list-style: none;
     padding: 0.3em 0;
     font-size: 1.1em;
     border-bottom: 1px solid #cdcdcd;
 }
 
-#dev_pipeline .dev_pipeline-column__list li a {
+#dev_pipeline .dev_pipeline-column__list li a,
+#deprecated  .dev_pipeline-column__list li a {
     color: #333;
 }
 
-#dev_pipeline .dev_pipeline-column__list li .item-name {
+#dev_pipeline .dev_pipeline-column__list li .item-name,
+#deprecated .dev_pipeline-column__list li .item-name {
     max-width: 9em;
 }
 
-#dev_pipeline .dev_pipeline-column__list .ia-item--stamp {
+#dev_pipeline .dev_pipeline-column__list .ia-item--stamp,
+#deprecated .dev_pipeline-column__list .ia-item--stamp {
     width: 20px;
     height: 20px;
     position: inherit;
@@ -1332,10 +1338,14 @@ input.not_saved, select.not_saved, .button.not_saved {
     box-shadow: none;
 }
 
+#pipeline_toggle-dev {
+    margin-left: 2em;
+    width: 6em;
+}
+
 #pipeline_toggle-live {
-    margin-left: 1em;
     margin-right: 4em;
-    width: 5em;
+    width: 4em;
 }
 
 #pipeline-live-container .list-container--left {

--- a/src/templates/overview.handlebars
+++ b/src/templates/overview.handlebars
@@ -3,7 +3,7 @@
     <h2 class="left">
         <span class="heavy">{{count}}</span> {{@key}} Instant Answers
     </h2>
-        <div class="button btn--primary right"><a href="/ia{{#eq @key 'new'}}/pipeline/dev{{/eq}}">See All</a></div>
+        <div class="button btn--primary right"><a href="/ia{{#eq @key 'new'}}/dev/pipeline{{/eq}}">See All</a></div>
         <span class="clearfix"></span>
         
         <ul class="iap-list">
@@ -36,7 +36,7 @@
 <div id="top-issues">
     <div class="top-issues__title">
         <h2 class="left">Top Issues on GitHub</h2>
-        <div class="button btn--primary right"><a href="/ia/pipeline/live">See All</a></div>
+        <div class="button btn--primary right"><a href="/ia/dev/issues">See All</a></div>
         <span class="clearfix"></span>
     </div>
     <ul class="top-issues__list">

--- a/templates/instantanswer/deprecated.tx
+++ b/templates/instantanswer/deprecated.tx
@@ -1,18 +1,18 @@
 <div class="pipeline__toggle-view" id="pipeline_toggle-view">
     <div class="pager-wrap">
         <span class="button-group  button-group--paging">
-            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-home">
+            <a href="/ia/dev" class="button pipeline__toggle-view__button" id="pipeline_toggle-home">
                 Home
-            </span>
-            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-dev">
+            </a>
+            <a href="/ia/dev/pipeline" class="button pipeline__toggle-view__button" id="pipeline_toggle-dev">
                 Dev Pipeline
-            </span>
-            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-live">
+            </a>
+            <a href="/ia/dev/issues" class="button pipeline__toggle-view__button" id="pipeline_toggle-live">
                 Issues
-            </span>
-            <span class="button pipeline__toggle-view__button  button-nav-current disabled" id="pipeline_toggle-deprecated">
+            </a>
+            <a href="#" class="button pipeline__toggle-view__button  button-nav-current disabled" id="pipeline_toggle-deprecated">
                 Deprecated
-            </span>
+            </a>
         </span>
     </div>
 </div>

--- a/templates/instantanswer/deprecated.tx
+++ b/templates/instantanswer/deprecated.tx
@@ -1,0 +1,21 @@
+<div class="pipeline__toggle-view" id="pipeline_toggle-view">
+    <div class="pager-wrap">
+        <span class="button-group  button-group--paging">
+            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-home">
+                Home
+            </span>
+            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-dev">
+                Dev Pipeline
+            </span>
+            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-live">
+                Issues
+            </span>
+            <span class="button pipeline__toggle-view__button  button-nav-current disabled" id="pipeline_toggle-deprecated">
+                Deprecated
+            </span>
+        </span>
+    </div>
+</div>
+
+<div id="deprecated">
+</div>

--- a/templates/instantanswer/dev_pipeline.tx
+++ b/templates/instantanswer/dev_pipeline.tx
@@ -53,18 +53,18 @@
 <div class="pipeline__toggle-view" id="pipeline_toggle-view">
     <div class="pager-wrap">
         <span class="button-group  button-group--paging">
-            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-home">
+            <a href="/ia/dev" class="button pipeline__toggle-view__button" id="pipeline_toggle-home">
                 Home
-            </span>
-            <span class="button pipeline__toggle-view__button button-nav-current disabled" id="pipeline_toggle-dev">
+            </a>
+            <a href="#" class="button pipeline__toggle-view__button button-nav-current disabled" id="pipeline_toggle-dev">
                 Dev Pipeline
-            </span>
-            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-live">
+            </a>
+            <a href="/ia/dev/issues" class="button pipeline__toggle-view__button" id="pipeline_toggle-live">
                 Issues
-            </span>
-            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-deprecated">
+            </a>
+            <a href="/ia/dev/deprecated" class="button pipeline__toggle-view__button" id="pipeline_toggle-deprecated">
                 Deprecated
-            </span>
+            </a>
         </span>
     </div>
 

--- a/templates/instantanswer/dev_pipeline.tx
+++ b/templates/instantanswer/dev_pipeline.tx
@@ -53,19 +53,22 @@
 <div class="pipeline__toggle-view" id="pipeline_toggle-view">
     <div class="pager-wrap">
         <span class="button-group  button-group--paging">
-            <span class="button pipeline__toggle-view__button <: if $view == 'dev' { :>button-nav-current disabled<: } :>" id="pipeline_toggle-dev">
-                New
+            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-home">
+                Home
             </span>
-            <span class="button pipeline__toggle-view__button <: if $view == 'live' { :>button-nav-current disabled<: } :>" id="pipeline_toggle-live">
-                Live
+            <span class="button pipeline__toggle-view__button button-nav-current disabled" id="pipeline_toggle-dev">
+                Dev Pipeline
             </span>
-            <span class="button pipeline__toggle-view__button <: if $view == 'deprecated' { :>button-nav-current disabled<: } :>" id="pipeline_toggle-deprecated">
+            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-live">
+                Issues
+            </span>
+            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-deprecated">
                 Deprecated
             </span>
         </span>
     </div>
 
-    <: if $view == 'dev' && $logged_in { :>
+    <: if $logged_in { :>
         <div class="filter-team">
             <i class="filter-team__checkbox icon-check-empty" id="filter-team_checkbox"></i>
             <span class="filter-team__span">

--- a/templates/instantanswer/issues.tx
+++ b/templates/instantanswer/issues.tx
@@ -1,0 +1,21 @@
+<div class="pipeline__toggle-view" id="pipeline_toggle-view">
+    <div class="pager-wrap">
+        <span class="button-group  button-group--paging">
+            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-home">
+                Home
+            </span>
+            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-dev">
+                Dev Pipeline
+            </span>
+            <span class="button pipeline__toggle-view__button  button-nav-current disabled" id="pipeline_toggle-live">
+                Issues
+            </span>
+            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-deprecated">
+                Deprecated
+            </span>
+        </span>
+    </div>
+</div>
+
+<div id="issues">
+</div>

--- a/templates/instantanswer/issues.tx
+++ b/templates/instantanswer/issues.tx
@@ -1,18 +1,18 @@
 <div class="pipeline__toggle-view" id="pipeline_toggle-view">
     <div class="pager-wrap">
         <span class="button-group  button-group--paging">
-            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-home">
+            <a href="/ia/dev" class="button pipeline__toggle-view__button" id="pipeline_toggle-home">
                 Home
-            </span>
-            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-dev">
+            </a>
+            <a href="/ia/dev/pipeline" class="button pipeline__toggle-view__button" id="pipeline_toggle-dev">
                 Dev Pipeline
-            </span>
-            <span class="button pipeline__toggle-view__button  button-nav-current disabled" id="pipeline_toggle-live">
+            </a>
+            <a href="#" class="button pipeline__toggle-view__button  button-nav-current disabled" id="pipeline_toggle-live">
                 Issues
-            </span>
-            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-deprecated">
+            </a>
+            <a href="/ia/dev/deprecated" class="button pipeline__toggle-view__button" id="pipeline_toggle-deprecated">
                 Deprecated
-            </span>
+            </a>
         </span>
     </div>
 </div>

--- a/templates/instantanswer/overview.tx
+++ b/templates/instantanswer/overview.tx
@@ -1,18 +1,18 @@
 <div class="pipeline__toggle-view" id="pipeline_toggle-view">
     <div class="pager-wrap">
         <span class="button-group  button-group--paging">
-            <span class="button pipeline__toggle-view__button button-nav-current disabled" id="pipeline_toggle-home">
+            <a href="#" class="button pipeline__toggle-view__button button-nav-current disabled" id="pipeline_toggle-home">
                 Home
-            </span>
-            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-dev">
+            </a>
+            <a href="/ia/dev/pipeline" class="button pipeline__toggle-view__button" id="pipeline_toggle-dev">
                 Dev Pipeline
-            </span>
-            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-live">
+            </a>
+            <a href="/ia/dev/issues" class="button pipeline__toggle-view__button" id="pipeline_toggle-live">
                 Issues
-            </span>
-            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-deprecated">
+            </a>
+            <a href="/ia/dev/deprecated" class="button pipeline__toggle-view__button" id="pipeline_toggle-deprecated">
                 Deprecated
-            </span>
+            </a>
         </span>
     </div>
 </div>

--- a/templates/instantanswer/overview.tx
+++ b/templates/instantanswer/overview.tx
@@ -1,3 +1,22 @@
+<div class="pipeline__toggle-view" id="pipeline_toggle-view">
+    <div class="pager-wrap">
+        <span class="button-group  button-group--paging">
+            <span class="button pipeline__toggle-view__button button-nav-current disabled" id="pipeline_toggle-home">
+                Home
+            </span>
+            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-dev">
+                Dev Pipeline
+            </span>
+            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-live">
+                Issues
+            </span>
+            <span class="button pipeline__toggle-view__button" id="pipeline_toggle-deprecated">
+                Deprecated
+            </span>
+        </span>
+    </div>
+</div>
+
 <h1>IA Pages Overview</h1>
 <div id="ia-overview">
 </div>


### PR DESCRIPTION
@russellholt So, now the URLs are:
* Overview page: ia/dev
  * Dev Pipeline: ia/dev/pipeline
  * Issues: ia/dev/issues
  * Deprecated: ia/dev/deprecated

Index and single pages have the same URLs, as usual. I changed the breadcrumbs accordingly.
Still need to add the toggle button on the Overview page and then I'm done.