### PR TITLE
fix messed up perl modules from ghIssues

### DIFF
--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -117,6 +117,8 @@ sub getIssues{
                     $tmp_repo =~ s/s$//g;
 
                     if(my ($name) = $file->{filename} =~ /lib\/DDG\/$tmp_repo\/(.+)\.pm/i ){
+                        my @parts = split('/', $name);
+                        $name = join('::', @parts);
                         $pm = "DDG::".$tmp_repo."::$name";
                         last;
                     }


### PR DESCRIPTION
I'm pretty sure this is what was causing the messed up perl modules like `DDG::Sports/MLB/Games`.

I don't have the complat set up so this needs some testing.