### PR TITLE
Deprecate XSlate results() calls

### DIFF
--- a/lib/DDGC.pm
+++ b/lib/DDGC.pm
@@ -369,17 +369,6 @@ sub _build_xslate {
 			# Mark text as raw HTML
 			r => sub { mark_raw(@_) },
 
-			# trick function for DBIx::Class::ResultSet
-			results => sub {
-				my ( $rs, $sorting, $order ) = @_;
-				my @results = $rs->all;
-				$sorting
-					? ( ($order // '') eq 'asc' )
-						? [ sort { $a->$sorting <=> $b->$sorting } @results ]
-						: [ sort { $b->$sorting <=> $a->$sorting } @results ]
-					: [ @results ];
-			},
-
 			# general functions avoiding xslates problems
 			call => sub {
 				my $thing = shift;

--- a/lib/DDGC/DB/Base/ResultSet.pm
+++ b/lib/DDGC/DB/Base/ResultSet.pm
@@ -43,4 +43,8 @@ sub prefetch_context_config {
   return \%prefetch;
 }
 
+sub all_ref {
+  [ $_[0]->all ];
+}
+
 1;

--- a/lib/DDGC/Web/Controller/Admin.pm
+++ b/lib/DDGC/Web/Controller/Admin.pm
@@ -27,11 +27,11 @@ sub base :Chained('/base') :PathPart('admin') :CaptureArgs(0) {
 sub index :Chained('base') :PathPart('') :Args(0) {
     my ( $self, $c ) = @_;
 	$c->bc_index;
-	$c->stash->{latest_updated_users} = $c->d->rs('User')->search({},{
+	$c->stash->{latest_updated_users} = [ $c->d->rs('User')->search({},{
 		order_by => { -desc => 'me.updated' },
 		rows => 5,
 		page => 1,
-	});
+	})->all ];
 	$c->stash->{day_registrations_count} = $c->d->rs('User')->search({
 		created => { ">" => $c->d->db->storage->datetime_parser->format_datetime(
 			DateTime->now - DateTime::Duration->new( days => 1 )

--- a/lib/DDGC/Web/Controller/Admin/Help.pm
+++ b/lib/DDGC/Web/Controller/Admin/Help.pm
@@ -90,10 +90,10 @@ sub index :Chained('base') :PathPart('') :Args(0) {
 		order_by => { -asc => 'me.key' },
 	})->all];
 
-	$c->stash->{helps} = $c->d->rs('Help')->search({},{
+	$c->stash->{helps} = [ $c->d->rs('Help')->search({},{
 		order_by => [ { -asc => 'help_category.sort' }, { -asc => 'me.sort' } ],
 		prefetch => [ 'help_contents', { help_category => [ 'help_category_contents','helps' ] } ],
-	});
+	})->all ];
 
 }
 
@@ -152,9 +152,9 @@ sub categories :Chained('base') :Args(0) {
 		}
 	}
 
-	$c->stash->{categories} = $c->d->rs('Help::Category')->search({},{
+	$c->stash->{categories} = [ $c->d->rs('Help::Category')->search({},{
 		order_by => { -asc => 'me.sort' },
-	});
+	})->all ];
 
 }
 

--- a/lib/DDGC/Web/Controller/Admin/Language.pm
+++ b/lib/DDGC/Web/Controller/Admin/Language.pm
@@ -58,9 +58,9 @@ sub index :Chained('base') :PathPart('') :Args(0) {
 		}
 	}
 
-	$c->stash->{languages} = $c->d->rs('Language')->search({},{
+	$c->stash->{languages} = [ $c->d->rs('Language')->search({},{
 		order_by => { -desc => 'me.updated' },
-	});
+	})->all ];
 
 }
 
@@ -101,9 +101,9 @@ sub countries :Chained('base') :Args(0) {
 		}
 	}
 
-	$c->stash->{countries} = $c->d->rs('Country')->search({},{
+	$c->stash->{countries} = [ $c->d->rs('Country')->search({},{
 		order_by => { -desc => 'me.updated' },
-	});
+	})->all ];
 
 }
 

--- a/lib/DDGC/Web/Controller/Admin/Token.pm
+++ b/lib/DDGC/Web/Controller/Admin/Token.pm
@@ -45,7 +45,7 @@ sub index :Chained('base') :PathPart('') :Args(0) {
 		}
 	}
 
-	$c->stash->{token_domains} = $c->d->rs('Token::Domain')->search({},{
+	$c->stash->{token_domains} = [ $c->d->rs('Token::Domain')->search({},{
 		'+columns' => {
 			token_count => $c->d->rs('Token')->search({
 				'token_domain_id' => { -ident => 'me.id' },
@@ -72,7 +72,7 @@ sub index :Chained('base') :PathPart('') :Args(0) {
 			})->count_rs->as_query,
 		},
 		order_by => { -asc => 'sorting' },
-	});
+	})->all ];
 
 }
 

