### PR TITLE
Disambiguate Core::index call

### DIFF
--- a/lib/DDGC/Web/Controller/Ideas.pm
+++ b/lib/DDGC/Web/Controller/Ideas.pm
@@ -126,7 +126,7 @@ sub status_name_to_id {
 	my $idea = $c->d->rs('Idea')->first;
 	my $statuses = $idea->statuses;
 	$status =~ s/-/ /g;
-	return ( grep { index( lc($statuses->{$_}), lc($status) ) == 0 } keys $statuses )[0];
+	return ( grep { Core::index( lc($statuses->{$_}), lc($status) ) == 0 } keys $statuses )[0];
 }
 
 sub status :Chained('base') :Args(1) {


### PR DESCRIPTION
Index controller route (`sub index`) was causing a warning here.

Should this be an 'eq' check? Or status number?