### PR TITLE
Perform redirect for hosts that aren't this and ddg

### DIFF
--- a/src/js/ddgc/ddgc.js
+++ b/src/js/ddgc/ddgc.js
@@ -54,7 +54,7 @@ $(document).ready(function() {
 
 	$("a[href^='http']").mousedown(function() {
 		current_hostname = location.hostname;
-		current_hostname.replace(/\./g, '\\.');
+		current_hostname.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
 		hostname_re = new RegExp("^https?:\\/\\/(\\w+\\.)?(duckduckgo\\.com|" + current_hostname + ")");
 		if (this.href.search(hostname_re) === -1) {
 			set_url_to_redirect(this);

--- a/src/js/ddgc/ddgc.js
+++ b/src/js/ddgc/ddgc.js
@@ -54,7 +54,7 @@ $(document).ready(function() {
 
 	$("a[href^='http']").mousedown(function() {
 		current_hostname = location.hostname;
-		current_hostname.replace(/\./, '\\.');
+		current_hostname.replace(/\./g, '\\.');
 		hostname_re = new RegExp("^https?:\\/\\/(\\w+\\.)?(duckduckgo\\.com|" + current_hostname + ")");
 		if (this.href.search(hostname_re) === -1) {
 			set_url_to_redirect(this);

--- a/src/js/ddgc/ddgc.js
+++ b/src/js/ddgc/ddgc.js
@@ -53,7 +53,10 @@ $(document).ready(function() {
 	});
 
 	$("a[href^='http']").mousedown(function() {
-		if (this.href.indexOf(location.hostname) === -1) {
+		current_hostname = location.hostname;
+		current_hostname.replace(/\./, '\\.');
+		hostname_re = new RegExp("^https?:\\/\\/(\\w+\\.)?(duckduckgo\\.com|" + current_hostname + ")");
+		if (this.href.search(hostname_re) === -1) {
 			set_url_to_redirect(this);
 		}
 	});


### PR DESCRIPTION
@bsstoner @andrey-p Many thanks for you feedback in #779 

I think this should be closer to achieving what we want (filter out duckduckgo and $self, where $self is staging, dev or view - dynamic).

Could you also confirm I am right with my string escaping - I think I need to escape the backslashes themselves when building a new re from strings - this is what my REPL tells me anyway:

```
> /^https?:\/\/(\w+\.)?(duckduckgo\.com|duck\.co)/
/^https?:\/\/(\w+\.)?(duckduckgo\.com|duck\.co)/
> new RegExp("^https?:\\/\\/(\\w+\\.)?(duckduckgo\\.com|duck\\.co)")
/^https?:\/\/(\w+\.)?(duckduckgo\.com|duck\.co)/
```

Thanks!