### PR TITLE
Advanced Activity Rendering

### DIFF
--- a/lib/DDGC/Schema/Result/ActivityFeed.pm
+++ b/lib/DDGC/Schema/Result/ActivityFeed.pm
@@ -3,6 +3,8 @@ package DDGC::Schema::Result::ActivityFeed;
 
 use Moo;
 extends 'DDGC::Schema::Result';
+with 'DDGC::Schema::Role::Result::ActivityFeed::AdvancedDescription';
+
 use DBIx::Class::Candy;
 use DDGC::Util::Markup;
 

--- a/lib/DDGC/Schema/Role/Result/ActivityFeed/AdvancedDescription.pm
+++ b/lib/DDGC/Schema/Role/Result/ActivityFeed/AdvancedDescription.pm
@@ -1,0 +1,40 @@
+package DDGC::Schema::Role::Result::ActivityFeed::AdvancedDescription;
+use strict;
+use warnings;
+
+use Moo::Role;
+
+has xslate => (
+    is => 'ro',
+    lazy => 1,
+    builder => '_build_xslate',
+);
+sub _build_xslate {
+    Text::Xslate->new(
+        path => 'views',
+    );
+}
+
+sub describe {
+    my ( $self ) = @_;
+    my $sub = sprintf 'describe_%s',
+                join( '_', ( $self->category, $self->action ) );
+
+    return $self->$sub if $self->can( $sub );
+    return $self->render_description;
+}
+
+sub describe_instant_answer_updated {
+    my ( $self ) = @_;
+    my $updates = { map { split ',', $_ } ( $self->meta3 =~ /:(.*?):/g ) };
+    use DDP; p $updates;
+
+    $self->xslate->render(
+        'includes/activity_feed/instant_answer_updated.tx', {
+            activity => $self,
+            updates  => join( ', ', keys $updates ),
+        }
+    );
+}
+
+1;

--- a/views/email/activity.tx
+++ b/views/email/activity.tx
@@ -2,7 +2,7 @@
     : for $user.subscriptions.all_ref -> $subscription {
         : for $subscription.activity.all_ref -> $activity {
             <li>
-                : $activity.render_description | raw
+                : $activity.describe | raw
             </li>
         : }
     : }

--- a/views/includes/activity_feed/instant_answer_updated.tx
+++ b/views/includes/activity_feed/instant_answer_updated.tx
@@ -1,0 +1,7 @@
+<p>
+    : $activity.render_description | raw
+</p>
+<p>
+    Updated fields :
+    : $updates
+</p>


### PR DESCRIPTION
So the emails we've recieved so far have been pretty uninformative. "IA Page Created" is OK, but "IA Page Updated" is less useful - what exactly has been updated?

This role allows **optional** advanced rendering for an activity feed entry. If description isn't going to cut it, you can expand on it here with a sub based on your category name and action.

...I am beginning to think that an application that wants to qualify as `$schema->app` should provide an xslate instance since instantiating one for each result (whether needed or not) is pretty crusty and probably slow.

...though not as slow as everything else :wink: 