### PR TITLE
IA Index - add ability to filter using URL params

### DIFF
--- a/lib/DDGC.pm
+++ b/lib/DDGC.pm
@@ -402,7 +402,12 @@ sub _build_xslate {
 				$source =~ s/$from/$to/g;
 				return $source;
 			},
-			urify => sub { lc(join('-',split(/\s+/,join(' ',@_)))) },
+			urify => sub {
+                my $value = shift;
+                $value = lc $value;
+                $value =~ s/[^a-zA-Z]+/-/g;
+                return $value;
+            },
 
 			floor => sub { floor($_[0]) },
 			ceil => sub { ceil($_[0]) },

--- a/src/js/ia/IAIndex.js
+++ b/src/js/ia/IAIndex.js
@@ -39,8 +39,6 @@
                 //right_pane_left = $right_pane.offset().left;
                 $dropdown_header = $right_pane.children(".dropdown").children(".dropdown_header");
                 $input_query = $('#filters input[name="query"]');
-
-                ind.filter($list_item, query);
                 
                 var parameters = window.location.search.replace("?", "");
                 parameters = $.trim(parameters.replace(/\/$/, ''));
@@ -53,7 +51,10 @@
                         var value = temp[1];
                         if (field && value && ind.selected_filter.hasOwnProperty(field)) {
                             if (ind.selected_filter.hasOwnProperty(field)) {
-                                $("#ia_" + field + "-" + value).parent().trigger("click");
+                                var selector = "ia_" + field + "-" + value;
+                                selector = (field === 'topic')? "." + selector : "#" + selector;
+                                console.log(selector);
+                                $(selector).parent().trigger("click");
                             } else if ((field === "q") && value) {
                                 $(".filters--search-button").trigger("click");
                             }
@@ -262,7 +263,14 @@
                 $obj.hide();
                 $.each(this.selected_filter, function(key, val) {
                     if (val) {
-                        url += "&" + key + "=" + val.replace(".ia_" + key + "-", "");
+                        if (key === "topic") {
+                            val = val.replace(".", "#");
+                            val = $(val).attr("class").replace("ia_topic-", "");
+                        } else {
+                            val = val.replace(".ia_" + key + "-", "");
+                        }
+                        
+                        url += "&" + key + "=" + val;
                     }
                 });
 
@@ -284,7 +292,7 @@
                 }
             }
 
-            url = url.length? "?" + url : "/ia";
+            url = url.length? "?" + url.replace("#", "") : "/ia";
             
             // Allows changing URL without reloading, since it doesn't add the new URL to history;
             // Not supported on IE8 and IE9.

--- a/src/js/ia/IAIndex.js
+++ b/src/js/ia/IAIndex.js
@@ -51,11 +51,12 @@
                         var temp = parameters[idx].split("=");
                         var field = temp[0];
                         var value = temp[1];
-                        console.log(field);
-                        console.log(value);
                         if (field && value && ind.selected_filter.hasOwnProperty(field)) {
-                            //ind.selected_filter[field] = ".ia_" + field + "-" + value;
-                            $("#ia_" + field + "-" + value).parent().trigger("click");
+                            if (ind.selected_filter.hasOwnProperty(field)) {
+                                $("#ia_" + field + "-" + value).parent().trigger("click");
+                            } else if ((field === "q") && value) {
+                                $(".filters--search-button").trigger("click");
+                            }
                         }
                     });
                 }
@@ -247,17 +248,24 @@
             var topic = this.selected_filter.topic;
             var template = this.selected_filter.template;
             var regex;
+            var url = "";
 
             if (query) {
                 query = query.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
                 regex = new RegExp(query, "gi");
+                url += "&q=" + query;
             }
 
             if (!query && !repo.length && !topic.length && !dev_milestone.length && !template.length) {
                 $obj.show();
             } else {
                 $obj.hide();
-                 
+                $.each(this.selected_filter, function(key, val) {
+                    if (val) {
+                        url += "&" + key + "=" + val.replace(".ia_" + key + "-", "");
+                    }
+                });
+
                 var $children = $obj.children(dev_milestone + repo + topic + template);
                
                 var temp_name;
@@ -275,7 +283,13 @@
                     $children.parent().show();
                 }
             }
- 
+
+            url = url.length? "?" + url : "/ia";
+            
+            // Allows changing URL without reloading, since it doesn't add the new URL to history;
+            // Not supported on IE8 and IE9.
+            history.pushState({}, "Index: Instant Answers", url);
+
             this.count($obj, $("#filter_repo ul li a"), regex, dev_milestone + topic + template);
             this.count($obj, $("#filter_topic ul li a"), regex, dev_milestone + repo + template);
             this.count($obj, $("#filter_template ul li a"), regex, dev_milestone + repo + topic);

--- a/src/js/ia/IAIndex.js
+++ b/src/js/ia/IAIndex.js
@@ -41,7 +41,25 @@
                 $input_query = $('#filters input[name="query"]');
 
                 ind.filter($list_item, query);
-            });
+                
+                var parameters = window.location.search.replace("?", "");
+                parameters = $.trim(parameters.replace(/\/$/, ''));
+                if (parameters) {
+                    parameters = parameters.split("&");
+
+                    $.each(parameters, function(idx) {
+                        var temp = parameters[idx].split("=");
+                        var field = temp[0];
+                        var value = temp[1];
+                        console.log(field);
+                        console.log(value);
+                        if (field && value && ind.selected_filter.hasOwnProperty(field)) {
+                            //ind.selected_filter[field] = ".ia_" + field + "-" + value;
+                            $("#ia_" + field + "-" + value).parent().trigger("click");
+                        }
+                    });
+                }
+           });
 
             $(document).click(function(evt) {
                 if (!$(evt.target).closest(".dropdown").length) {
@@ -228,7 +246,6 @@
             var dev_milestone = this.selected_filter.dev_milestone;
             var topic = this.selected_filter.topic;
             var template = this.selected_filter.template;
-
             var regex;
 
             if (query) {

--- a/templates/instantanswer/index.tx
+++ b/templates/instantanswer/index.tx
@@ -88,7 +88,7 @@
             </li>
             <: for $topic_list -> $topic { :>
                 <li class="row">
-                    <a id="ia_topic-<: $topic.id :>" href="#">
+                    <a id="ia_topic-<: $topic.id :>" class="ia_topic-<: urify($topic.name) :>" href="#">
                         <: $topic.name :>
                     </a>
                 </li>
@@ -145,3 +145,4 @@
 </div>
 
 <span class="clearfix"></span>
+


### PR DESCRIPTION
@russellholt The URLs will be like "/ia?&repo=spice&template=info"; when the page is loaded the final part of the URL path gets splitted and for each field-value pair, if it's valid, a click event is triggered on the corresponding element.
It basically mimics the manual clicks on the filter options in the sidebar.

I just need to change the URL whenever a filter option is clicked, so we easily get a shareable link without the hassle of having to craft it ourselves, and then it's done.