### PR TITLE
cpanfile - bump DBIx::Class version

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -37,7 +37,7 @@ requires 'DateTime::Format::RSS', '0.03000';
 requires 'DateTime::Format::Strptime', '1.5000';
 requires 'DBD::Pg', '0';
 requires 'DBICx::Indexing', '0.002';
-requires 'DBIx::Class', '0.08250';
+requires 'DBIx::Class', '0.082820';
 requires 'DBIx::Class::AlwaysUpdate', '0.001';
 requires 'DBIx::Class::Candy', '0.002104';
 requires 'DBIx::Class::Cursor::Cached', '1.001002';


### PR DESCRIPTION
New versions for Pinto:

```
http://www.cpan.org/authors/id/R/RI/RIBASUSHI/DBIx-Class-0.082820.tar.gz
http://www.cpan.org/authors/id/R/RI/RIBASUSHI/SQL-Abstract-1.81.tar.gz
http://www.cpan.org/authors/id/H/HA/HAARG/Moo-2.000002.tar.gz
http://www.cpan.org/authors/id/H/HA/HAARG/Role-Tiny-2.000001.tar.gz
http://www.cpan.org/authors/id/F/FR/FREW/DBIx-Class-Helpers-2.031000.tar.gz
```