### PR TITLE
Don't update the users table.  Its not needed atm.

### DIFF
--- a/lib/DDGC/GitHub.pm
+++ b/lib/DDGC/GitHub.pm
@@ -95,8 +95,8 @@ sub one_second {
 sub update_database {
     my ($self) = @_;
 
-    print "Updating github_user table\n";
-    $self->update_users;
+    #print "Updating github_user table\n";
+    #$self->update_users;
 
     $self->update_repos($self->ddgc->config->github_org, 1);
 }
@@ -264,7 +264,7 @@ sub update_users {
         if ($@) {
             # ignore errors about users who are not found because they changed
             # their username or deleted their account
-            die $@ unless $@ eq 'Not Found';
+            die $@ unless $@ =~ 'Not Found';
         }
     }
 }


### PR DESCRIPTION
# Overview

Updating the github_user table causes problems when the user has deleted their account or renamed it.  Need to restructure the code to handle that.  But atm this feature isn't needed.  So I will just comment it out.  This has the added benefit of decreasing the # of requests to GitHub api by like 80%.  

# Testing

 * [x] Ran script/ddgc_import_github.pl manually on my dev box. 