### PR TITLE
Markdown blog posts

### DIFF
--- a/lib/DDGC/DB/Result/Language.pm
+++ b/lib/DDGC/DB/Result/Language.pm
@@ -126,7 +126,6 @@ belongs_to 'parent', 'DDGC::DB::Result::Language', 'parent_id', { join_type => '
 belongs_to 'country', 'DDGC::DB::Result::Country', 'country_id', { join_type => 'left' };
 
 has_many 'user_languages', 'DDGC::DB::Result::User::Language', 'language_id';
-has_many 'user_blogs', 'DDGC::DB::Result::User::Blog', 'language_id';
 has_many 'token_domains', 'DDGC::DB::Result::Token::Domain', 'source_language_id';
 has_many 'token_domain_languages', 'DDGC::DB::Result::Token::Domain::Language', 'language_id';
 has_many 'help_contents', 'DDGC::DB::Result::Help::Content', 'language_id';

--- a/lib/DDGC/DB/Result/User/Blog.pm
+++ b/lib/DDGC/DB/Result/User/Blog.pm
@@ -57,10 +57,10 @@ column company_blog => {
     default_value => 0,
 };
 
-column raw_html => {
-    data_type     => 'int',
+column format => {
+    data_type     => 'varchar(8)',
     is_nullable   => 0,
-    default_value => 0,
+    default_value => 'markdown',
 };
 
 column live => {

--- a/lib/DDGC/DB/Result/User/Blog.pm
+++ b/lib/DDGC/DB/Result/User/Blog.pm
@@ -20,11 +20,6 @@ column users_id => {
     is_nullable => 0,
 };
 
-column translation_of_id => {
-    data_type   => 'bigint',
-    is_nullable => 1,
-};
-
 column title => {
     data_type   => 'text',
     is_nullable => 0,
@@ -74,17 +69,6 @@ column seen_live => {
     data_type     => 'int',
     is_nullable   => 0,
     default_value => 0,
-};
-
-column language_id => {
-    data_type   => 'bigint',
-    is_nullable => 1,
-};
-
-column data => {
-    data_type        => 'text',
-    is_nullable      => 1,
-    serializer_class => 'JSON',
 };
 
 column fixed_date => {

--- a/lib/DDGC/Schema/Result/User/Blog.pm
+++ b/lib/DDGC/Schema/Result/User/Blog.pm
@@ -40,8 +40,8 @@ column teaser => {
 sub html_teaser {
     my ($self) = @_;
     my $markup = DDGC::Util::Markup->new;
-    return $markup->html( $self->teaser ) if $self->raw_html;
-    return $markup->bbcode( $self->teaser );
+    my $format = $self->format;
+    return $markup->$format( $self->teaser );
 }
 
 column content => {
@@ -52,8 +52,8 @@ column content => {
 sub html {
     my ($self) = @_;
     my $markup = DDGC::Util::Markup->new;
-    return $markup->html( $self->content ) if $self->raw_html;
-    return $markup->bbcode( $self->content );
+    my $format = $self->format;
+    return $markup->$format( $self->content );
 }
 
 column topics => {

--- a/lib/DDGC/Schema/Result/User/Blog.pm
+++ b/lib/DDGC/Schema/Result/User/Blog.pm
@@ -74,10 +74,10 @@ column company_blog => {
     default_value => 0,
 };
 
-column raw_html => {
-    data_type     => 'int',
+column format => {
+    data_type     => 'varchar(8)',
     is_nullable   => 0,
-    default_value => 0,
+    default_value => 'markdown',
 };
 
 column live => {
@@ -151,7 +151,7 @@ sub for_edit {
         $self->topics
             ? ( topics => join( ', ', @{ $self->topics } ) )
             : (),
-        raw_html => $self->raw_html,
+        format => $self->format,
         $self->fixed_date
             ? ( fixed_date =>
               DateTime::Format::RSS->new->format_datetime(

--- a/lib/DDGC/Schema/Result/User/Blog.pm
+++ b/lib/DDGC/Schema/Result/User/Blog.pm
@@ -22,11 +22,6 @@ column users_id => {
     is_nullable => 0,
 };
 
-column translation_of_id => {
-    data_type   => 'bigint',
-    is_nullable => 1,
-};
-
 column title => {
     data_type   => 'text',
     is_nullable => 0,
@@ -91,17 +86,6 @@ column seen_live => {
     data_type     => 'int',
     is_nullable   => 0,
     default_value => 0,
-};
-
-column language_id => {
-    data_type   => 'bigint',
-    is_nullable => 1,
-};
-
-column data => {
-    data_type        => 'text',
-    is_nullable      => 1,
-    serializer_class => 'JSON',
 };
 
 column fixed_date => {

--- a/lib/DDGC/Web/Controller/My/Blog.pm
+++ b/lib/DDGC/Web/Controller/My/Blog.pm
@@ -70,11 +70,10 @@ sub edit :Chained('base') :Args(1) {
 
 		my %values;
 
-		for (qw( title uri topics teaser content live fixed_date )) {
+		for (qw( format title uri topics teaser content live fixed_date )) {
 			$values{$_} = $c->req->param($_);
 		}
 
-		$values{raw_html} = $c->req->param('raw_html') ? 1 : 0;
 		$values{company_blog} = 1;
 
 		my $ok = 1;

--- a/lib/Dancer2/Plugin/DDGC/Validate.pm
+++ b/lib/Dancer2/Plugin/DDGC/Validate.pm
@@ -27,7 +27,7 @@ on_plugin_import {
         { optional => 'topics', valid => ANY_VALUE, split => ',' },
         { optional => 'fixed_date', valid => ANY_VALUE },
         { param    => 'company_blog', valid => POS_ZERO_VALUE },
-        { param    => 'raw_html', valid => POS_ZERO_VALUE },
+        { param    => 'format', valid => ENUM_VALUE(qw/ html markdown bbcode /) },
         { param    => 'live', valid => POS_ZERO_VALUE },
         { param    => 'users_id', valid => POS_VALUE },
         { param    => 'uri', valid => ANY_VALUE },

--- a/sql/1.051/00-blog-new-cols.sql
+++ b/sql/1.051/00-blog-new-cols.sql
@@ -1,0 +1,28 @@
+BEGIN;
+
+ALTER TABLE user_blog DROP CONSTRAINT user_blog_fk_language_id;
+
+ALTER TABLE user_blog DROP CONSTRAINT user_blog_fk_translation_of_id;
+
+ALTER TABLE user_blog DROP CONSTRAINT user_blog_fk_users_id;
+
+ALTER TABLE user_blog DROP COLUMN translation_of_id;
+
+ALTER TABLE user_blog DROP COLUMN language_id;
+
+ALTER TABLE user_blog DROP COLUMN data;
+
+ALTER TABLE user_blog ADD COLUMN format varchar(8) DEFAULT 'markdown' NOT NULL;
+
+ALTER TABLE user_blog ADD CONSTRAINT user_blog_fk_users_id FOREIGN KEY (users_id)
+  REFERENCES users (id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+UPDATE user_blog SET format = 'html' WHERE raw_html = 1;
+
+UPDATE user_blog SET format = 'bbcode' WHERE raw_html = 0;
+
+ALTER TABLE user_blog DROP COLUMN raw_html;
+
+COMMIT;
+
+

--- a/templates/my/blog/edit.tx
+++ b/templates/my/blog/edit.tx
@@ -72,10 +72,14 @@
 				<: if $c.user.admin { :>
 					<div class="row">
 						<div class="third">
-							<label for="raw_html">Raw HTML post</label>
+							<label for="format">Format</label>
 						</div>
 						<div class="twothird">
-							<input type="checkbox" name="raw_html" value="1" <: if $post.raw_html { :>checked="checked"<: } :>/>
+							<select name="format">
+								: for [ 'markdown', 'html', 'bbcode' ] -> $format {
+									<option value="<: $format :>" <: if $post.format == $format { :>selected="selected"<: } :>><: $format :></option>
+								: }
+							</select>
 						</div>
 					</div>
 				<: } :>


### PR DESCRIPTION
This allows basic Markdown syntax in blog posts (i.e. if you want highlighted code blocks, you should use HTML for now), using [`Text::Markdown`](https://metacpan.org/pod/Text::Markdown).

@jagtalon @moollaza @russellholt @zekiel 