### PR TITLE
Quack and Hack IA status

### DIFF
--- a/lib/DDGC/DB/Result/Idea.pm
+++ b/lib/DDGC/DB/Result/Idea.pm
@@ -80,6 +80,7 @@ sub statuses {{
 	9 => "Not an Instant Answer idea",
 	10 => "Improvement",
 	11 => "Declined",
+	12 => "Quack and Hack!"
 }}
 
 sub status_name { $_[0]->statuses->{$_[0]->status} }
@@ -96,6 +97,7 @@ sub status_colors {{
 	9 => "#af5d9c",
 	10 => "#d83677",
 	11 => "#9e8b75",
+	12 => "#de5833",
 }}
 
 sub status_color { $_[0]->status_colors->{$_[0]->status} }

--- a/lib/DDGC/Web/Controller/Ideas.pm
+++ b/lib/DDGC/Web/Controller/Ideas.pm
@@ -1,6 +1,8 @@
 package DDGC::Web::Controller::Ideas;
 # ABSTRACT: Idea controller
 
+use Scalar::Util qw/ looks_like_number /;
+
 use Moose;
 BEGIN { extends 'Catalyst::Controller'; }
 
@@ -118,8 +120,19 @@ sub type :Chained('base') :Args(1) {
 	$c->add_bc('Filtered');
 }
 
+sub status_name_to_id {
+	my ( $self, $c, $status ) = @_;
+	my $idea = $c->d->rs('Idea')->first;
+	my $statuses = $idea->statuses;
+	$status =~ s/-/ /g;
+	return ( grep { index( lc($statuses->{$_}), lc($status) ) == 0 } keys $statuses )[0];
+}
+
 sub status :Chained('base') :Args(1) {
 	my ( $self, $c, $status ) = @_;
+	if ( !looks_like_number( $status ) ) {
+		$status = $self->status_name_to_id( $c, $status );
+	}
 	$c->stash->{ideas_rs} = $c->stash->{ideas_rs}->search_rs({
 		status => $status,
 	});

--- a/templates/ideas/sidebar.tx
+++ b/templates/ideas/sidebar.tx
@@ -35,6 +35,7 @@
 		<section class="menu-list">
 			<h5>View by Status:</h5>
 			<ul>
+				<li><a href="<: $u('Ideas','status',12) :>">Quack and Hack!</a></li>
 				<li><a href="<: $u('Ideas','status',3) :>">Needs a Developer</a></li>
 				<li><a href="<: $u('Ideas','status',2) :>">Needs Source</a></li>
 				<li><a href="<: $u('Ideas','status',1) :>">Needs Definition</a></li>


### PR DESCRIPTION
- Adds 'Quack and Hack' status.
- Adds ability to link to status by name rather than numeric ID (e.g. /ideas/status/quack-and-hack, /ideas/status/live)
- Can be reverted to "Needs a Developer" status after the event with a single db op