--- a/lib/DDGC/Web/Controller/Forum.pm
+++ b/lib/DDGC/Web/Controller/Forum.pm
@@ -51,12 +51,12 @@ sub userbase : Chained('base') PathPart('') CaptureArgs(0) {
 
 sub get_sticky_threads {
   my ( $self, $c ) = @_;
-  $c->stash->{sticky_threads} = $c->d->rs('Thread')->search_rs({
+  $c->stash->{sticky_threads} = [ $c->d->rs('Thread')->search_rs({
     sticky => 1,
     forum  => $c->stash->{forum_index} // 1,
   },{
     cache_for => 3600,
-  });
+  })->all ];
 }
 
 sub set_grouped_comments {

--- a/lib/DDGC/Web/Controller/Forum/Admin.pm
+++ b/lib/DDGC/Web/Controller/Forum/Admin.pm
@@ -176,18 +176,18 @@ sub reports : Chained('base') Args(0) {
 
   unless ($c->req->param('json')) {
     if ($c->stash->{show_checked}) {
-      $c->stash->{reports} = $c->d->rs('User::Report')->search_rs({
+      $c->stash->{reports} = [ $c->d->rs('User::Report')->search_rs({
         'me.checked' => { '!=' => undef },
       },{
         order_by => { -desc => 'me.created' },
-      })->prefetch_all;
+      })->prefetch_all->all ];
     } else {
-      $c->stash->{reports} = $c->d->rs('User::Report')->search_rs({
+      $c->stash->{reports} = [ $c->d->rs('User::Report')->search_rs({
         'me.checked' => undef,
         'me.ignore' => $c->stash->{show_ignore},
       },{
         order_by => { -desc => 'me.created' },
-      })->prefetch_all;
+      })->prefetch_all->all ];
     }
   }
 }

--- a/lib/DDGC/Web/Controller/Help.pm
+++ b/lib/DDGC/Web/Controller/Help.pm
@@ -48,7 +48,7 @@ sub search :Chained('base') :Args(0) {
   );
 
   $c->stash->{articles} = $articles;
-  $c->stash->{search_helps} = $articles_rs;
+  $c->stash->{search_helps} = [ $articles_rs->all ];
   $c->stash->{title} = 'Search help pages';
 }
 
@@ -73,6 +73,7 @@ sub category_base :Chained('base') :PathPart('') :CaptureArgs(1) {
     return $c->detach;
   }
   $c->stash->{help_category_content} = $c->stash->{help_category}->content_by_language_id_cached($c->stash->{help_language_id});
+  $c->stash->{help_category_helps} = [ $c->stash->{help_category}->helps->all ];
   $c->add_bc($c->stash->{help_category_content}->title, $c->chained_uri('Help','category',$c->stash->{help_category}->key));
   $c->stash->{title} = $c->stash->{help_category_content}->title;
 }
@@ -94,6 +95,7 @@ sub help_base :Chained('category_base') :PathPart('') :CaptureArgs(1) {
 		$c->response->redirect($c->chained_uri('Help','index',{ help_notfound => 1 }));
 		return $c->detach;
 	}
