### PR TITLE
IA Pages - make sure the ID (and meta_id) doesn't have weird chars in it before saving

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -878,14 +878,14 @@ sub create_ia :Chained('base') :PathPart('create') :Args() {
 sub format_id {
     my( $id ) = @_;
 
-    # id must be unique, lowercase and without weird chars
-    $id =~ s/[^a-zA-Z0-9]+/_/g;
-    $id =~ s/^[^a-zA-Z]//;
+    # id must be lowercase and without weird chars
+    $id = lc $id;
+    $id =~ s/[^a-z0-9]+/_/g;
+    $id =~ s/^[^a-zA-Z]+//;
     $id =~ s/[^a-zA-Z0-9]$//;
 
     # make the id string empty if it only contains non-alphabetic chars
     $id =~ s/^[^a-zA-Z]+$//;
-    $id = lc $id;
 
     return $id;
 }

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -882,7 +882,7 @@ sub format_id {
     $id = lc $id;
     $id =~ s/[^a-z0-9]+/_/g;
     $id =~ s/^[^a-zA-Z]+//;
-    $id =~ s/[^a-zA-Z0-9]$//;
+    $id =~ s/_$//;
 
     # make the id string empty if it only contains non-alphabetic chars
     $id =~ s/^[^a-zA-Z]+$//;

--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -29,9 +29,14 @@
                 $("#create-new-ia").show();
             });
 
+            $("body").on("focusin", "#id-input.not_saved", function(evt) {
+                $(this).removeClass("not_saved");
+            });
+
             $("body").on('click', "#new-ia-form-save", function(evt) {
+                var $id_input = $("#id-input");
                 var name = $.trim($("#name-input").val());
-                var id = $.trim($("#id-input").val());
+                var id = $.trim($id_input.val());
                 var description = $.trim($("#description-input").val());
                 var dev_milestone = $.trim($("#dev_milestone-select .available_dev_milestones option:selected").text());
                 
@@ -45,7 +50,11 @@
                         dev_milestone : dev_milestone
                     })
                     .done(function(data) {
-                        window.location = '/ia/view/' + id;
+                        if (data.result && data.id) {
+                            window.location = '/ia/view/' + data.id;
+                        } else {
+                            $id_input.addClass("not_saved");
+                        }
                     });
                 }
             });


### PR DESCRIPTION
@russellholt @jagtalon the check happens when creating a new IA Page and also when editing the meta_id both on the dev pages and the live pages; any non-alphanumeric char gets replaced by an underscore, unless they're at the beginning or end of the string: in that case they get cut off entirely.

The ID can have numbers in it, but they can't be at the beginning of the string, and they need to be mixed with alphabetic (a-z) chars.

If the string only contains weird chars and/or numbers, it gets emptied, so the caller won't save it.

Also, now inside the dialog for creating a new IA Page the ID input field turns red if the entered string is invalid and thus the page is not created.

![screenshot-maria duckduckgo com 5001 2015-07-02 17-13-51](https://cloud.githubusercontent.com/assets/3652195/8480420/ca882caa-20dd-11e5-8813-ddd92e83d3dd.png)
