### PR TITLE
Deployment hot fixes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -35,8 +35,8 @@ To install community-platform's Perl dependencies, go to its directory and
 run:
 
 ```
-  dzil authordeps --missing | cpanm --mirror http://duckpan.org/
-  dzil listdeps --missing | grep -v abstract | cpanm --mirror http://duckpan.org/
+  dzil authordeps --missing | cpanm
+  dzil listdeps --missing | grep -v abstract | cpanm
 ```
 
 This will take some time. You can add `--notest` to the cpanm command to speed

--- a/lib/DDGC.pm
+++ b/lib/DDGC.pm
@@ -27,10 +27,6 @@ use IPC::Run qw/ run timeout /;
 use POSIX;
 use Cache::FileCache;
 use Cache::NullCache;
-use LWP::Protocol::Net::Curl;
-use if ($ENV{DDGC_PROSODY_USERHOST} ne 'dukgo.com'),
-    'LWP::Protocol::Net::Curl',
-    ssl_verifyhost => 0, ssl_verifypeer => 0;
 use LWP::UserAgent;
 use HTTP::Request;
 use Carp;

--- a/lib/DDGC/Util/Markup.pm
+++ b/lib/DDGC/Util/Markup.pm
@@ -183,13 +183,13 @@ sub html {
 
     if ( $opts->{proxify_images} ) {
         for my $node ( $tree->findnodes('//img') ) {
-            my $src = trim($node->attr('src'));
-            next if $src =~ /^$self->image_proxy_base/;
-            next if $src !~ /^http/i;
-            $node->attr(
-                'src',
-                sprintf($self->image_proxy_url, uri_escape($src))
-            );
+            my $src = lc(trim($node->attr('src')));
+            if (index($src, $self->image_proxy_base) != 0 && index($src, 'http') == 0) {
+                $node->attr(
+                    'src',
+                    sprintf($self->image_proxy_url, uri_escape($src))
+                );
+            }
         }
     }
 

--- a/lib/DDGC/Web/Service/Blog.pm
+++ b/lib/DDGC/Web/Service/Blog.pm
@@ -212,7 +212,7 @@ get '/post' => sub {
     my $v = validate('/blog.json/post', params_hmv );
     if (
         !(scalar $v->errors) &&
-        (my $post = posts_rset
+        (my $post = rset('User::Blog')
             ->prefetch([
                 'user',
                 { comments => 'user' },

--- a/lib/Dancer2/Plugin/DDGC/Request.pm
+++ b/lib/Dancer2/Plugin/DDGC/Request.pm
@@ -5,10 +5,6 @@ package Dancer2::Plugin::DDGC::Request;
 use strict;
 use warnings;
 
-use LWP::Protocol::Net::Curl;
-use if ($ENV{DANCER_ENVIRONMENT} ne 'production'),
-    'LWP::Protocol::Net::Curl',
-    ssl_verifyhost => 0, ssl_verifypeer => 0;
 use LWP::UserAgent;
 use HTTP::Request;
 use JSON;

--- a/lib/Dancer2/Plugin/DDGC/Validate.pm
+++ b/lib/Dancer2/Plugin/DDGC/Validate.pm
@@ -26,6 +26,7 @@ on_plugin_import {
         { optional => 'id', valid => POS_VALUE },
         { optional => 'topics', valid => ANY_VALUE, split => ',' },
         { optional => 'fixed_date', valid => ANY_VALUE },
+        { param    => 'company_blog', valid => POS_ZERO_VALUE },
         { param    => 'raw_html', valid => POS_ZERO_VALUE },
         { param    => 'live', valid => POS_ZERO_VALUE },
         { param    => 'users_id', valid => POS_VALUE },


### PR DESCRIPTION
- Ditch libcurl, HTTPS verification is wonky
- Ditch regex for detecting if image already proxied - not reliable
- Don't filter requests for single posts on company blog / live flags to allow preview
- Add company_blog flag to validator, since its value still exists in db

@malbin If that's not the last of them I'll eat my hat!

(pass the ketchup just in case)