### PR TITLE
Give option of bailing out of deploy when pg_dump is running.

### DIFF
--- a/script/ddgc_release.sh
+++ b/script/ddgc_release.sh
@@ -28,6 +28,19 @@ if [[ -z $DDGC_RELEASE_VERSION ]] ; then
 	exit -1
 fi
 
+PG_DUMP_PID=$(ssh -t ddgc@$DDGC_RELEASE_HOSTNAME "pgrep pg_dump");
+if [ -n "$PG_DUMP_PID" ] ; then
+	printf "************* W A R N I N G *************\n\n"
+	printf "It appears a database backup is in progress\n"
+	printf "This will BLOCK schema changes from deploying\n\n"
+	read -p "Continue deployment [y/N]?" response
+	case $response in
+		[Yy]* ) break;;
+		*) exit;;
+	esac
+fi
+
+
 DDGC_RELEASE_DIRECTORY="/mnt/md0/deploy/$DDGC_RELEASE_VERSION-$CURRENT_DATE_FILENAME"
 
 printf "\n*** Releasing DDGC $DDGC_RELEASE_VERSION to $DDGC_RELEASE_HOSTNAME...\n\n"


### PR DESCRIPTION
@malbin @MariagraziaAlastra If pg_dump is running on production, you will see the following:

```
************* W A R N I N G *************

It appears a database backup is in progress
This will BLOCK schema changes from deploying

Continue deployment [y/N]?
```

This will allow you to abandon a deployment if there are schema changes for the current release.