### PR TITLE
Change non-private username to "hidden"

### DIFF
--- a/views/includes/user/username.tx
+++ b/views/includes/user/username.tx
@@ -1,7 +1,7 @@
 <span class='user-name'>
 
 : if $user.username == nil {
-    &lt;nobody&gt;
+    &lt;hidden&gt;
 : } elsif $user.public != 1 {
     : if $vars.user != nil {
         : if $vars.user.admin {


### PR DESCRIPTION
Don't know where "nobody" came from - I think it was a mishandled special case which got ported over to new templates.