### PR TITLE
Ideas.pm - fix claimed page (duck.co/ideas/claimed)

### DIFF
--- a/lib/DDGC/Web/Controller/Ideas.pm
+++ b/lib/DDGC/Web/Controller/Ideas.pm
@@ -157,7 +157,7 @@ sub claimed :Chained('base') :Args(0) {
 	my ( $self, $c ) = @_;
 	$c->stash->{ideas_rs} = $c->stash->{ideas_rs}->search_rs({
 		claimed_by => { '!=' => undef },
-		instant_answer_id => undef,
+		instant_answer_id => { '!=' => undef },
 	});
 	$self->add_ideas_table($c,'claimed');
 	$self->add_latest_ideas($c);


### PR DESCRIPTION
@tagawa Just needed to get ideas which are claimed && have an IA Page, instead of claimed ideas with an undef IA Page :)

Now it works:
![screenshot-maria duckduckgo com 5001 2015-08-31 16-33-19](https://cloud.githubusercontent.com/assets/3652195/9581168/0f20664e-4ffe-11e5-8fdb-8f651ba866a9.png)
