### PR TITLE
Fix generated HTML content tag closing

### DIFF
--- a/lib/DDGC/Util/Markup.pm
+++ b/lib/DDGC/Util/Markup.pm
@@ -202,7 +202,15 @@ sub html {
     my $guts = $tree->guts;
 
     if ($guts) {
-        return $guts->as_XML;
+        # as_HTML reliably closes empty tags supplied by BBCode and other
+        # generators, e.g. [b][/b] -> <b></b>
+        # as_XML would return a self-closed tag, <b /> which is interpreted
+        # by renderer as <b>, so we have an open tag hanging.
+        # as_HTML does *not* currently understand non-nested tags (like img,
+        # hr, br) and generates closing tags for these. Only </br> is
+        # actually problematic in our case so we ditch these by hand.
+        # Is this worth it for a fast performing HTML munger?
+        return $guts->as_HTML =~ s{</br>}{}gmr;
     }
     return ' ';
 }


### PR DESCRIPTION
`HTML::TreeBuilder::LibXML::Node::as_XML` doesn't handle empty elements correctly so if, say, some BBCode has empty tags and generates `<b></b>`, `as_XML` will output <b />

`as_HTML` will output the correct opening / closing tags for empty nodes, but will also do the same for tags which don't nest, like `<br>`, `<hr>` and `<img>`, i.e. you'll get `<br></br>`.

Since only `</br>` poses an actual problem in our output, I've filtered these out as a quick fix until other options are explored.