### PR TITLE
Do not generate activity if updates are from ghIssues.pl

### DIFF
--- a/lib/DDGC/DB/Result/InstantAnswer.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer.pm
@@ -415,6 +415,7 @@ around update => sub {
 
     my $ret = $self->$next( @extra );
     return $ret if (!$ret);
+    return $ret if ( $ENV{DDGC_RUNNING_GHISSUES} );
 
     my $meta3 = _updates_to_meta( $extra[0] );
 

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -13,6 +13,10 @@ use Net::GitHub;
 use Time::Local;
 my $d = DDGC->new;
 
+BEGIN {
+    $ENV{DDGC_RUNNING_GHISSUES} = 1;
+}
+
 # JSON response from GH API
 my %json;
 


### PR DESCRIPTION
cc @jdorweiler @zekiel @nilnilnil 

So it appears that ghIssues (as it runs on view anyway) generates very similar updates for each run - we should probably quash activity generated by these and stick to generating activity based on human activity for now...