### PR TITLE
Subscribe a user to IA Page updates when IA is claimed

### DIFF
--- a/lib/DDGC/DB/Base/ResultSet.pm
+++ b/lib/DDGC/DB/Base/ResultSet.pm
@@ -10,6 +10,7 @@ extends qw(
   DBIx::Class::Helper::ResultSet::Shortcut
   DBIx::Class::Helper::ResultSet::CorrelateRelationship
   DBIx::Class::Helper::ResultSet::SetOperations
+  DBIx::Class::Helper::ResultSet::OneRow
 );
 
 sub ddgc { shift->result_source->schema->ddgc }

--- a/lib/DDGC/DB/Result/Idea.pm
+++ b/lib/DDGC/DB/Result/Idea.pm
@@ -221,6 +221,13 @@ sub toggle_claim {
 		return 1;
 	}
 	elsif ( $self->claimed_by == $user->id || $user->is('forum_manager') ) {
+		my $claimant = ( $self->claimed_by == $user->id )
+		    ? $user
+		    : $self->schema->resultset('User')->find( $self->claimed_by );
+		my $ia = $self->instant_answer;
+		if ( $claimant && $ia ) {
+			$claimant->unsubscribe_from_instant_answer( $ia->id );
+		}
 		$self->update( {
 			claimed_by => undef,
 		} );

--- a/lib/DDGC/DB/Result/User.pm
+++ b/lib/DDGC/DB/Result/User.pm
@@ -4,6 +4,7 @@ package DDGC::DB::Result::User;
 use Moose;
 use MooseX::NonMoose;
 extends 'DDGC::DB::Base::Result';
+with 'DDGC::Schema::Role::Result::User::Subscription';
 use DBIx::Class::Candy;
 use DDGC::User::Page;
 use Path::Class;
@@ -19,6 +20,18 @@ use DateTime;
 use DateTime::Duration;
 
 table 'users';
+
+# Override subscription_types from Role::Result::User::Subscription
+#  - our reference to config is elsewhere
+has '+subscription_types' => (
+    is => 'ro',
+    lazy => 1,
+    builder => '_build_subscriptions',
+);
+sub _build_subscriptions {
+    $_[0]->ddgc->config->subscriptions;
+}
+
 
 sub u_userpage {
 	my ( $self ) = @_;

--- a/lib/DDGC/Schema/Result/User.pm
+++ b/lib/DDGC/Schema/Result/User.pm
@@ -4,6 +4,8 @@ package DDGC::Schema::Result::User;
 
 use Moo;
 extends 'DDGC::Schema::Result';
+with 'DDGC::Schema::Role::Result::User::Subscription';
+
 use DBIx::Class::Candy;
 use Scalar::Util qw/ looks_like_number /;
 use namespace::autoclean;

--- a/lib/DDGC/Schema/ResultSet/User/Role.pm
+++ b/lib/DDGC/Schema/ResultSet/User/Role.pm
@@ -1,0 +1,8 @@
+package DDGC::Schema::ResultSet::User::Role;
+
+# ABSTRACT: Resultset class for user roles
+
+use Moo;
+extends 'DDGC::Schema::ResultSet';
+
+1;

--- a/lib/DDGC/Schema/Role/Result/User/Subscription.pm
+++ b/lib/DDGC/Schema/Role/Result/User/Subscription.pm
@@ -29,7 +29,7 @@ sub unsubscribe_from_instant_answer {
     my ( $self, $ia_id ) = @_;
 
     return 0 if ( !$ia_id );
-    my $sub = $self->search(
+    my $sub = $self->subscriptions->search(
         $self->subscription_types->updated_ia_page({
             meta1 => $ia_id,
         })

--- a/lib/DDGC/Util/Script/ActivityMailer.pm
+++ b/lib/DDGC/Util/Script/ActivityMailer.pm
@@ -69,7 +69,7 @@ sub email {
     $self->smtp->send( {
         to       => $user->email,
         verified => $user->email_verified,
-        from     => 'ddgc@duckduckgo.com',
+        from     => '"DuckDuckGo Community" <ddgc@duckduckgo.com>',
         subject  => $subject,
         template => 'email/activity.tx',
         content  => {

--- a/lib/DDGC/Web/Controller/Ideas.pm
+++ b/lib/DDGC/Web/Controller/Ideas.pm
@@ -273,6 +273,8 @@ sub claim : Chained('idea_id') Args(0) {
         $c->stash->{idea}->update;
 	}
 
+	$c->user->subscribe_to_instant_answer( $ia->id );
+
 	$c->response->redirect( $c->chained_uri(@{ $c->stash->{idea}->u }) );
 }
 

--- a/lib/DDGC/Web/Controller/Ideas.pm
+++ b/lib/DDGC/Web/Controller/Ideas.pm
@@ -271,9 +271,8 @@ sub claim : Chained('idea_id') Args(0) {
 
         $c->stash->{idea}->instant_answer($ia);
         $c->stash->{idea}->update;
+        $c->user->subscribe_to_instant_answer( $ia->id );
 	}
-
-	$c->user->subscribe_to_instant_answer( $ia->id );
 
 	$c->response->redirect( $c->chained_uri(@{ $c->stash->{idea}->u }) );
 }


### PR DESCRIPTION
cc @zekiel @russellholt @MariagraziaAlastra @nilnilnil 

I discussed this with @MariagraziaAlastra already, would be interested in other thoughts.

First thought of mine, doing this without being explicit about it is potentially problematic (especially without a nice way to unsubscribe or remove the subscription).