### PR TITLE
Create IA Page from Idea thread when a user claims it

### DIFF
--- a/src/templates/advanced.handlebars
+++ b/src/templates/advanced.handlebars
@@ -1,3 +1,4 @@
+{{#if repo}}
 {{#is_true permissions.can_edit}}
     {{#ne_and dev_milestone 'live' 'deprecated'}}
     <div class="ia-single--details {{#ne_and dev_milestone 'live' 'deprecated'}}wicked-border{{/ne_and}}" tabindex="0" id="ia-single--details">
@@ -289,3 +290,4 @@
     </div>
     {{/ne_and}}
 {{/is_true}}
+{{/if}}

--- a/src/templates/description.handlebars
+++ b/src/templates/description.handlebars
@@ -9,7 +9,7 @@
         {{/ne_and}}
     {{/if}}
         {{#if forum_link}}
-            <a href="{{forum_link}}" {{#if permissions.can_edit}}{{#ne_and dev_milestone 'live' 'deprecated'}}class="sep--before devpage-forum"{{/ne_and}}{{/if}}>Forum Thread</a>
+            <a href="/ideas/idea/{{forum_link}}" {{#if permissions.can_edit}}{{#ne_and dev_milestone 'live' 'deprecated'}}class="sep--before devpage-forum"{{/ne_and}}{{/if}}>Forum Thread</a>
         {{/if}}
     </h3>
 

--- a/src/templates/description.handlebars
+++ b/src/templates/description.handlebars
@@ -9,7 +9,7 @@
         {{/ne_and}}
     {{/if}}
         {{#if forum_link}}
-            <a href="/ideas/idea/{{forum_link}}" {{#if permissions.can_edit}}{{#ne_and dev_milestone 'live' 'deprecated'}}class="sep--before devpage-forum"{{/ne_and}}{{/if}}>Forum Thread</a>
+            <a href="/ideas/idea/{{forum_link}}" {{#ne_and dev_milestone 'live' 'deprecated'}}class="sep--before devpage-forum"{{/ne_and}}>Forum Thread</a>
         {{/if}}
     </h3>
 

--- a/templates/i/idea/view.tx
+++ b/templates/i/idea/view.tx
@@ -26,6 +26,7 @@
 		</span>
 		<div class="content">
 		<div class="p"><: r($_.html) :></div>
+        <: if $_.instant_answer { :><div class="p"><a href="/ia/view/<: $_.instant_answer.meta_id :>"> IA Page </a></div><: } :>
 		</div>
 		<: if $_.source { :>
 		<div class="idea__label">


### PR DESCRIPTION
@russellholt @jbarrett @zekiel This automatically creates an IA Page from an Idea thread when it's claimed, and it fills in the following fields:

- id, meta_id (aka the editable IA Page id) and forum_link from the idea thread id, 
- the name from the thread title, 
- the description from the content of the first post,
- created_date (using Time::Local),
- dev milestone, setting it to "planning".

Also, the user who claimed the idea gets edit permissions for it.

If the idea is unclaimed and then claimed again, we only update the missing IA Page values without overwriting the existing ones, and give edit permissions to the new claimant.

![screenshot-maria duckduckgo com 5001 2015-08-17 16-46-15](https://cloud.githubusercontent.com/assets/3652195/9307719/63ef95a4-4500-11e5-9e77-541964ce197a.png)
![screenshot-maria duckduckgo com 5001 2015-08-17 16-46-45](https://cloud.githubusercontent.com/assets/3652195/9307724/6687ba3a-4500-11e5-9142-d198f639f55b.png)

