### PR TITLE
Fix C3 Method Resolution errors.

### DIFF
--- a/lib/DDGC/DB/Base/ResultSet.pm
+++ b/lib/DDGC/DB/Base/ResultSet.pm
@@ -4,14 +4,15 @@ package DDGC::DB::Base::ResultSet;
 use Moose;
 use namespace::autoclean;
 
-extends qw(
-  DBIx::Class::ResultSet
-  DBIx::Class::Helper::ResultSet::Me
-  DBIx::Class::Helper::ResultSet::Shortcut
-  DBIx::Class::Helper::ResultSet::CorrelateRelationship
-  DBIx::Class::Helper::ResultSet::SetOperations
-  DBIx::Class::Helper::ResultSet::OneRow
-);
+extends 'DBIx::Class::ResultSet';
+
+__PACKAGE__->load_components(qw/
+    Helper::ResultSet::Me
+    Helper::ResultSet::Shortcut
+    Helper::ResultSet::CorrelateRelationship
+    Helper::ResultSet::SetOperations
+    Helper::ResultSet::OneRow
+/);
 
 sub ddgc { shift->result_source->schema->ddgc }
 sub schema { shift->result_source->schema }


### PR DESCRIPTION
For some reason the DDGC::DB base ResultSet class was written to extend the DBIC components it used rather than use the `load_components` method.

Using `load_components` we no longer get conflicts around `Helper::ResultSet::Shortcut::OrderBy` and `Helper::ResultSet::Shortcut::OrderByMagic`.

Further work may include restricting Shortcut helpers to the set we use but we shouldn't **have to** do this.