### PR TITLE
Object instance leak detection

### DIFF
--- a/script/ddgc_leak_report.pl
+++ b/script/ddgc_leak_report.pl
@@ -1,0 +1,39 @@
+#!/usr/bin/env perl
+
+# Output Devel::Leak::Object counts accumulated in a series of requests
+#
+# You will probably need to update this script to suit your needs,
+# i.e. adding apps to the mounts in builder
+
+use strict;
+use warnings;
+
+use FindBin;
+use lib $FindBin::Dir . "/../lib";
+
+use Plack::Builder;
+use CHI;
+use DDGC::Web;
+use DDGC::Web::App::Blog;
+use DDGC::Web::Service::Blog;
+use HTTP::Request::Common;
+use Plack::Test;
+use Plack::App::File;
+use Plack::Session::State::Cookie;
+use Plack::Session::Store::File;
+
+use Devel::Leak::Object qw{ GLOBAL_bless };
+
+my $iterations = $ARGV[0] // 100;
+my $route = $ARGV[1] // '/';
+
+my $app = builder {
+    mount '/blog' => DDGC::Web::App::Blog->to_app;
+    mount '/blog.json' => DDGC::Web::Service::Blog->to_app;
+    mount '/' => DDGC::Web->new->psgi_app;
+};
+
+test_psgi $app => sub {
+    $_[0]->(GET $route) for (1..$iterations)
+};
+


### PR DESCRIPTION
@nilnilnil @malbin 

This is intended to help track down object instance leaks in a coarse fashion. The idea is you pick a route and do multiple runs against it with different numbers of iterations (GET requests) and compare the numbers:

```
$ script/ddgc_leak_report.pl 1 '/help' 2>&1 | grep -v ^DEP
Tracked objects by class:
        DBD::Pg::DefaultValue                    1
        DBI::var                                 5
        DBIx::Class::Cursor::Cached              1
        DBIx::Class::Storage::DBI::Cursor        1
        Hash::Merge                              2
$ script/ddgc_leak_report.pl 100 '/help' 2>&1 | grep -v ^DEP
Tracked objects by class:
        DBD::Pg::DefaultValue                    1
        DBI::var                                 5
        DBIx::Class::Cursor::Cached              100
        DBIx::Class::Storage::DBI::Cursor        100
        Hash::Merge                              2
```

Excuse the grep - the new applications have erroneous deprecation warnings. Anyway, you can see we are accumulating instances of DBIC Cursor modules in the help controller.