### PR TITLE
Temporarily disable / hide GitHub account linking.

### DIFF
--- a/lib/DDGC/Web/Controller/My/GitHub.pm
+++ b/lib/DDGC/Web/Controller/My/GitHub.pm
@@ -7,6 +7,7 @@ use DDGC::GitHub::Plugin;
 BEGIN {extends 'Catalyst::Controller'; }
 
 sub base :Chained('/my/logged_in') :PathPart('github') :CaptureArgs(0) {
+	return;
 	my ( $self, $c ) = @_;
 	$c->require_action_token;
 	$c->stash->{title} = 'GitHub';

--- a/templates/my/account.tx
+++ b/templates/my/account.tx
@@ -111,21 +111,6 @@
 					<a href="<: $u('My','changepw') :>" class="button button--right">Change password</a>
 				</div>
 			</div>
-			<: my $github_user = cur_user().github_user :>
-			<div class="row">
-				<div class="twothird">
-					<label>
-						<: if $github_user { :>
-							Update your Github link <: i($github_user) :>:
-						<: } else { :>
-							Link your GitHub:
-						<: } :>
-					</label>
-				</div>
-				<div class="third">
-					<a href="<: $u('My::GitHub','index', { action_token => $action_token }) :>" class="button button--right">GitHub Link</a>
-				</div>
-			</div>
 			<div class="row">
 				<div class="twothird">
 					<label>

--- a/templates/my/github/index.tx
+++ b/templates/my/github/index.tx
@@ -1,3 +1,5 @@
+<h3>Back soon...</h3>
+: if 0 {
 <: if $github_user { :>
   <: i($github_user,'view') :>
   <: if cur_user().admin { :>
@@ -8,4 +10,4 @@
     Link your GitHub account
   </a>
 <: } :>
-
+: }


### PR DESCRIPTION
This currently does nothing, is getting in the way of other work.