### PR TITLE
Upgrade Net::GitHub to v0.77

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -80,7 +80,7 @@ requires 'MooseX::Storage', '0.43';
 requires 'namespace::autoclean', '0.14';
 requires 'Net::AIML', '0.0.5';
 requires 'JSON::Any', '1.32';
-requires 'Net::GitHub', '0.57';
+requires 'Net::GitHub', '0.77';
 requires 'Parallel::ForkManager', '1.05';
 requires 'Parse::BBCode', '0.14';
 requires 'Path::Class', '0.32';

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -11,7 +11,6 @@ use Data::Dumper;
 use Try::Tiny;
 use Net::GitHub;
 use Time::Local;
-use Encode qw(decode_utf8);
 my $d = DDGC->new;
 
 # JSON response from GH API
@@ -74,8 +73,8 @@ sub getIssues{
 				repo => $repo || '',
 				issue_id => $issue->{'number'} || '',
                 author => $issue->{user}->{login} || '', 
-				title => decode_utf8($issue->{'title'}) || '',
-				body => decode_utf8($issue->{'body'}) || '',
+				title => $issue->{'title'} || '',
+				body => $issue->{'body'} || '',
 				tags => $issue->{'labels'} || '',
 				date => $issue->{'created_at'} || '',
                 is_pr => $is_pr,


### PR DESCRIPTION
Arg.  @jdorweiler  I figured out why I could not run your ghIssues.pl script on my box -- because I upgraded to Net::GitHub v0.77 which handles utf8 strings differently so you no longer need to decode stuff.

But I need v0.77 because it has methods for new parts of the github api.  So I think we need to release an updated version of your script at the same time I upgrade Net::GitHub.

This pr has the changes.  

cc @MariagraziaAlastra @jbarrett 