### PR TITLE
capitalize Instant Answer

### DIFF
--- a/lib/DDGC/Feedback/Config/Suggest.pm
+++ b/lib/DDGC/Feedback/Config/Suggest.pm
@@ -22,7 +22,7 @@ sub feedback {[
   },
     # suggest_idea(),
   {
-	description => "It's an idea for an instant answer (not a general suggestion!)",
+	description => "It's an idea for an Instant Answer (not a general suggestion!)",
 	icon => "sun",
 	type => "link",
 	link => ['Ideas','newidea'],


### PR DESCRIPTION
We capitalize it everywhere in the docs and we should follow suite here too. It also helps to make the term a little more pronounced on the page.

to @jbarrett 
/cc @zekiel 