### PR TITLE
github.handlebars: Fend against missing tags.

### DIFF
--- a/src/scss/ia/_live.scss
+++ b/src/scss/ia/_live.scss
@@ -34,6 +34,10 @@
         margin-right: 1em;
     }
 
+    .tag-grp:last-child {
+        margin-right: 0;
+    }
+
     .btn {
         font-weight: 400;
     }
@@ -269,10 +273,8 @@
          */
         .icon-circle {
             font-size: 9px;
-        }
-
-        .tag-name {
-            vertical-align: middle;
+            position: relative;
+            bottom: 2px;
         }
 
         .ia-single--header {
@@ -298,11 +300,6 @@
 
         .date {
             font-size: smaller;
-            display: block;
-            padding-top: 27px;
-            padding-bottom: 4px;
-            width: 100%;
-            text-align: right;
         }
     }
 

--- a/src/templates/github.handlebars
+++ b/src/templates/github.handlebars
@@ -11,16 +11,18 @@
     <ul class="clear">
       {{#each issues}}
         <li {{#gt @index 4}}class="hide"{{/gt}}>
-          <div class="pull-left twothird sixty--screen-m sixty--screen-s">
+          <div>
             <a class="one-line" href="https://github.com/duckduckgo/zeroclickinfo-{{../repo}}/issues/{{issue_id}}">{{title}} #{{issue_id}}</a>
-            {{#loop_n 3 tags}}
-              <span class="tag-grp">
-                <i class="icon-circle" style="color: #{{color}};" /> <span class="tag-name">{{name}}</span>
-              </span>
-            {{/loop_n}}
-          </div>
-          <div class="third g thirty--screen-m thirty--screen-s">
-            <span class="date one-line pull-right">created {{parse_date date}} by <a class="author" href="https://github.com/{{author}}">{{author}}</a></span>
+            <span class="{{#if tags}}sep--after{{/if}}">
+                {{#loop_n 3 tags}}
+                  <span class="tag-grp">
+                    <i class="icon-circle" style="color: #{{color}};" /> <span class="tag-name">{{name}}</span>
+                  </span>
+                {{/loop_n}}
+            </span>
+            <span>
+                <span class="date">Created {{parse_date date}} by <a class="author" href="https://github.com/{{author}}">{{author}}</a></span>
+            </span>
           </div>
           <span class="clearfix"></span>
         </li>


### PR DESCRIPTION
If there are no tags, position the "created" label somewhere else.

![screen shot 2015-06-29 at 4 23 19 pm](https://cloud.githubusercontent.com/assets/81969/8417522/3554a992-1e7b-11e5-8a42-2d5c0d4d6d49.png)
