### PR TITLE
Fix apparent DDGC::Util::Markup instantiation leak.

### DIFF
--- a/lib/DDGC/Base/Web/Common.pm
+++ b/lib/DDGC/Base/Web/Common.pm
@@ -15,6 +15,7 @@ use Dancer2::Plugin::Params::HashMultiValue;
 use Dancer2::Plugin::DDGC::Config;
 use Dancer2::Plugin::DDGC::Session;
 use Dancer2::Plugin::DDGC::Request;
+use Dancer2::Plugin::DDGC::Markup;
 use Dancer2::Plugin::DDGC::Validate;
 use Dancer2::Plugin::DDGC::UserRole;
 use Dancer2::Plugin::DDGC::SchemaApp;
@@ -34,6 +35,7 @@ use Dancer2::Plugin::DDGC::SchemaApp;
             Dancer2::Plugin::DDGC::Config
             Dancer2::Plugin::DDGC::Session
             Dancer2::Plugin::DDGC::Request
+            Dancer2::Plugin::DDGC::Markup
             Dancer2::Plugin::DDGC::Validate
             Dancer2::Plugin::DDGC::UserRole
             Dancer2::Plugin::DDGC::SchemaApp

--- a/lib/DDGC/Schema/Result/Comment.pm
+++ b/lib/DDGC/Schema/Result/Comment.pm
@@ -4,7 +4,6 @@ package DDGC::Schema::Result::Comment;
 use Moo;
 extends 'DDGC::Schema::Result';
 use DBIx::Class::Candy;
-use DDGC::Util::Markup;
 use DDGC::Util::DateTime qw/ dur /;
 
 table 'comment';
@@ -79,9 +78,8 @@ belongs_to 'parent',   'DDGC::Schema::Result::Comment', 'parent_id';
 
 sub html {
     my ( $self ) = @_;
-    my $markup = DDGC::Util::Markup->new;
-    return $markup->html( $self->content ) if $self->is_html;
-    return $markup->bbcode( $self->content );
+    return $self->app->markup->html( $self->content ) if $self->is_html;
+    return $self->app->markup->bbcode( $self->content );
 }
 
 sub TO_JSON {

--- a/lib/DDGC/Schema/Result/User/Blog.pm
+++ b/lib/DDGC/Schema/Result/User/Blog.pm
@@ -6,7 +6,6 @@ use Moo;
 extends 'DDGC::Schema::Result';
 use DBIx::Class::Candy;
 use DateTime::Format::RSS;
-use DDGC::Util::Markup;
 use DDGC::Util::DateTime qw/ dur /;
 
 table 'user_blog';
@@ -39,9 +38,8 @@ column teaser => {
 
 sub html_teaser {
     my ($self) = @_;
-    my $markup = DDGC::Util::Markup->new;
     my $format = $self->format;
-    return $markup->$format( $self->teaser );
+    return $self->app->markup->$format( $self->teaser );
 }
 
 column content => {
@@ -51,9 +49,8 @@ column content => {
 
 sub html {
     my ($self) = @_;
-    my $markup = DDGC::Util::Markup->new;
     my $format = $self->format;
-    return $markup->$format( $self->content );
+    return $self->app->markup->$format( $self->content );
 }
 
 column topics => {

--- a/lib/Dancer2/Plugin/DDGC/Markup.pm
+++ b/lib/Dancer2/Plugin/DDGC/Markup.pm
@@ -1,0 +1,61 @@
+package Dancer2::Plugin::DDGC::Markup;
+
+# ABSTRACT: Return a DDGC::Util::Markup instance
+
+use strict;
+use warnings;
+
+use DDGC::Util::Markup;
+use Dancer2::Plugin;
+
+my $markup = DDGC::Util::Markup->new;
+
+register markup => sub { $markup };
+
+register_plugin;
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Dancer2::Plugin::DDGC::Markup - HTML Rendering / Cleaning with Markdown,
+BBCode support
+
+=head1 SYNOPSIS
+
+    use Dancer2;
+    use Dancer2::Plugin::DDGC::Markup;
+
+    my $html = markup->markdown( $markdown_string );
+
+=head1 DESCRIPTION
+
+Dancer2::Plugin::DDGC::Markup provides HTML Rendering for BBCode and
+Markdown content. It can also clean and render existing HTML (i.e.
+run images through 
+
+=head1 FUNCTIONS
+
+=head2 markdown
+
+Returns a DDGC::Util::Markdown instance
+
+=head1 METHODS
+
+Use the method which matches the format of your source string.
+
+=head2 html
+
+=head2 bbcode
+
+=head2 markdown
+
+=head1 SEE ALSO
+
+See L<DDGC::Util::Markup> for more detail.
+
+=cut


### PR DESCRIPTION
@nilnilnil @malbin #784 paying off already.

/blog.json appears to be leaking `DDGC::Util::Markup` instances like crazy. This moves the facility out to the application and makes an instance available via a plugin keyword.

#### Before:

```
$ script/ddgc_leak_report.pl 1 '/blog.json' 2>&1 | grep -v ^DEP
Tracked objects by class:
        DBD::Pg::DefaultValue                    1
        DBI::var                                 5
        DDGC::Util::Markup                       38
        Hash::Merge                              2
$ script/ddgc_leak_report.pl 100 '/blog.json' 2>&1 | grep -v ^DEP                                                                                                                                 
Tracked objects by class:
        DBD::Pg::DefaultValue                    1
        DBI::var                                 5
        DDGC::Util::Markup                       3800
        Hash::Merge                              2
```

#### After:
```
$ script/ddgc_leak_report.pl 1 '/blog.json' 2>&1 | grep -v ^DEP
Tracked objects by class:
        DBD::Pg::DefaultValue                    1
        DBI::var                                 5
        Hash::Merge                              2
You have new mail in /var/mail/ubuntu
$ script/ddgc_leak_report.pl 100 '/blog.json' 2>&1 | grep -v ^DEP                                                                                                                              
Tracked objects by class:
        DBD::Pg::DefaultValue                    1
        DBI::var                                 5
        Hash::Merge                              2
```

Instantiating this for each render request was bad either way.

This may make support for the "Open forum links in new window" user setting awkward later, but that strikes me as a bit of an unfeature anyway - users who want new windows/tabs typically know how to achieve that in their user agent.