### PR TITLE
IAPage.js: Image proxy should have the parameter f=1

### DIFF
--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -299,7 +299,8 @@
                             url: function() {
                                 var image = Screens.state.isMobile ? 'mobile' : 'index';
                                 return 'https://images.duckduckgo.com/iu/?u=' +
-                                       encodeURIComponent('https://ia-screenshots.s3.amazonaws.com/' + DDH_iaid + '_' + image + '.png?nocache=' + Math.floor(Math.random() * 10000));
+                                       encodeURIComponent('https://ia-screenshots.s3.amazonaws.com/' + DDH_iaid + '_' + image + '.png?nocache=' + Math.floor(Math.random() * 10000)) +
+                                       '&f=1';
                             },
                             createImageEndpoint: 'https://jag.duckduckgo.com/screenshot/create/' + DDH_iaid,
                             saveImageEndpoint: 'https://jag.duckduckgo.com/screenshot/save/' + DDH_iaid


### PR DESCRIPTION
Our image proxy checks if the end of a URL contains .jpg / .gif / .png. Since we don't have that in our URLs (because of the `nocache` parameter), it wasn't serving the images at all.