### PR TITLE
Fix blog sorting

### DIFF
--- a/lib/DDGC/Web/Service/Blog.pm
+++ b/lib/DDGC/Web/Service/Blog.pm
@@ -45,7 +45,7 @@ sub posts_page {
     $params = validate('/blog.json', $params)->values;
 
     my $posts_rset = posts_rset->search_rs({}, {
-        order_by => { -desc => \'concat( me.fixed_date, me.created )' },
+        order_by => { -desc => \'coalesce( me.fixed_date, me.created )' },
         rows     => $params->{pagesize} || pagesize,
         page     => $params->{page} || 1,
     });


### PR DESCRIPTION
coalesce() is a better option than concat() for this type of sort - this fixes sqlite and older postgres support.