### PR TITLE
Gruntfile.js: Don't let deleteBuildFiles error out.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -220,7 +220,7 @@ module.exports = function(grunt) {
         exec: {
             revert: "./script/revert_pkg_version.pl",
             revert_release: "./script/revert_pkg_version.pl release",
-            deleteBuildFiles: "rm -r build",
+            deleteBuildFiles: "mkdir -p build && rm -r build",
             bower: "bower install"
         },
 


### PR DESCRIPTION
When first running Grunt, `build/` might not exist so deleteBuildFiles throws an error. This workaround makes sure that there's a build/ directory in the first place before doing anything.