+  $c->stash->{help_related_helps} = [ $c->stash->{help}->related_helps->all ];
   $c->stash->{help_content} = $c->stash->{help}->search_related('help_contents',{
     language_id => $c->stash->{help_language}->id
   },{

--- a/lib/DDGC/Web/Controller/Help.pm
+++ b/lib/DDGC/Web/Controller/Help.pm
@@ -9,11 +9,11 @@ BEGIN {extends 'Catalyst::Controller'; }
 sub base :Chained('/base') :PathPart('help') :CaptureArgs(0) {
   my ( $self, $c ) = @_;
   $c->stash->{page_class} = "page-help  texture-ducksymbol";
-  $c->stash->{help_categories} = $c->d->rs('Help::Category')->search({},{
+  $c->stash->{help_categories} = [ $c->d->rs('Help::Category')->search({},{
     order_by => { -asc => 'me.sort' },
     prefetch => [ 'help_category_contents', { helps => 'help_contents' } ],
     cache_for => 600,
-  });
+  })->all ];
   $c->stash->{title} = 'Help pages';
   $c->stash->{help_language} = $c->d->rs('Language')->search({ locale => 'en_US' })->first;
   $c->stash->{help_language_id} = $c->stash->{help_language}->id;

--- a/lib/DDGC/Web/Controller/Help.pm
+++ b/lib/DDGC/Web/Controller/Help.pm
@@ -29,30 +29,6 @@ sub old_url_redirect :Chained('base') :PathPart('customer/portal/articles/') :Ar
   $c->response->redirect("/help/$article");
 }
 
-# sub language :Chained('base') :PathPart('') :CaptureArgs(1) {
-#   my ( $self, $c, $locale ) = @_;
-#   my $oldurl_help = $c->d->rs('Help')->search({
-#     old_url => { -like => 'http://help.dukgo.com/customer/portal/articles/'.$locale.'%' }
-#   },{
-#     cache_for => 86400,
-#   })->first;
-#   if ($oldurl_help) {
-#     $c->response->redirect($c->chained_uri('Help','help','en_US',$oldurl_help->help_category->key,$oldurl_help->key));
-#     return $c->detach;
-#   }
-#   unless ($locale eq 'en_US') {
-#     $c->response->redirect($c->chained_uri('Root','index',{ help_language_notfound => 1 }));
-#     return $c->detach;
-#   }
-#   $c->stash->{help_language} = $c->d->rs('Language')->search({ locale => $locale })->first;
-#   if (!$c->stash->{help_language}) {
-#     $c->response->redirect($c->chained_uri('Root','index',{ help_language_notfound => 1 }));
-#     return $c->detach;
-#   }
-#   $c->add_bc('Help articles', $c->chained_uri('Help','index',$locale));
-#   $c->stash->{help_language_id} = $c->stash->{help_language}->id;
-# }
-
 sub index :Chained('base') :PathPart('') :Args(0) {
   my ( $self, $c ) = @_;
   $c->bc_index;

--- a/lib/DDGC/Web/Controller/Ideas.pm
+++ b/lib/DDGC/Web/Controller/Ideas.pm
@@ -25,13 +25,13 @@ sub base :Chained('/base') :PathPart('ideas') :CaptureArgs(0) {
 
 sub add_latest_ideas {
 	my ( $self, $c ) = @_;
-	$c->stash->{latest_ideas} = $c->d->rs('Idea')->ghostbusted->search_rs({
+	$c->stash->{latest_ideas} = [ $c->d->rs('Idea')->ghostbusted->search_rs({
 			migrated_to_thread => undef,
 		},{
 		order_by => { -desc => 'me.created' },
 		rows => 5,
 		page => 1,
-	});
+	})->all ];
 }
 
 sub add_ideas_table {

--- a/lib/DDGC/Web/Controller/My/Notifications.pm
+++ b/lib/DDGC/Web/Controller/My/Notifications.pm
@@ -58,11 +58,11 @@ sub following :Chained('base') :Args(0) {
 	my ( $self, $c ) = @_;
 	$c->add_bc('Following');
 	$c->pager_init($c->action,'30');
-	$c->stash->{user_notification_matrixes} = $c->user->search_related('user_notification_matrixes',{
+	$c->stash->{user_notification_matrixes} = [ $c->user->search_related('user_notification_matrixes',{
 		'me.context_id' => { '!=' => undef },
 	},{
 		order_by => { -desc => 'me.created' },
-	})->prefetch_all->paging($c->stash->{page},$c->stash->{pagesize});
+	})->prefetch_all->paging($c->stash->{page},$c->stash->{pagesize}) -> all ];
 }
 
 sub all_done :Chained('base') :Args(0) {

--- a/lib/DDGC/Web/Controller/My/Notifications.pm
+++ b/lib/DDGC/Web/Controller/My/Notifications.pm
@@ -28,7 +28,7 @@ sub index :Chained('base') :PathPart('') :Args(0) {
 	}
 	my $limit = $c->req->param('all') && $c->user->admin
 		? undef : 40;
-	$c->stash->{undone_notifications} = $c->user->undone_notifications($limit);
+	$c->stash->{undone_notifications} = [ $c->user->undone_notifications($limit)->all ];
 	$c->stash->{undone_notifications_count} = $c->user->undone_notifications_count;
 	$c->bc_index;
 }

--- a/lib/DDGC/Web/Controller/Translate.pm
+++ b/lib/DDGC/Web/Controller/Translate.pm
@@ -31,7 +31,7 @@ sub base :Chained('/base') :PathPart('translate') :CaptureArgs(0) {
 sub index :Chained('base') :PathPart('') :Args(0) {
     my ( $self, $c ) = @_;
 	$c->stash->{headline_template} = 'headline/translate.tt';
-	$c->stash->{token_domains} = $c->d->rs('Token::Domain')->search({
+	$c->stash->{token_domains} = [ $c->d->rs('Token::Domain')->search({
 			active => 1,
 		},{
 		'+columns' => {
@@ -42,7 +42,7 @@ sub index :Chained('base') :PathPart('') :Args(0) {
 			})->count_rs->as_query,
 		},
 		cache_for => 300,
-	});
+	})->all ];
 	$c->bc_index;
 }
 

--- a/lib/DDGC/Web/Controller/Translate/Notes.pm
+++ b/lib/DDGC/Web/Controller/Translate/Notes.pm
@@ -28,12 +28,12 @@ sub base :Chained('/translate/base') :PathPart('notes') :CaptureArgs(0) {
 sub index :Chained('base') :PathPart('') :Args(0) {
 	my ( $self, $c ) = @_;
 	$c->bc_index;
-	$c->stash->{token_domains} = $c->d->resultset('Token::Domain')->search({
+	$c->stash->{token_domains} = [ $c->d->resultset('Token::Domain')->search({
 		'tokens.notes' => [ undef, "" ],
 	},{
 		prefetch => [qw( tokens )],
 		order_by => [ qw( tokens.msgid )],
-	});
+	})->all ];
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/DDGC/Web/Role/ScreenshotForm.pm
+++ b/lib/DDGC/Web/Role/ScreenshotForm.pm
@@ -16,9 +16,9 @@ sub screenshot_form {
 		@screenshot_ids = $c->stash->{thread}->sorted_screenshots->ids;
 		$c->session->{forms}->{$c->stash->{form_id}}->{screenshots} = [@screenshot_ids];
 	}
-	$c->stash->{screenshots} = $c->d->rs('Screenshot')->search({
+	$c->stash->{screenshots} = [ $c->d->rs('Screenshot')->search({
 		id => { -in => [@screenshot_ids] },
-	});
+	})->all ];
 }
 
 sub screenshot_ids {

--- a/templates/admin/help/categories.tx
+++ b/templates/admin/help/categories.tx
@@ -1,7 +1,7 @@
 <: include admin::help::menu :>
 <h2>Help Categories</h2>
 <hr/>
-<: for results($categories) -> $category { :>
+<: for $categories -> $category { :>
   <form method="POST" action="<: $u('Admin::Help','categories') :>">
     <div class="content-box content-box-toggleclick only">
       <div id="help_<: $category.id :>_clicker" class="head">

--- a/templates/admin/help/index.tx
+++ b/templates/admin/help/index.tx
@@ -2,7 +2,7 @@
 <h2>Help Articles</h2>
 <hr/>
 
-<: for results($helps) -> $help { :>
+<: for $helps -> $help { :>
   <form method="POST" action="<: $u('Admin::Help','index') :>">
     <div class="content-box content-box-toggleclick only">
       <div id="help_<: $help.id :>_clicker" class="head">

--- a/templates/admin/index.tx
+++ b/templates/admin/index.tx
@@ -9,7 +9,7 @@
 		<div class="g twothirds">
 			<h3 class="mg-top--small">User management</h3>
 			<p>Latest updates:
-				<: for results($latest_updated_users) -> $user { :>
+				<: for $latest_updated_users -> $user { :>
 					<a href="<: $u('Admin::User','user',$user.username) :>">
 						<: $user.username :>
 					</a>

--- a/templates/admin/language/countries.tx
+++ b/templates/admin/language/countries.tx
@@ -1,5 +1,5 @@
 <: include admin::language::menu :>
-<: for results($countries) -> $country { :>
+<: for $countries -> $country { :>
   <form method="POST" action="<: $u('Admin::Language','countries') :>">
     <div class="content-box content-box-toggleclick only">
       <div id="country_<: $country.id :>_clicker" class="head">

--- a/templates/admin/language/index.tx
+++ b/templates/admin/language/index.tx
@@ -1,5 +1,5 @@
 <: include admin::language::menu :>
-<: for results($languages) -> $language { :>
+<: for $languages -> $language { :>
 	<form method="POST" action="<: $u('Admin::Language','index') :>">
 		<div class="content-box content-box-toggleclick only">
 			<div id="language_<: $language.id :>_clicker" class="head">

--- a/templates/admin/token/index.tx
+++ b/templates/admin/token/index.tx
@@ -1,4 +1,4 @@
-<: for results($token_domains) -> $token_domain { :>
+<: for $token_domains -> $token_domain { :>
 	<form method="POST" action="<: $u('Admin::Token','index') :>">
 		<div class="content-box content-box-toggleclick only">
 			<div id="token_domain_<: $token_domain.id :>_clicker" class="head">

--- a/templates/forum/admin/reports.tx
+++ b/templates/forum/admin/reports.tx
@@ -21,7 +21,7 @@
     <: } :>
   </div>
   <div class="body">
-    <: for results($reports) -> $report { :>
+    <: for $reports -> $report { :>
       <div class="report  row">
         <div class="row">
           <: i($report) :>

--- a/templates/forum/sidebar.tx
+++ b/templates/forum/sidebar.tx
@@ -20,7 +20,7 @@
 		<section class="menu-list">
 			<h5>Sticky threads</h5>
 			<ul>
-				<: for results($sticky_threads) -> $thread { :>
+				<: for $sticky_threads -> $thread { :>
 					<li><a href="<: $u($thread.u) :>"><: $thread.title :></a></li>
 				<: } else { :>
 					Nothing here yet!

--- a/templates/help/category.tx
+++ b/templates/help/category.tx
@@ -11,7 +11,7 @@
 
 <div class="twothird  block-mid  mg-bottom--big">
 		
-  <: for results($help_category.helps) -> $help { :>	
+  <: for $help_category_helps -> $help { :>	
 	<a class="linkbox  linkbox--category" href="<: $u('Help','help',$help_category.key,$help.key) :>">
 		<i class="linkbox__icon  icon-question-sign"></i>
 		<div class="linkbox__body">

--- a/templates/help/help.tx
+++ b/templates/help/help.tx
@@ -30,7 +30,7 @@
 			  <h5><strong>Related Help Articles</strong></h5>
 			</div>
 			<div class="body">
-			  <: for results($help.related_helps) -> $related_help { :>
+			  <: for $help_related_helps -> $related_help { :>
 				<div class="row">
 				  <a href="<: $u('Help','help',$related_help.category.key,$related_help.key) :>" class="fill">
 					<: $related_help.content_by_language_id($help_language_id).title :>
@@ -42,7 +42,7 @@
 		<: } :>		
 		<a href="javascript:" class="button  hide  palm-block  js-palm-toggle"><i class="icon  icon-list-ul"></i> Show More Links</a>
 		<ul class="nav  nav--panels  palm-hide">
-		  <: for results($help_categories) -> $category { :>
+		  <: for $help_categories -> $category { :>
 			<li class="nav-item <: if $category.key == $help_category.key { :> nav-item--active<:}:>">
 			  <: if $category.key != $help_category.key { :>
 				<a href="<: $u('Help','category',$category.key) :>" class="nav-item__title  nav-item__link  js-toggle-sibling  is-exclusive"><: $category.content_by_language_id($help_language_id).title :></a>
@@ -50,7 +50,7 @@
 				<span class="nav-item__title  js-toggle-sibling  is-exclusive"><: $category.content_by_language_id($help_language_id).title :></span>
 			  <: } :>
 				<ul class="nav  nav--sub <: if $category.key == $help_category.key { :> is-open <: } else {:> is-closed <:}:>">
-					<: for results($category.helps) -> $help_nav { :>
+					<: for $category.helps.all_ref -> $help_nav { :>
 					  <li class="sub-item <: if $help_nav.key == $help.key { :> sub-item--active<:}:>">
 						<: if $help_nav.key == $help.key { :>
 						  <span class="sub-item__title"><: $help_nav.content_by_language_id($help_language_id).title :></span>

--- a/templates/help/index.tx
+++ b/templates/help/index.tx
@@ -6,7 +6,7 @@
 </div>
 
 <div class="gw  mg-bottom--big">
-  <: for results($help_categories) -> $category { :>    
+  <: for $help_categories -> $category { :>
 	<div class="g half">	  
 		<a class="linkbox  linkbox--category" href="<: $u('Help','category',$category.key) :>">
 			<i class="linkbox__icon  icon-question-sign"></i>

--- a/templates/help/search.tx
+++ b/templates/help/search.tx
@@ -9,8 +9,8 @@
 </div>
 <div class="help-search-results  twothird  block-mid">
 <: if $help_search { :>
-  <: if $search_helps.count { :>    
-      <: for results($search_helps) -> $help { :>        
+  <: if $search_helps { :>
+      <: for $search_helps -> $help { :>
 		<a class="linkbox  linkbox--result" href="<: $u('Help','help',$help.help_category.key,$help.key) :>">
 			<i class="linkbox__icon  icon-file-alt"></i>
 			<div class="linkbox__body">

--- a/templates/i/comment/thread.tx
+++ b/templates/i/comment/thread.tx
@@ -58,7 +58,7 @@
 <: if $_.get_context_obj.sorted_screenshots.count { # added .count to ensure there's at least 1 :>
 	<h6 class="uploaded--title"><em>Attached Files: <: $_.get_context_obj.sorted_screenshots.count :></em></h6>
 	<div class="uploaded">
-	<: for results($_.get_context_obj.sorted_screenshots) -> $screenshot { :>
+	<: for $_.get_context_obj.sorted_screenshots.all_ref -> $screenshot { :>
 		<:# loop through the thumbs for each item :>		
 		<a class="uploaded__link" href="<: $screenshot.media.url :>" target="ddgc_screenshot" data-reveal-id="img-<: $screenshot.media.id:>" data-animation="popDown" data-lazyload="true">
 			<img src="<: $screenshot.media.url_thumbnail :>" title="<: $screenshot.media.upload_filename :>" alt="<: $screenshot.media.upload_filename :>" class="uploaded__thumb">
@@ -67,7 +67,7 @@
 		</a>
 	<: } :>
 	</div>
-	<: for results($_.get_context_obj.sorted_screenshots) -> $screenshot { :>
+	<: for $_.get_context_obj.sorted_screenshots.all_ref -> $screenshot { :>
 		<:# create a modal for each item :>
 		<img id="img-<: $screenshot.media.id:>" src="/static/img/spinner.gif" data-src="<: $screenshot.media.url :>" alt="<: $screenshot.media.upload_filename :> - Full" class="reveal-modal reveal-modal--img" />
 	<: } :>

--- a/templates/i/comment/view.tx
+++ b/templates/i/comment/view.tx
@@ -66,7 +66,7 @@
 		</div>
 		<: if $children_count { :>
 			<: if !$no_kids { :>
-				<: for results($_.children,'updated','asc') -> $child { :>
+				<: for $_.children.order_by({ -asc => 'me.updated' }).all_ref -> $child { :>
 					<: i($child,'view', {tier => $tier_level+1}) :>				
 				<: } :>
 			<: } :>

--- a/templates/i/comment_rs/forum.tx
+++ b/templates/i/comment_rs/forum.tx
@@ -12,7 +12,7 @@
 	</div>
   </div>
   <div class="body  body--round">
-    <: for results($_) -> $comment { :>
+    <: for $_.all_ref -> $comment { :>
       <: my $context_obj = $comment.get_context_obj :>
       <: my $reply_count = $comment.comments_count :>
       <: # my $children_count = $context_obj.comment.children.count :>

--- a/templates/i/comment_rs/view.tx
+++ b/templates/i/comment_rs/view.tx
@@ -9,7 +9,7 @@
   <div class="notice alert warning"><i class="icn icon-warning-sign"></i> You must be logged in to comment. Please, <a href="<: $u('My','login') :>" data-reveal-id="login-box">Log in</a> or <a href="<: $u('My','register') :>">Register</a>.</div>
 <: } :>
 <: if $_.count { :>	
-	<: for results($_,'updated','asc') -> $comment { :>
+	<: for $_.order_by({ -asc => 'me.updated' }).all_ref -> $comment { :>
 		<: i($comment,'view', { userpic_size => 48 }) :>
 	<: } :>	
 <: } :>

--- a/templates/i/duckpan_release/teaser.tx
+++ b/templates/i/duckpan_release/teaser.tx
@@ -12,7 +12,7 @@
 	</div>
 	<div class="body">
 		<div class="row">
-			<: for results($_.duckpan_modules) -> $duckpan_module { :>
+			<: for $_.duckpan_modules.all_ref -> $duckpan_module { :>
 				<: $duckpan_module.name :>
 				<: if !$~duckpan_module.is_last { :>&nbsp;|&nbsp;<: } :>
 			<: } :>

--- a/templates/i/duckpan_release/view.tx
+++ b/templates/i/duckpan_release/view.tx
@@ -11,7 +11,7 @@
     </h2>
   </div>
   <div class="body">
-    <: for results($_.duckpan_modules) -> $duckpan_module { :>
+    <: for $_.duckpan_modules.all_ref -> $duckpan_module { :>
       <: if $~duckpan_module % 2 == 0 { :>
         <div class="row">
       <: } :>

--- a/templates/i/event_notification_group/email_comments.tx
+++ b/templates/i/event_notification_group/email_comments.tx
@@ -1,5 +1,5 @@
 <div <: style("quote") :>>
-<: for results($_.event_notifications) -> $event_notification { :>
+<: for $_.event_notifications.rs_all -> $event_notification { :>
 	<:- i($event_notification.event.get_context_obj,'view',{
     no_kids => 1, no_reply => 1, no_userpic => 1,
   }) -:>

--- a/templates/i/event_notification_group/moderations/email.tx
+++ b/templates/i/event_notification_group/moderations/email.tx
@@ -1,4 +1,4 @@
-<: for results($_.event_notifications) -> $event_notification { :>
+<: for $_.event_notifications.all_ref -> $event_notification { :>
   <div <: style("quote") :>>
     <: i($event_notification.event.user,'name') :> produced ghosted content <: i($event_notification.event.get_context_obj) :>
     <hr <: style("hr") :>>

--- a/templates/i/event_notification_group/reports/email.tx
+++ b/templates/i/event_notification_group/reports/email.tx
@@ -1,4 +1,4 @@
-<: for results($_.event_notifications) -> $event_notification { :>
+<: for $_.event_notifications.rs_all -> $event_notification { :>
   <div <: style("quote") :>>
     <: i($event_notification.event.get_context_obj) :>
     <hr <: style("hr") :>>

--- a/templates/i/event_notification_group/tokens/email.tx
+++ b/templates/i/event_notification_group/tokens/email.tx
@@ -1,5 +1,5 @@
 <div  <: style("quote") :>>
-<: for results($_.event_notifications) -> $event_notification { :>
+<: for $_.event_notifications.all_ref -> $event_notification { :>
   <: i('msgctxtid',$event_notification.event.get_context_obj) :>
   <: if !$~event_notification.is_last { :><hr <: style("hr") :>><: } :>
 <: } :>

--- a/templates/i/github_user/repos.tx
+++ b/templates/i/github_user/repos.tx
@@ -18,7 +18,7 @@
         <: if !$repos || !$repos.count { :>
             <div class="notice contrast">You have no DuckDuckGo repos! Get forking!</div>
         <: } else { :>
-            <: for results($repos) -> $repo { :>
+            <: for $repos.all_ref -> $repo { :>
                 <div class="row">
                     <div class="quarter"><a href="<: $repo.gh_data.html_url :>"><: $repo.gh_data.name :></a></div>
                     <div class="half"><: $repo.description :></div>

--- a/templates/i/screenshot.tx
+++ b/templates/i/screenshot.tx
@@ -25,7 +25,7 @@
             init: function() {
 
                 <: if $screenshots { :>
-                    <: for results($screenshots) -> $screenshot { :>
+                    <: for $screenshots -> $screenshot { :>
                         var mockFile<: $screenshot.id :> = {
                             name: "<: $screenshot.upload_filename :>",
                             screenshot_id: <: $screenshot.id :>,

--- a/templates/i/table/ideas.tx
+++ b/templates/i/table/ideas.tx
@@ -8,7 +8,7 @@
 		</div>
 	</div>
 	<div class="body  body--round">
-		<: for results($_.paged_rs) -> $idea { :>
+		<: for $_.paged_rs.all_ref -> $idea { :>
 			<div class="row">
 				<: i($idea,'teaser') :>
 			</div>

--- a/templates/i/thread_rs/forum.tx
+++ b/templates/i/thread_rs/forum.tx
@@ -12,7 +12,7 @@
 	</div>
   </div>
   <div class="body  body--round">
-    <: for results($_) -> $thread { :>
+    <: for $_.all_ref -> $thread { :>
       <: my $context_obj = $thread :>
       <div class="row">
         <div class="forum-item">

--- a/templates/i/user/admin.tx
+++ b/templates/i/user/admin.tx
@@ -76,7 +76,7 @@
     </div>
     <div class="row">
       <h2><: $_.token_language_translations.count :> translations (<: $_.token_languages.count :> in use) and <: $_.translation_votes.count :> votes.</h2>
-      <: for results($_.user_languages) -> $user_language { :>
+      <: for $_.user_languages.all_ref -> $user_language { :>
         <span class="button"><: $user_language.language.name_in_english :></span>
         <span class="tag green circle"><: $user_language.grade :></span>
       <: } :>

--- a/templates/ideas/sidebar.tx
+++ b/templates/ideas/sidebar.tx
@@ -24,7 +24,7 @@
 			<section class="menu-list tab-mid">
 				<h5>Newest Ideas:</h5>
 				<ul>
-					<: for results($latest_ideas) -> $idea { :>
+					<: for $latest_ideas -> $idea { :>
 						<li><a href="<: $u($idea.u) :>"><: $idea.title :></a></li>
 					<: } else { :>
 						Nothing here yet!

--- a/templates/my/account.tx
+++ b/templates/my/account.tx
@@ -28,7 +28,7 @@
 			</div>
 		</div>
 		<div class="body">
-			<: for results($c.user.user_languages) -> $user_language { :>
+			<: for $c.user.user_languages.all_ref -> $user_language { :>
 				<div class="row">
 					<div class="forty">
 						<span class="locale locale--account">
@@ -60,7 +60,7 @@
 			<div class="row">
 				<p>Trying to add a language that's not on the list? <a href="<: $u('My','requestlanguage') :>">Request it here!</a></p>
 			</div>
-			<: if my $size = results($c.user.user_languages).size() { :>
+			<: if my $size = $c.user.user_languages.count { :>
 				<div class="row callout-row">
 					<: if $c.user.translation_manager { :>
 						<a class="callout-link" href="http://duckpan.org/perldoc/DDG::Manual::Translation">
@@ -225,7 +225,7 @@
 
 </form>
 
-<: for results($c.user.user_languages) -> $user_language { :>
+<: for $c.user.user_languages.all_ref -> $user_language { :>
 	<: include "my/account/language_remove.tx" { lang_id => $user_language.language.id } :> 
 <: } :>
 <: include "my/account/language_tip.tx" :>

--- a/templates/my/notifications/following.tx
+++ b/templates/my/notifications/following.tx
@@ -14,7 +14,7 @@
 		<h3>Currently Receiving Notifications For ...<a class="icn icn--sup" href="https://duck.co/blog/post/8/notification-system" title="Get more information about the notification system"><i class="icon-question-sign"></i></a></h3>
 	</div>
 	<div class="body">
-		<: for results($user_notification_matrixes) -> $user_notification_matrix { :>
+		<: for $user_notification_matrixes -> $user_notification_matrix { :>
 			<div class="row notification">				
 				<i class="notification__following  icon-eye-open"></i> 
 				<a href="<: $u('My::Notifications','unfollow',$user_notification_matrix.id, { action_token => $action_token }) :>" title="Stop following this item" class="notification__unfollow  button">Unfollow</a>

--- a/templates/my/notifications/index.tx
+++ b/templates/my/notifications/index.tx
@@ -6,7 +6,7 @@
 	<div class="head">
 		<h2>Your Notifications</h2>
 		<span class="button-group pull-right">			
-		<: if $undone_notifications.count { :>
+		<: if $undone_notifications_count { :>
 			<a class="button red" href="<: $u('My::Notifications','all_done') :>">
 				<i class="icon-folder-open"></i><span class="button__label">Mark All Read</span>
 			</a>	
@@ -14,7 +14,7 @@
 		</span>
 	</div>
 	<div class="body">
-		<: for results($undone_notifications) -> $event_notification_group { :>
+		<: for $undone_notifications -> $event_notification_group { :>
 			<: i($event_notification_group,'view') :>
 		<: } :>
 		<: if $undone_notifications_count > 40 { :>

--- a/templates/translate/admin.tx
+++ b/templates/translate/admin.tx
@@ -9,7 +9,7 @@
 		<h2>Latest comments on <: $token_domain.name :></h2>
 	</div>
 	<div class="body">
-		<: for results($latest_comments) -> $comment { :>
+		<: for $latest_comments -> $comment { :>
 			<div class="row">
 				<: i($comment.get_context_obj.token_domain_language.language,'flag') :>
 				<: $comment.get_context_obj.token_domain_language.language.name_in_english :>

--- a/templates/translate/alltokens.tx
+++ b/templates/translate/alltokens.tx
@@ -11,7 +11,7 @@
 		<div class="row nav">
 			<: include "translate/tokens/nav.tx" { overview => 1 } :>
 		</div>
-		<: for results($token_languages) -> $token_language { :>
+		<: for $token_languages -> $token_language { :>
 			<: include "translate/tokens/token_overview.tx" { token_language => $token_language } :>
 		<: } :>
 		<div class="row nav">

--- a/templates/translate/domainsearch.tx
+++ b/templates/translate/domainsearch.tx
@@ -14,7 +14,7 @@
 	  <: include 'i/head_icons.tx' :>
     </div>
     <div class="body">
-      <: for results($token_results) -> $token { :>
+      <: for $token_results -> $token { :>
         <: i($token,'search') :>
       <: } :>
     </div>
@@ -28,7 +28,7 @@
 	  <: include 'i/head_icons.tx' :>
     </div>
     <div class="body">
-      <: for results($token_language_translation_results) -> $token_language_translation { :>
+      <: for $token_language_translation_results -> $token_language_translation { :>
         <: i($token_language_translation,'search') :>
       <: } :>
     </div>

--- a/templates/translate/index.tx
+++ b/templates/translate/index.tx
@@ -37,7 +37,7 @@
 	<i class="icn icn--large icon-flag"></i><h3>Become a Translation Manager!</h3>
 </a>
 
-<: for results($token_domains.sorted) -> $token_domain { :>
+<: for $token_domains -> $token_domain { :>
 	<: if $token_domain.get_column('token_count') { :>
 		<div class="content-box translate-overview">	
 			<div class="head">		

--- a/templates/translate/notes/notes.tx
+++ b/templates/translate/notes/notes.tx
@@ -1,10 +1,10 @@
-<: for results($token_domains) -> $token_domain { :>
+<: for $token_domains -> $token_domain { :>
 	<div class="content-box translate-overview">
 		<div class="head">
 			<h2><: $token_domain.name :></h2>
 		</div>
 		<div class="body">
-			<: for results($token_domain.tokens) -> $token { :>
+			<: for $token_domain.tokens -> $token { :>
 				<div class="row">		
 					<a href="<: $u('Translate','token', $token.id) :>"><: i('msgctxtid', $token) :></a>
 				</div>

--- a/templates/translate/tokens.tx
+++ b/templates/translate/tokens.tx
@@ -24,7 +24,7 @@
 				<: include "translate/tokens/nav_paging.tx" :>
 				<: include "translate/tokens/nav.tx" :>
 			</div>
-			<: for results($token_languages) -> $token_language { :>
+			<: for $token_languages -> $token_language { :>
 				<: include "translate/tokens/token_language.tx" { token_language => $token_language } :>
 			<: } :>
 			<: if $user_can_speak { :>

--- a/templates/userpage/home.tx
+++ b/templates/userpage/home.tx
@@ -27,7 +27,7 @@
                 </div>
             </div>
             <div class="body">
-                <: for results($comments.paged_rs) -> $comment { :>
+                <: for $comments.paged_rs.all_ref -> $comment { :>
                     <div class="row">
                         <: i($comment,'label') :>
                         <span class="pull-right" title="<: $dur_precise($comment.created) :>"><: $dur($comment.created) :></span>

--- a/templates/userpage/third/languages.tx
+++ b/templates/userpage/third/languages.tx
@@ -1,4 +1,4 @@
-<: for results($user.user_languages) -> $user_language { :>
+<: for $user.user_languages.all_ref -> $user_language { :>
 	<div class="row">
     <: i($_.token_domain_language.language,'flag',{ flag_size => 24 }) :>
 		<: $user_language.language.name_in_local :>

--- a/templates/userpage/twothird/blog.tx
+++ b/templates/userpage/twothird/blog.tx
@@ -1,4 +1,4 @@
-<: for results($user.user_blogs.sorted.live) -> $user_blog { :>
+<: for $user.user_blogs.sorted.live.all_ref -> $user_blog { :>
 	<div class="row">
 		<div class="row">
 			<: if $user_blog.company_blog { :>


### PR DESCRIPTION
[`results()`](https://github.com/duckduckgo/community-platform/blob/19cdc66/lib/DDGC.pm#L373-L381)

- This appears to leak DBIC stuff (see #784)
- Let's sort in the RDBMS instead, it's very good at it.

[`Devel::Leak::Object`](https://metacpan.org/pod/Devel::Leak::Object) profiling shows none of the DBIC instances we saw before hanging around after this change, so let's do the same for everything practical:

```
$ script/ddgc_leak_report.pl 1 /help 2>&1 | grep -v ^DEP
Tracked objects by class:
        DBD::Pg::DefaultValue                    1
        DBI::var                                 5
        Hash::Merge                              2
$ script/ddgc_leak_report.pl 100 /help 2>&1 | grep -v ^DEP
Tracked objects by class:
        DBD::Pg::DefaultValue                    1
        DBI::var                                 5
        Hash::Merge                              2
```

Even if this fails to reduce our footprint, it should at least reduce load a smidgen.

// @nilnilnil @malbin @zekiel 