### PR TITLE
Dev Page - fix keeping unsaved values for details and examples

### DIFF
--- a/src/js/ia/Helpers.js
+++ b/src/js/ia/Helpers.js
@@ -33,6 +33,38 @@
         return word;
     });
 
+    Handlebars.registerHelper("exists", function(obj, key, options) {
+       if (obj && obj.hasOwnProperty(key)) {
+           return options.fn(this);
+       } else {
+           return options.inverse(this);
+       }
+    });
+
+    Handlebars.registerHelper("exists_subkey", function(obj, key, subkey, options) {
+        if (obj && obj[key] && obj[key].hasOwnProperty(subkey)) {
+            return options.fn(this);
+        } else {
+            return options.inverse(this);
+        }
+    });
+
+    Handlebars.registerHelper("n_exists", function(obj, key, options) {
+        if (!obj || !obj.hasOwnProperty(key)) {
+            return options.fn(this);
+        } else {
+            return options.inverse(this);
+        }
+    });
+
+    Handlebars.registerHelper("n_exists_subkey", function(obj, key, subkey, options) {
+        if (!obj || !obj[key] || !obj[key].hasOwnProperty(subkey)) {
+            return options.fn(this);
+        } else {
+            return options.inverse(this);
+        }
+    });
+
     // True if v1 or v2 (or both) are true
     Handlebars.registerHelper('or', function(v1, v2, options) {
         if (v1 || v2) {

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1215,6 +1215,7 @@
                         var secondary_field = "";
                         ia_data.staged = {};
                         var error_save = [];
+                        var examples_done = false;
                         field = field? field : "";
 
                         if ((field === "example_query") || (field === "other_queries")) {
@@ -1240,7 +1241,22 @@
                                     temp_value = "n---d";
                                 }
                                 
-                                ia_data.staged[temp_field] = temp_value;
+                                if (!examples_done || (temp_field !== "example_query" && temp_field !== "other_examples")) {
+                                    ia_data.staged[temp_field] = temp_value;
+
+                                    if (temp_field === "example_query") {
+                                        temp_result = getUnsavedValue($(".other_queries input"), "other_queries", true);
+                                        temp_value = temp_result.value? $.parseJSON(temp_result.value) : temp_result.value;
+
+                                        ia_data.staged.other_queries = temp_value;
+                                        examples_done = true;
+                                    } else if (temp_field === "other_queries") {
+                                        temp_result = getUnsavedValue($("#example_query-input"), "example_query");
+                                        ia_data.staged.example_query = temp_result.value;
+
+                                        examples_done = true;
+                                    }
+                                }
 
                                 if ($unsaved_edits.hasClass("not_saved") && ($.inArray(temp_field, error_save) === -1)) {
                                     var temp_error = {};

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -734,6 +734,11 @@
                     // Dev Page: cancel edits in the details section
                     $("body").on("click", "#devpage-cancel-details", function(evt) {
                         evt.preventDefault();
+
+                        if (ia_data.staged && ia_data.staged.details) {
+                            delete ia_data.staged.details;
+                        }
+                        
                         keepUnsavedEdits();
                     });
 

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1247,7 +1247,7 @@
 
                                 if (temp_result.is_json && temp_value) {
                                     temp_value = $.parseJSON(temp_value);
-                                } else if (!temp_value) {
+                                } else if (!temp_value && (temp_field === "example_query") || (temp_field === "triggers")) {
                                     temp_value = "n---d";
                                 }
                                 
@@ -1314,8 +1314,6 @@
 
                                         if (temp_result.is_json && temp_value) {
                                             temp_value = $.parseJSON(temp_value);
-                                        } else if (!temp_value) {
-                                            temp_value = "n---d";
                                         }
 
                                         ia_data.staged.details[temp_field] = temp_value;

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1243,10 +1243,12 @@
                             console.log(temp_result);
 
                             if ((temp_field !== field) && (temp_field !== secondary_field)) {
-                                var temp_value = temp_result.value? temp_result.value : "n---d";
+                                var temp_value = temp_result.value;
 
-                                if (temp_value && temp_result.is_json) {
-                                    temp_value = JSON.parse(temp_value);
+                                if (temp_result.is_json && temp_value) {
+                                    temp_value = $.parseJSON(temp_value);
+                                } else if (!temp_value) {
+                                    temp_value = "n---d";
                                 }
                                 
                                 ia_data.staged[temp_field] = temp_value;
@@ -1287,6 +1289,41 @@
                                     ia_data.staged.top_fields[temp_field] = temp_value;
                                 }
                             });
+                        }
+
+                        // If the details commit button is visible it means at least one field
+                        // in the details section was edited.
+                        // These fields have the same behaviour as the blue band fields, too,
+                        // so we perform the same actions for them as well
+                        if (!$("#devpage-commit-details").hasClass("hide")) {
+                            ia_data.staged.details = {};
+                            var section_done = false;
+                            var $details = $("#ia-single--details .js-autocommit");
+
+                            $details.each(function(idx) {
+                                if ((!section_done) || (!$(this).hasClass("section-group__item"))) {
+                                    if ($(this).hasClass("section-group__item")) {
+                                        section_done = true;
+                                    }
+                                    
+                                    var temp_result = getUnsavedValue($(this));
+                                    var temp_field = temp_result.field;
+
+                                    if ((temp_field !== field) && (temp_field !== secondary_field)) {
+                                        var temp_value = temp_result.value;
+
+                                        if (temp_result.is_json && temp_value) {
+                                            temp_value = $.parseJSON(temp_value);
+                                        } else if (!temp_value) {
+                                            temp_value = "n---d";
+                                        }
+
+                                        ia_data.staged.details[temp_field] = temp_value;
+                                    }
+
+                                }
+                            });
+
                         }
 
                         if (ia_data.live.test_machine && ia_data.live.example_query && ia_data.permissions.can_edit) {

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1051,7 +1051,6 @@
                         is_json = result.is_json;
                         parent_field = result.parent_field;
 
-                        console.log("IS JSON " + is_json);
                         var live_data = (ia_data.live[field] && is_json)? JSON.stringify(ia_data.live[field]) : ia_data.live[field];
 
                         console.log("After getUnsaved... " + field + " " + value);
@@ -1092,7 +1091,6 @@
                                 field = $editable.parents(".parent-group").attr("id").replace(/\-.+/, "");
                                 var $obj = field === "topic"? $(".topic-group.js-autocommit option:selected") : "";
                                 value = getGroupVals(field, $obj);
-                                console.log(value);
                                 value = JSON.stringify(value);
                             } else {
                                 field = $editable.attr("id").replace(/\-.+/, "");
@@ -1148,9 +1146,6 @@
                                 $selector = $(".developer_username input[type='text']");
                             } else {
                                 $selector = $("." + field).children("input");
-
-                                console.log($selector.parent().attr("class"));
-                                console.log($selector.length);
                             }
                         }
 
@@ -1245,8 +1240,6 @@
                             var temp_result = getUnsavedValue($unsaved_edits);
                             var temp_field = temp_result.field;
 
-                            console.log(temp_result);
-
                             if ((temp_field !== field) && (temp_field !== secondary_field)) {
                                 var temp_value = temp_result.value;
 
@@ -1313,6 +1306,7 @@
                                     
                                     var temp_result = getUnsavedValue($(this));
                                     var temp_field = temp_result.field;
+                                    var temp_parent = temp_result.parent_field;
 
                                     if ((temp_field !== field) && (temp_field !== secondary_field)) {
                                         var temp_value = temp_result.value;
@@ -1321,7 +1315,7 @@
                                             temp_value = $.parseJSON(temp_value);
                                         }
 
-                                        ia_data.staged.details[temp_field] = temp_value;
+                                        ia_data.staged.details[temp_field] = temp_parent? temp_value[temp_field] : temp_value;
                                     }
 
                                 }

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -739,7 +739,7 @@
                             delete ia_data.staged.details;
                         }
                         
-                        keepUnsavedEdits();
+                        keepUnsavedEdits("details");
                     });
 
                     $("body").on("click", "#ia-single--details .frm__label__chk.js-autocommit", function(evt) {
@@ -1300,7 +1300,7 @@
                         // in the details section was edited.
                         // These fields have the same behaviour as the blue band fields, too,
                         // so we perform the same actions for them as well
-                        if (!$("#devpage-commit-details").hasClass("hide")) {
+                        if (!$("#devpage-commit-details").hasClass("hide") && (field !== "details")) {
                             ia_data.staged.details = {};
                             var section_done = false;
                             var $details = $("#ia-single--details .js-autocommit");

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1021,7 +1021,7 @@
                             } else if (temp_refresh && ia_data.examples_saved) {
                                 // For now we're using this only for example queries
                                 // so it's ok to avoid checking for the field here
-                                keepUnsavedEdits();
+                                keepUnsavedEdits("example_query");
                             } else if (!ia_data.examples_saved && (field === "example_query" || field === "other_queries")) {
                                 ia_data.examples_saved = 1;
                             }

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -220,16 +220,7 @@
                                 delete ia_data.staged.top_details;
                             }
 
-                            // Remove and then append again all the templates for the top blue band
-
-                            $(".ia-single--name").remove();
-                            $("#ia-single-top-name").html(readonly_templates.live.name);
-                            $('#ia-breadcrumbs').html(readonly_templates.live.breadcrumbs);
-                            $("#ia-single-top-details").html(readonly_templates.live.top_details);
-                            $('.edit-container').html(readonly_templates.live.edit_buttons);
-
-                            $(this, "#js-top-details-submit").addClass("is-disabled");
-                            page.appendTopics($(".topic-group.js-autocommit"));
+                            keepUnsavedEdits("top_details");
 
                             // Make sure to update the widths of the topics.
                             $("select.top-details.js-autocommit").each(function() {
@@ -1267,7 +1258,7 @@
                         // and are always editable for people with permissions,
                         // so we don't know which fields have been modified and which haven't:
                         // let's just take all the current values as unsaved
-                        if (!$("#js-top-details-submit").hasClass("is-disabled")) {
+                        if (!$("#js-top-details-submit").hasClass("is-disabled") && (field !== "top_details")) {
                             ia_data.staged.top_fields = {};
                             $(".top-details.js-autocommit").each(function(idx) {
                                 var temp_field;

--- a/src/templates/advanced.handlebars
+++ b/src/templates/advanced.handlebars
@@ -3,8 +3,8 @@
     {{#ne_and dev_milestone 'live' 'deprecated'}}
     <div class="ia-single--details {{#ne_and dev_milestone 'live' 'deprecated'}}wicked-border{{/ne_and}}" tabindex="0" id="ia-single--details">
         <h3 class="ia-single--header">Details
-            <a href="#" class="devpage-commit-details sep--after {{#unless staged.details}}hide{{/unless}}" id="devpage-commit-details">Commit Changes</a>
-            <a href="#" class="devpage-cancel-details {{#unless staged.details}}hide{{/unless}}" id="devpage-cancel-details">Revert All</a>
+            <a href="#" class="devpage-commit-details sep--after {{#n_exists staged 'details'}}hide{{/n_exists}}" id="devpage-commit-details">Commit Changes</a>
+            <a href="#" class="devpage-cancel-details {{#n_exists staged 'details'}}hide{{/n_exists}}" id="devpage-cancel-details">Revert All</a>
         </h3>
 
         <div class="section-group" {{#eq repo 'spice'}}id="answerbar-group"{{/eq}} {{#eq repo 'fathead'}}id="src_options-group"{{/eq}}>
@@ -16,13 +16,13 @@
                     <label class="details__label">
                         <span {{#ne_and dev_milestone 'live' 'deprecated'}}class="asterisk"{{/ne_and}}>Perl Module</span>
                     </label>
-                    <input type="text" class="js-autocommit frm__input perl_module" id="perl_module-input" value="{{#if staged.details.perl_module}}{{staged.details.perl_module}}{{else}}{{perl_module}}{{/if}}">
+                    <input type="text" class="js-autocommit frm__input perl_module" id="perl_module-input" value="{{#exists_subkey staged 'details' 'perl_module'}}{{staged.details.perl_module}}{{else}}{{perl_module}}{{/exists_subkey}}">
                 </div>
                 <div class="third g">
                     <label class="details__label">
                         Template
                     </label>
-                    <input type="text" class="js-autocommit frm__input template" id="template-input" value="{{#if staged.details.template}}{{staged.details.template}}{{else}}{{template}}{{/if}}">
+                    <input type="text" class="js-autocommit frm__input template" id="template-input" value="{{#exists_subkey staged 'details' 'template'}}{{staged.details.template}}{{else}}{{template}}{{/exists_subkey}}">
                 </div>
             </div>
 
@@ -31,14 +31,14 @@
                     <label class="details__label">
                         Perl Dependencies
                     </label>
-                    <input type="text" value="{{#if staged.details.perl_dependencies}}{{staged.details.perl_dependencies}}{{else}}{{perl_dependencies}}{{/if}}" class="comma-separated js-autocommit frm__input perl_dependencies" id="perl_dependencies-input">
+                    <input type="text" value="{{#exists_subkey staged 'details' 'perl_dependencies'}}{{staged.details.perl_dependencies}}{{else}}{{perl_dependencies}}{{/exists_subkey}}" class="comma-separated js-autocommit frm__input perl_dependencies" id="perl_dependencies-input">
                 </div>
                 {{#is_true permissions.admin}}
                     <div class="third g">
                         <label class="details__label">
                             Tab Name
                         </label>
-                        <input type="text" value="{{#if staged.details.tab}}{{staged.details.tab}}{{else}}{{tab}}{{/if}}" class="js-autocommit frm__input tab" id="tab-input">
+                        <input type="text" value="{{#exists_subkey staged 'details' 'tab'}}{{staged.details.tab}}{{else}}{{tab}}{{/exists_subkey}}" class="js-autocommit frm__input tab" id="tab-input">
                     </div>
                 {{/is_true}}
             </div>
@@ -48,21 +48,21 @@
                     <label class="details__label">
                         API Documentation
                     </label>
-                    <input type="text" value="{{#if staged.details.src_api_documentation}}{{staged.details.src_api_documentation}}{{else}}{{src_api_documentation}}{{/if}}" class="js-autocommit frm__input src_api_documentation" id="src_api_documentation-input">
+                    <input type="text" value="{{#exists_subkey staged 'details' 'src_api_documentation'}}{{staged.details.src_api_documentation}}{{else}}{{src_api_documentation}}{{/exists_subkey}}" class="js-autocommit frm__input src_api_documentation" id="src_api_documentation-input">
                 </div>
 
                 <div class="third g">
                     <label class="details__label">
                         API Status Page
                     </label>
-                    <input type="text" value="{{#if staged.details.api_status_page}}{{staged.details.api_status_page}}{{else}}{{api_status_page}}{{/if}}" class="js-autocommit frm__input api_status_page" id="api_status_page-input">
+                    <input type="text" value="{{#exists_subkey staged 'details' 'api_status_page'}}{{staged.details.api_status_page}}{{else}}{{api_status_page}}{{/exists_subkey}}" class="js-autocommit frm__input api_status_page" id="api_status_page-input">
                 </div>
 
                 <div class="third g">
                     <ul>
                         <li>
                             <label class="details__label">Fallback Timeout (ms):</label>
-                            <input type="number" value="{{#if staged.details.answerbar.fallback_timeout}}{{staged.details.answerbar.fallback_timeout}}{{else}}{{answerbar.fallback_timeout}}{{/if}}" id="fallback_timeout-input" class="js-autocommit frm__input fallback_timeout section-group__item">
+                            <input type="number" value="{{#exists_subkey staged 'details' 'fallback_timeout'}}{{staged.details.fallback_timeout}}{{else}}{{answerbar.fallback_timeout}}{{/exists_subkey}}" id="fallback_timeout-input" class="js-autocommit frm__input fallback_timeout section-group__item">
                         </li>
                     </ul>
                 </div>
@@ -76,13 +76,13 @@
                     <label class="details__label">
                         <span {{#ne_and dev_milestone 'live' 'deprecated'}}class="asterisk"{{/ne_and}}>Perl Module</span>
                     </label>
-                    <input type="text" class="js-autocommit frm__input perl_module" id="perl_module-input" value="{{#if staged.details.perl_module}}{{staged.details.perl_module}}{{else}}{{perl_module}}{{/if}}">
+                    <input type="text" class="js-autocommit frm__input perl_module" id="perl_module-input" value="{{#exists_subkey staged 'details' 'perl_module'}}{{staged.details.perl_module}}{{else}}{{perl_module}}{{/exists_subkey}}">
                 </div>
                 <div class="third g">
                     <label class="details__label">
                         Template
                     </label>
-                    <input type="text" class="js-autocommit frm__input template" id="template-input" value="{{#if staged.details.template}}{{staged.details.template}}{{else}}{{template}}{{/if}}">
+                    <input type="text" class="js-autocommit frm__input template" id="template-input" value="{{#exists_subkey staged 'details' 'template'}}{{staged.details.template}}{{else}}{{template}}{{/exists_subkey}}">
                 </div>
             </div>
 
@@ -91,14 +91,14 @@
                     <label class="details__label">
                         Perl Dependencies
                     </label>
-                    <input type="text" value="{{#if staged.details.perl_dependencies}}{{staged.details.perl_dependencies}}{{else}}{{perl_dependencies}}{{/if}}" class="comma-separated js-autocommit frm__input perl_dependencies" id="perl_dependencies-input">
+                    <input type="text" value="{{#exists_subkey staged 'details' 'perl_dependencies'}}{{staged.details.perl_dependencies}}{{else}}{{perl_dependencies}}{{/exists_subkey}}" class="comma-separated js-autocommit frm__input perl_dependencies" id="perl_dependencies-input">
                 </div>
                 {{#is_true permissions.admin}}
                     <div class="third g">
                         <label class="details__label">
                             Tab Name
                         </label>
-                        <input type="text" value="{{#if staged.details.tab}}{{staged.details.tab}}{{else}}{{tab}}{{/if}}" class="js-autocommit frm__input tab" id="tab-input">
+                        <input type="text" value="{{#exists_subkey staged 'details' 'tab'}}{{staged.details.tab}}{{else}}{{tab}}{{/exists_subkey}}" class="js-autocommit frm__input tab" id="tab-input">
                     </div>
                 {{/is_true}}
             </div>
@@ -111,26 +111,26 @@
                         <label class="details__label">
                             <span class="{{#ne_and dev_milestone 'live' 'deprecated'}}asterisk{{/ne_and}}">Perl Module</span>
                         </label>
-                        <input type="text" class="js-autocommit frm__input perl_module" id="perl_module-input" value="{{#if staged.details.perl_module}}{{staged.details.perl_module}}{{else}}{{perl_module}}{{/if}}">
+                        <input type="text" class="js-autocommit frm__input perl_module" id="perl_module-input" value="{{#exists_subkey staged 'details' 'perl_module'}}{{staged.details.perl_module}}{{else}}{{perl_module}}{{/exists_subkey}}">
                     </div>
                     <div>
                         <label class="details__label">
                             Template
                         </label>
-                        <input type="text" class="js-autocommit frm__input template" id="template-input" value="{{#if staged.details.template}}{{staged.details.template}}{{else}}{{template}}{{/if}}">
+                        <input type="text" class="js-autocommit frm__input template" id="template-input" value="{{#exists_subkey staged 'details' 'template'}}{{staged.details.template}}{{else}}{{template}}{{/exists_subkey}}">
                     </div>
 
                     <div class="half">
                         <label  class="details__label">
                             Source ID
                         </label>
-                        <input type="number" value="{{#if staged.details.src_id}}{{staged.details.src_id}}{{else}}{{src_id}}{{/if}}" class="js-autocommit frm__input src_id" id="src_id-input">
+                        <input type="number" value="{{#exists_subkey staged 'details' 'src_id'}}{{staged.details.src_id}}{{else}}{{src_id}}{{/exists_subkey}}" class="js-autocommit frm__input src_id" id="src_id-input">
                     </div>
                     <div class="half g">
                         <label class="details__label">
                             Directory
                         </label>
-                        <input type="text" value="{{#if staged.details.directory}}{{staged.details.directory}}{{else}}{{src_options.directory}}{{/if}}" class="js-autocommit frm__input directory clearfix section-group__item" id="directory-input">
+                        <input type="text" value="{{#exists_subkey staged 'details' 'directory'}}{{staged.details.directory}}{{else}}{{src_options.directory}}{{/exists_subkey}}" class="js-autocommit frm__input directory clearfix section-group__item" id="directory-input">
                     </div>
                 </div>
                 <div class="third g">
@@ -140,43 +140,43 @@
                     <ul>
                         <li>
                             <label class="frm__label">
-                                <input id="skip_abstract-check" class="skip_abstract section-group__item frm__label__chk js-autocommit" type="checkbox" {{#if staged.details.skip_abstract}}{{#is_true staged.details.skip_abstract}}checked="checked"{{/is_true}}{{else}}{{#is_true src_options.skip_abstract}}checked="checked"{{/is_true}}{{/if}}>
+                                <input id="skip_abstract-check" class="skip_abstract section-group__item frm__label__chk js-autocommit" type="checkbox" {{#exists_subkey staged 'details' 'skip_abstract'}}{{#is_true staged.details.skip_abstract}}checked="checked"{{/is_true}}{{else}}{{#is_true src_options.skip_abstract}}checked="checked"{{/is_true}}{{/exists_subkey}}>
                                 <span class="frm__label__txt">Skip Abstract</span>
                             </label>
                         </li>
                         <li>
                             <label class="frm__label">
-                                <input id="skip_abstract_paren-check" class="skip_abstract_paren section-group__item frm__label__chk js-autocommit" type="checkbox" {{#if staged.details.skip_abstract_paren}}{{#is_true staged.details.skip_abstract_paren}}checked="checked"{{/is_true}}{{else}}{{#is_true src_options.skip_abstract_paren}}checked="checked"{{/is_true}}{{/if}}>
+                                <input id="skip_abstract_paren-check" class="skip_abstract_paren section-group__item frm__label__chk js-autocommit" type="checkbox" {{#exists_subkey staged 'details' 'skip_abstract_paren'}}{{#is_true staged.details.skip_abstract_paren}}checked="checked"{{/is_true}}{{else}}{{#is_true src_options.skip_abstract_paren}}checked="checked"{{/is_true}}{{/exists_subkey}}>
                                 <span class="frm__label__txt">Skip Abstract Parent</span>
                             </label>
                         </li>
                         <li>
                             <label class="frm__label">
-                                <input id="skip_icon-check" class="skip_icon section-group__item frm__label__chk js-autocommit" type="checkbox" {{#if staged.details.skip_icon}}{{#is_true staged.details.skip_icon}}checked="checked"{{/is_true}}{{else}}{{#is_true src_options.skip_icon}}checked="checked"{{/is_true}}{{/if}}>
+                                <input id="skip_icon-check" class="skip_icon section-group__item frm__label__chk js-autocommit" type="checkbox" {{#exists_subkey staged 'details' 'skip_icon'}}{{#is_true staged.details.skip_icon}}checked="checked"{{/is_true}}{{else}}{{#is_true src_options.skip_icon}}checked="checked"{{/is_true}}{{/exists_subkey}}>
                                 <span class="frm__label__txt">Skip Icon</span>
                             </label>
                         </li>
                         <li>
                             <label class="frm__label">
-                                <input id="skip_image_name-check" class="skip_image_name section-group__item frm__label__chk js-autocommit" type="checkbox" {{#if staged.details.skip_image_name}}{{#is_true staged.details.skip_image_name}}checked="checked"{{/is_true}}{{else}}{{#is_true src_options.skip_image_name}}checked="checked"{{/is_true}}{{/if}}>
+                                <input id="skip_image_name-check" class="skip_image_name section-group__item frm__label__chk js-autocommit" type="checkbox" {{#exists_subkey staged 'details' 'skip_image_name'}}{{#is_true staged.details.skip_image_name}}checked="checked"{{/is_true}}{{else}}{{#is_true src_options.skip_image_name}}checked="checked"{{/is_true}}{{/exists_subkey}}>
                                 <span class="frm__label__txt">Skip Image Name</span>
                             </label>
                         </li>
                         <li>
                             <label class="frm__label">
-                                <input id="is_wikipedia-check" class="is_wikipedia section-group__item frm__label__chk js-autocommit" type="checkbox" {{#if staged.details.is_wikipedia}}{{#is_true staged.details.is_wikipedia}}checked="checked"{{/is_true}}{{else}}{{#is_true src_options.is_wikipedia}}checked="checked"{{/is_true}}{{/if}}>
+                                <input id="is_wikipedia-check" class="is_wikipedia section-group__item frm__label__chk js-autocommit" type="checkbox" {{#exists_subkey staged 'details' 'is_wikipedia'}}{{#is_true staged.details.is_wikipedia}}checked="checked"{{/is_true}}{{else}}{{#is_true src_options.is_wikipedia}}checked="checked"{{/is_true}}{{/exists_subkey}}>
                                 <span class="frm__label__txt">Is Wikipedia</span>
                             </label>
                         </li>
                         <li>
                             <label class="frm__label">
-                                <input id="is_mediawiki-check" class="is_mediawiki section-group__item frm__label__chk js-autocommit" type="checkbox" {{#if staged.details.is_mediawiki}}{{#is_true staged.details.is_mediawiki}}checked="checked"{{/is_true}}{{else}}{{#is_true src_options.is_mediawiki}}checked="checked"{{/is_true}}{{/if}}>
+                                <input id="is_mediawiki-check" class="is_mediawiki section-group__item frm__label__chk js-autocommit" type="checkbox" {{#exists_subkey staged 'details' 'is_mediawiki'}}{{#is_true staged.details.is_mediawiki}}checked="checked"{{/is_true}}{{else}}{{#is_true src_options.is_mediawiki}}checked="checked"{{/is_true}}{{/exists_subkey}}>
                                 <span class="frm__label__txt">Is MediaWiki</span>
                             </label>
                         </li>
                         <li>
                             <label class="frm__label">
-                                <input id="is_fanon-check" class="is_fanon section-group__item frm__label__chk js-autocommit" type="checkbox" {{#if staged.details.is_fanon}}{{#is_true staged.details.is_fanon}}checked="checked"{{/is_true}}{{#is_true src_options.is_fanon}}checked="checked"{{/is_true}}{{/if}}>
+                                <input id="is_fanon-check" class="is_fanon section-group__item frm__label__chk js-autocommit" type="checkbox" {{#exists_subkey staged 'details' 'is_fanon'}}{{#is_true staged.details.is_fanon}}checked="checked"{{/is_true}}{{#is_true src_options.is_fanon}}checked="checked"{{/is_true}}{{/exists_subkey}}>
                                 <span class="frm__label__txt">Is Fanon</span>
                             </label>
                         </li>
@@ -188,21 +188,21 @@
                     <label class="details__label">
                         Source Name
                     </label>
-                    <input type="text" value="{{#if staged.details.src_name}}{{staged.details.src_name}}{{else}}{{src_name}}{{/if}}" class="js-autocommit frm__input src_name" id="src_name-input">
+                    <input type="text" value="{{#exists_subkey staged 'details' 'src_name'}}{{staged.details.src_name}}{{else}}{{src_name}}{{/exists_subkey}}" class="js-autocommit frm__input src_name" id="src_name-input">
                 </div>
 
                 <div class="third g">
                     <label class="details__label">
                         Minimum Abstract Length
                     </label>
-                    <input type="number" step="1" value="{{#if staged.details.min_abstract_length}}{{staged.details.min_abstract_length}}{{else}}{{src_options.min_abstract_length}}{{/if}}" class="js-autocommit frm__input min_abstract_length clearfix section-group__item" id="min_abstract_length-input">
+                    <input type="number" step="1" value="{{#exists_subkey staged 'details' 'min_abstract_length'}}{{staged.details.min_abstract_length}}{{else}}{{src_options.min_abstract_length}}{{/exists_subkey}}" class="js-autocommit frm__input min_abstract_length clearfix section-group__item" id="min_abstract_length-input">
                 </div>
 
                 <div class="third g">
                     <label class="details__label">
                         Source Skip
                     </label>
-                    <input type="text" value="{{#if staged.details.src_skip}}{{staged.details.src_skip}}{{else}}{{src_options.src_skip}}{{/if}}" class="js-autocommit frm__input src_skip clearfix section-group__item" id="src_skip-input">
+                    <input type="text" value="{{#exists_subkey staged 'details' 'src_skip'}}{{staged.details.src_skip}}{{else}}{{src_options.src_skip}}{{/exists_subkey}}" class="js-autocommit frm__input src_skip clearfix section-group__item" id="src_skip-input">
                 </div>
             </div>
             <div class="gw">
@@ -210,26 +210,26 @@
                     <label class="details__label">
                         Source Domain
                     </label>
-                    <input type="text" value="{{#if staged.details.src_domain}}{{staged.details.src_domain}}{{else}}{{src_domain}}{{/if}}" class="js-autocommit frm__input src_domain" id="src_domain-input">
+                    <input type="text" value="{{#exists_subkey staged 'details' 'src_domain'}}{{staged.details.src_domain}}{{else}}{{src_domain}}{{/exists_subkey}}" class="js-autocommit frm__input src_domain" id="src_domain-input">
                 </div>
                 <div class="third g">
                     <label class="details__label">
                         Language
                     </label>
-                    <input type="text" value="{{#if staged.details.language}}{{staged.details.language}}{{else}}{{src_options.language}}{{/if}}" class="js-autocommit frm__input language clearfix section-group__item" id="language-input">
+                    <input type="text" value="{{#exists_subkey staged 'details' 'language'}}{{staged.details.language}}{{else}}{{src_options.language}}{{/exists_subkey}}" class="js-autocommit frm__input language clearfix section-group__item" id="language-input">
                 </div>
                 <div class="third g">
                     <label class="details__label">
                         Source Info
                     </label>
-                    <input type="text" value="{{#if staged.details.src_info}}{{staged.details.src_info}}{{else}}{{src_options.src_info}}{{/if}}" class="js-autocommit frm__input src_info clearfix section-group__item" id="src_info-input">
+                    <input type="text" value="{{#exists_subkey staged 'details' 'src_info'}}{{staged.details.src_info}}{{else}}{{src_options.src_info}}{{/exists_subkey}}" class="js-autocommit frm__input src_info clearfix section-group__item" id="src_info-input">
                 </div>
             </div>
             <div>
                 <label class="details__label">
                     Skip Query
                 </label>
-                <input type="text" value="{{#if staged.details.skip_qr}}{{staged.details.skip_qr}}{{else}}{{src_options.skip_qr}}{{/if}}" class="js-autocommit frm__input skip_qr clearfix section-group__item" id="skip_qr">
+                <input type="text" value="{{#exists_subkey staged 'details' 'skip_qr'}}{{staged.details.skip_qr}}{{else}}{{src_options.skip_qr}}{{/exists_subkey}}" class="js-autocommit frm__input skip_qr clearfix section-group__item" id="skip_qr">
             </div>
         {{/eq}}
 
@@ -240,13 +240,13 @@
                     <label class="details__label">
                         <span {{#ne_and dev_milestone 'live' 'deprecated'}}class="asterisk"{{/ne_and}}>Perl Module</span>
                     </label>
-                    <input type="text" class="js-autocommit frm__input perl_module" id="perl_module-input" value="{{#if staged.details.perl_module}}{{staged.details.perl_module}}{{else}}{{perl_module}}{{/if}}">
+                    <input type="text" class="js-autocommit frm__input perl_module" id="perl_module-input" value="{{#exists_subkey staged 'details' 'perl_module'}}{{staged.details.perl_module}}{{else}}{{perl_module}}{{/exists_subkey}}">
                 </div>
                 <div class="third g">
                     <label class="details__label">
                         Template
                     </label>
-                    <input type="text" class="js-autocommit frm__input template" id="template-input" value="{{#if staged.details.template}}{{staged.details.template}}{{else}}{{template}}{{/if}}">
+                    <input type="text" class="js-autocommit frm__input template" id="template-input" value="{{#exists_subkey staged 'details' 'template'}}{{staged.details.template}}{{else}}{{template}}{{/exists_subkey}}">
                 </div>
             </div>
 
@@ -255,14 +255,14 @@
                     <label class="details__label">
                         Perl Dependencies
                     </label>
-                    <input type="text" value="{{#if staged.details.perl_dependencies}}{{staged.details.perl_dependencies}}{{else}}{{perl_dependencies}}{{/if}}" class="comma-separated js-autocommit frm__input perl_dependencies" id="perl_dependencies-input">
+                    <input type="text" value="{{#exists_subkey staged 'details' 'perl_dependencies'}}{{staged.details.perl_dependencies}}{{else}}{{perl_dependencies}}{{/exists_subkey}}" class="comma-separated js-autocommit frm__input perl_dependencies" id="perl_dependencies-input">
                 </div>
                 {{#is_true permissions.admin}}
                     <div class="third g">
                         <label class="details__label">
                             Tab Name
                         </label>
-                        <input type="text" value="{{#if staged.details.tab}}{{staged.details.tab}}{{else}}{{tab}}{{/if}}" class="js-autocommit frm__input tab" id="tab-input">
+                        <input type="text" value="{{#exists_subkey staged 'details' 'tab'}}{{staged.details.tab}}{{else}}{{tab}}{{/exists_subkey}}" class="js-autocommit frm__input tab" id="tab-input">
                     </div>
                 {{/is_true}}
             </div>
@@ -272,14 +272,14 @@
                     <label class="details__label">
                         Source Domain
                     </label>
-                    <input type="text" value="{{#if staged.details.src_domain}}{{staged.details.src_domain}}{{else}}{{src_domain}}{{/if}}" class="js-autocommit frm__input src_domain" id="src_domain-input">
+                    <input type="text" value="{{#exists_subkey staged 'details' 'src_domain'}}{{staged.details.src_domain}}{{else}}{{src_domain}}{{/exists_subkey}}" class="js-autocommit frm__input src_domain" id="src_domain-input">
                 </div>
                 <div class="third g">
                     <label class="details__label">
                         Is StackExchange
                     </label>
                     <label class="frm__label">
-                        <input id="is_stackexchange-check" class="is_stackexchange frm__label__chk js-autocommit" type="checkbox" {{#if staged.details.is_stackexchange}}{{#is_true staged.details.is_stackexchange}}checked="checked"{{/is_true}}{{else}}{{#is_true is_stackexchange}}checked="checked"{{/is_true}}{{/if}}>
+                        <input id="is_stackexchange-check" class="is_stackexchange frm__label__chk js-autocommit" type="checkbox" {{#exists_subkey staged 'details' 'is_stackexchange'}}{{#is_true staged.details.is_stackexchange}}checked="checked"{{/is_true}}{{else}}{{#is_true is_stackexchange}}checked="checked"{{/is_true}}{{/exists_subkey}}>
                         <span class="frm__label__txt">Is StackExchange</span>
                     </label>
                 </div>

--- a/src/templates/advanced.handlebars
+++ b/src/templates/advanced.handlebars
@@ -3,8 +3,8 @@
     {{#ne_and dev_milestone 'live' 'deprecated'}}
     <div class="ia-single--details {{#ne_and dev_milestone 'live' 'deprecated'}}wicked-border{{/ne_and}}" tabindex="0" id="ia-single--details">
         <h3 class="ia-single--header">Details
-            <a href="#" class="devpage-commit-details sep--after hide" id="devpage-commit-details">Commit Changes</a>
-            <a href="#" class="devpage-cancel-details hide" id="devpage-cancel-details">Revert All</a>
+            <a href="#" class="devpage-commit-details sep--after {{#unless staged.details}}hide{{/unless}}" id="devpage-commit-details">Commit Changes</a>
+            <a href="#" class="devpage-cancel-details {{#unless staged.details}}hide{{/unless}}" id="devpage-cancel-details">Revert All</a>
         </h3>
 
         <div class="section-group" {{#eq repo 'spice'}}id="answerbar-group"{{/eq}} {{#eq repo 'fathead'}}id="src_options-group"{{/eq}}>
@@ -16,13 +16,13 @@
                     <label class="details__label">
                         <span {{#ne_and dev_milestone 'live' 'deprecated'}}class="asterisk"{{/ne_and}}>Perl Module</span>
                     </label>
-                    <input type="text" class="js-autocommit frm__input perl_module" id="perl_module-input" value="{{perl_module}}">
+                    <input type="text" class="js-autocommit frm__input perl_module" id="perl_module-input" value="{{#if staged.details.perl_module}}{{staged.details.perl_module}}{{else}}{{perl_module}}{{/if}}">
                 </div>
                 <div class="third g">
                     <label class="details__label">
                         Template
                     </label>
-                    <input type="text" class="js-autocommit frm__input template" id="template-input" value="{{template}}">
+                    <input type="text" class="js-autocommit frm__input template" id="template-input" value="{{#if staged.details.template}}{{staged.details.template}}{{else}}{{template}}{{/if}}">
                 </div>
             </div>
 
@@ -31,14 +31,14 @@
                     <label class="details__label">
                         Perl Dependencies
                     </label>
-                    <input type="text" value="{{perl_dependencies}}" class="comma-separated js-autocommit frm__input perl_dependencies" id="perl_dependencies-input">
+                    <input type="text" value="{{#if staged.details.perl_dependencies}}{{staged.details.perl_dependencies}}{{else}}{{perl_dependencies}}{{/if}}" class="comma-separated js-autocommit frm__input perl_dependencies" id="perl_dependencies-input">
                 </div>
                 {{#is_true permissions.admin}}
                     <div class="third g">
                         <label class="details__label">
                             Tab Name
                         </label>
-                        <input type="text" value="{{tab}}" class="js-autocommit frm__input tab" id="tab-input">
+                        <input type="text" value="{{#if staged.details.tab}}{{staged.details.tab}}{{else}}{{tab}}{{/if}}" class="js-autocommit frm__input tab" id="tab-input">
                     </div>
                 {{/is_true}}
             </div>
@@ -48,21 +48,21 @@
                     <label class="details__label">
                         API Documentation
                     </label>
-                    <input type="text" value="{{src_api_documentation}}" class="js-autocommit frm__input src_api_documentation" id="src_api_documentation-input">
+                    <input type="text" value="{{#if staged.details.src_api_documentation}}{{staged.details.src_api_documentation}}{{else}}{{src_api_documentation}}{{/if}}" class="js-autocommit frm__input src_api_documentation" id="src_api_documentation-input">
                 </div>
 
                 <div class="third g">
                     <label class="details__label">
                         API Status Page
                     </label>
-                    <input type="text" value="{{api_status_page}}" class="js-autocommit frm__input api_status_page" id="api_status_page-input">
+                    <input type="text" value="{{#if staged.details.api_status_page}}{{staged.details.api_status_page}}{{else}}{{api_status_page}}{{/if}}" class="js-autocommit frm__input api_status_page" id="api_status_page-input">
                 </div>
 
                 <div class="third g">
                     <ul>
                         <li>
                             <label class="details__label">Fallback Timeout (ms):</label>
-                            <input type="number" value="{{answerbar.fallback_timeout}}" id="fallback_timeout-input" class="js-autocommit frm__input fallback_timeout section-group__item">
+                            <input type="number" value="{{#if staged.details.answerbar.fallback_timeout}}{{staged.details.answerbar.fallback_timeout}}{{else}}{{answerbar.fallback_timeout}}{{/if}}" id="fallback_timeout-input" class="js-autocommit frm__input fallback_timeout section-group__item">
                         </li>
                     </ul>
                 </div>
@@ -76,13 +76,13 @@
                     <label class="details__label">
                         <span {{#ne_and dev_milestone 'live' 'deprecated'}}class="asterisk"{{/ne_and}}>Perl Module</span>
                     </label>
-                    <input type="text" class="js-autocommit frm__input perl_module" id="perl_module-input" value="{{perl_module}}">
+                    <input type="text" class="js-autocommit frm__input perl_module" id="perl_module-input" value="{{#if staged.details.perl_module}}{{staged.details.perl_module}}{{else}}{{perl_module}}{{/if}}">
                 </div>
                 <div class="third g">
                     <label class="details__label">
                         Template
                     </label>
-                    <input type="text" class="js-autocommit frm__input template" id="template-input" value="{{template}}">
+                    <input type="text" class="js-autocommit frm__input template" id="template-input" value="{{#if staged.details.template}}{{staged.details.template}}{{else}}{{template}}{{/if}}">
                 </div>
             </div>
 
@@ -91,14 +91,14 @@
                     <label class="details__label">
                         Perl Dependencies
                     </label>
-                    <input type="text" value="{{perl_dependencies}}" class="comma-separated js-autocommit frm__input perl_dependencies" id="perl_dependencies-input">
+                    <input type="text" value="{{#if staged.details.perl_dependencies}}{{staged.details.perl_dependencies}}{{else}}{{perl_dependencies}}{{/if}}" class="comma-separated js-autocommit frm__input perl_dependencies" id="perl_dependencies-input">
                 </div>
                 {{#is_true permissions.admin}}
                     <div class="third g">
                         <label class="details__label">
                             Tab Name
                         </label>
-                        <input type="text" value="{{tab}}" class="js-autocommit frm__input tab" id="tab-input">
+                        <input type="text" value="{{#if staged.details.tab}}{{staged.details.tab}}{{else}}{{tab}}{{/if}}" class="js-autocommit frm__input tab" id="tab-input">
                     </div>
                 {{/is_true}}
             </div>
@@ -111,26 +111,26 @@
                         <label class="details__label">
                             <span class="{{#ne_and dev_milestone 'live' 'deprecated'}}asterisk{{/ne_and}}">Perl Module</span>
                         </label>
-                        <input type="text" class="js-autocommit frm__input perl_module" id="perl_module-input" value="{{perl_module}}">
+                        <input type="text" class="js-autocommit frm__input perl_module" id="perl_module-input" value="{{#if staged.details.perl_module}}{{staged.details.perl_module}}{{else}}{{perl_module}}{{/if}}">
                     </div>
                     <div>
                         <label class="details__label">
                             Template
                         </label>
-                        <input type="text" class="js-autocommit frm__input template" id="template-input" value="{{template}}">
+                        <input type="text" class="js-autocommit frm__input template" id="template-input" value="{{#if staged.details.template}}{{staged.details.template}}{{else}}{{template}}{{/if}}">
                     </div>
 
                     <div class="half">
                         <label  class="details__label">
                             Source ID
                         </label>
-                        <input type="number" value="{{src_id}}" class="js-autocommit frm__input src_id" id="src_id-input">
+                        <input type="number" value="{{#if staged.details.src_id}}{{staged.details.src_id}}{{else}}{{src_id}}{{/if}}" class="js-autocommit frm__input src_id" id="src_id-input">
                     </div>
                     <div class="half g">
                         <label class="details__label">
                             Directory
                         </label>
-                        <input type="text" value="{{src_options.directory}}" class="js-autocommit frm__input directory clearfix section-group__item" id="directory-input">
+                        <input type="text" value="{{#if staged.details.directory}}{{staged.details.directory}}{{else}}{{src_options.directory}}{{/if}}" class="js-autocommit frm__input directory clearfix section-group__item" id="directory-input">
                     </div>
                 </div>
                 <div class="third g">
@@ -140,43 +140,43 @@
                     <ul>
                         <li>
                             <label class="frm__label">
-                                <input id="skip_abstract-check" class="skip_abstract section-group__item frm__label__chk js-autocommit" type="checkbox" {{#is_true src_options.skip_abstract}}checked="checked"{{/is_true}}>
+                                <input id="skip_abstract-check" class="skip_abstract section-group__item frm__label__chk js-autocommit" type="checkbox" {{#if staged.details.skip_abstract}}{{#is_true staged.details.skip_abstract}}checked="checked"{{/is_true}}{{else}}{{#is_true src_options.skip_abstract}}checked="checked"{{/is_true}}{{/if}}>
                                 <span class="frm__label__txt">Skip Abstract</span>
                             </label>
                         </li>
                         <li>
                             <label class="frm__label">
-                                <input id="skip_abstract_paren-check" class="skip_abstract_paren section-group__item frm__label__chk js-autocommit" type="checkbox" {{#is_true src_options.skip_abstract_paren}}checked="checked"{{/is_true}}>
+                                <input id="skip_abstract_paren-check" class="skip_abstract_paren section-group__item frm__label__chk js-autocommit" type="checkbox" {{#if staged.details.skip_abstract_paren}}{{#is_true staged.details.skip_abstract_paren}}checked="checked"{{/is_true}}{{else}}{{#is_true src_options.skip_abstract_paren}}checked="checked"{{/is_true}}{{/if}}>
                                 <span class="frm__label__txt">Skip Abstract Parent</span>
                             </label>
                         </li>
                         <li>
                             <label class="frm__label">
-                                <input id="skip_icon-check" class="skip_icon section-group__item frm__label__chk js-autocommit" type="checkbox" {{#is_true src_options.skip_icon}}checked="checked"{{/is_true}}>
+                                <input id="skip_icon-check" class="skip_icon section-group__item frm__label__chk js-autocommit" type="checkbox" {{#if staged.details.skip_icon}}{{#is_true staged.details.skip_icon}}checked="checked"{{/is_true}}{{else}}{{#is_true src_options.skip_icon}}checked="checked"{{/is_true}}{{/if}}>
                                 <span class="frm__label__txt">Skip Icon</span>
                             </label>
                         </li>
                         <li>
                             <label class="frm__label">
-                                <input id="skip_image_name-check" class="skip_image_name section-group__item frm__label__chk js-autocommit" type="checkbox" {{#is_true src_options.skip_image_name}}checked="checked"{{/is_true}}>
+                                <input id="skip_image_name-check" class="skip_image_name section-group__item frm__label__chk js-autocommit" type="checkbox" {{#if staged.details.skip_image_name}}{{#is_true staged.details.skip_image_name}}checked="checked"{{/is_true}}{{else}}{{#is_true src_options.skip_image_name}}checked="checked"{{/is_true}}{{/if}}>
                                 <span class="frm__label__txt">Skip Image Name</span>
                             </label>
                         </li>
                         <li>
                             <label class="frm__label">
-                                <input id="is_wikipedia-check" class="is_wikipedia section-group__item frm__label__chk js-autocommit" type="checkbox" {{#is_true src_options.is_wikipedia}}checked="checked"{{/is_true}}>
+                                <input id="is_wikipedia-check" class="is_wikipedia section-group__item frm__label__chk js-autocommit" type="checkbox" {{#if staged.details.is_wikipedia}}{{#is_true staged.details.is_wikipedia}}checked="checked"{{/is_true}}{{else}}{{#is_true src_options.is_wikipedia}}checked="checked"{{/is_true}}{{/if}}>
                                 <span class="frm__label__txt">Is Wikipedia</span>
                             </label>
                         </li>
                         <li>
                             <label class="frm__label">
-                                <input id="is_mediawiki-check" class="is_mediawiki section-group__item frm__label__chk js-autocommit" type="checkbox" {{#is_true src_options.is_mediawiki}}checked="checked"{{/is_true}}>
+                                <input id="is_mediawiki-check" class="is_mediawiki section-group__item frm__label__chk js-autocommit" type="checkbox" {{#if staged.details.is_mediawiki}}{{#is_true staged.details.is_mediawiki}}checked="checked"{{/is_true}}{{else}}{{#is_true src_options.is_mediawiki}}checked="checked"{{/is_true}}{{/if}}>
                                 <span class="frm__label__txt">Is MediaWiki</span>
                             </label>
                         </li>
                         <li>
                             <label class="frm__label">
-                                <input id="is_fanon-check" class="is_fanon section-group__item frm__label__chk js-autocommit" type="checkbox" {{#is_true src_options.is_fanon}}checked="checked"{{/is_true}}>
+                                <input id="is_fanon-check" class="is_fanon section-group__item frm__label__chk js-autocommit" type="checkbox" {{#if staged.details.is_fanon}}{{#is_true staged.details.is_fanon}}checked="checked"{{/is_true}}{{#is_true src_options.is_fanon}}checked="checked"{{/is_true}}{{/if}}>
                                 <span class="frm__label__txt">Is Fanon</span>
                             </label>
                         </li>
@@ -188,21 +188,21 @@
                     <label class="details__label">
                         Source Name
                     </label>
-                    <input type="text" value="{{src_name}}" class="js-autocommit frm__input src_name" id="src_name-input">
+                    <input type="text" value="{{#if staged.details.src_name}}{{staged.details.src_name}}{{else}}{{src_name}}{{/if}}" class="js-autocommit frm__input src_name" id="src_name-input">
                 </div>
 
                 <div class="third g">
                     <label class="details__label">
                         Minimum Abstract Length
                     </label>
-                    <input type="number" step="1" value="{{src_options.min_abstract_length}}" class="js-autocommit frm__input min_abstract_length clearfix section-group__item" id="min_abstract_length-input">
+                    <input type="number" step="1" value="{{#if staged.details.min_abstract_length}}{{staged.details.min_abstract_length}}{{else}}{{src_options.min_abstract_length}}{{/if}}" class="js-autocommit frm__input min_abstract_length clearfix section-group__item" id="min_abstract_length-input">
                 </div>
 
                 <div class="third g">
                     <label class="details__label">
                         Source Skip
                     </label>
-                    <input type="text" value="{{src_options.src_skip}}" class="js-autocommit frm__input src_skip clearfix section-group__item" id="src_skip-input">
+                    <input type="text" value="{{#if staged.details.src_skip}}{{staged.details.src_skip}}{{else}}{{src_options.src_skip}}{{/if}}" class="js-autocommit frm__input src_skip clearfix section-group__item" id="src_skip-input">
                 </div>
             </div>
             <div class="gw">
@@ -210,26 +210,26 @@
                     <label class="details__label">
                         Source Domain
                     </label>
-                    <input type="text" value="{{src_domain}}" class="js-autocommit frm__input src_domain" id="src_domain-input">
+                    <input type="text" value="{{#if staged.details.src_domain}}{{staged.details.src_domain}}{{else}}{{src_domain}}{{/if}}" class="js-autocommit frm__input src_domain" id="src_domain-input">
                 </div>
                 <div class="third g">
                     <label class="details__label">
                         Language
                     </label>
-                    <input type="text" value="{{src_options.language}}" class="js-autocommit frm__input language clearfix section-group__item" id="language-input">
+                    <input type="text" value="{{#if staged.details.language}}{{staged.details.language}}{{else}}{{src_options.language}}{{/if}}" class="js-autocommit frm__input language clearfix section-group__item" id="language-input">
                 </div>
                 <div class="third g">
                     <label class="details__label">
                         Source Info
                     </label>
-                    <input type="text" value="{{src_options.src_info}}" class="js-autocommit frm__input src_info clearfix section-group__item" id="src_info-input">
+                    <input type="text" value="{{#if staged.details.src_info}}{{staged.details.src_info}}{{else}}{{src_options.src_info}}{{/if}}" class="js-autocommit frm__input src_info clearfix section-group__item" id="src_info-input">
                 </div>
             </div>
             <div>
                 <label class="details__label">
                     Skip Query
                 </label>
-                <input type="text" value="{{src_options.skip_qr}}" class="js-autocommit frm__input skip_qr clearfix section-group__item" id="skip_qr">
+                <input type="text" value="{{#if staged.details.skip_qr}}{{staged.details.skip_qr}}{{else}}{{src_options.skip_qr}}{{/if}}" class="js-autocommit frm__input skip_qr clearfix section-group__item" id="skip_qr">
             </div>
         {{/eq}}
 
@@ -240,13 +240,13 @@
                     <label class="details__label">
                         <span {{#ne_and dev_milestone 'live' 'deprecated'}}class="asterisk"{{/ne_and}}>Perl Module</span>
                     </label>
-                    <input type="text" class="js-autocommit frm__input perl_module" id="perl_module-input" value="{{perl_module}}">
+                    <input type="text" class="js-autocommit frm__input perl_module" id="perl_module-input" value="{{#if staged.details.perl_module}}{{staged.details.perl_module}}{{else}}{{perl_module}}{{/if}}">
                 </div>
                 <div class="third g">
                     <label class="details__label">
                         Template
                     </label>
-                    <input type="text" class="js-autocommit frm__input template" id="template-input" value="{{template}}">
+                    <input type="text" class="js-autocommit frm__input template" id="template-input" value="{{#if staged.details.template}}{{staged.details.template}}{{else}}{{template}}{{/if}}">
                 </div>
             </div>
 
@@ -255,14 +255,14 @@
                     <label class="details__label">
                         Perl Dependencies
                     </label>
-                    <input type="text" value="{{perl_dependencies}}" class="comma-separated js-autocommit frm__input perl_dependencies" id="perl_dependencies-input">
+                    <input type="text" value="{{#if staged.details.perl_dependencies}}{{staged.details.perl_dependencies}}{{else}}{{perl_dependencies}}{{/if}}" class="comma-separated js-autocommit frm__input perl_dependencies" id="perl_dependencies-input">
                 </div>
                 {{#is_true permissions.admin}}
                     <div class="third g">
                         <label class="details__label">
                             Tab Name
                         </label>
-                        <input type="text" value="{{tab}}" class="js-autocommit frm__input tab" id="tab-input">
+                        <input type="text" value="{{#if staged.details.tab}}{{staged.details.tab}}{{else}}{{tab}}{{/if}}" class="js-autocommit frm__input tab" id="tab-input">
                     </div>
                 {{/is_true}}
             </div>
@@ -272,14 +272,14 @@
                     <label class="details__label">
                         Source Domain
                     </label>
-                    <input type="text" value="{{src_domain}}" class="js-autocommit frm__input src_domain" id="src_domain-input">
+                    <input type="text" value="{{#if staged.details.src_domain}}{{staged.details.src_domain}}{{else}}{{src_domain}}{{/if}}" class="js-autocommit frm__input src_domain" id="src_domain-input">
                 </div>
                 <div class="third g">
                     <label class="details__label">
                         Is StackExchange
                     </label>
                     <label class="frm__label">
-                        <input id="is_stackexchange-check" class="is_stackexchange frm__label__chk js-autocommit" type="checkbox" {{#is_true is_stackexchange}}checked="checked"{{/is_true}}>
+                        <input id="is_stackexchange-check" class="is_stackexchange frm__label__chk js-autocommit" type="checkbox" {{#if staged.details.is_stackexchange}}{{#is_true staged.details.is_stackexchange}}checked="checked"{{/is_true}}{{else}}{{#is_true is_stackexchange}}checked="checked"{{/is_true}}{{/if}}>
                         <span class="frm__label__txt">Is StackExchange</span>
                     </label>
                 </div>

--- a/src/templates/description.handlebars
+++ b/src/templates/description.handlebars
@@ -3,9 +3,9 @@
             <span {{#ne_and dev_milestone 'live' 'deprecated'}}{{#if permissions.can_edit}}class="asterisk"{{/if}}{{/ne_and}}>Description</span>
     {{#if permissions.can_edit}}
         {{#ne_and dev_milestone 'live' 'deprecated'}}
-            <a href="#" class="devpage-edit {{#if staged.description}}hide{{/if}}" id="dev-edit-description">Edit</a>
-            <a href="#" class="devpage-commit sep--after {{#unless staged.description}}hide{{/unless}}" id="dev-commit-description">Commit</a>
-            <a href="#" class="devpage-cancel {{#unless staged.description}}hide{{/unless}}" id="dev-cancel-description">Cancel</a>
+            <a href="#" class="devpage-edit {{#exists staged 'description'}}hide{{/exists}}" id="dev-edit-description">Edit</a>
+            <a href="#" class="devpage-commit sep--after {{#n_exists staged 'description'}}hide{{/n_exists}}" id="dev-commit-description">Commit</a>
+            <a href="#" class="devpage-cancel {{#n_exists staged 'description'}}hide{{/n_exists}}" id="dev-cancel-description">Cancel</a>
         {{/ne_and}}
     {{/if}}
         {{#if forum_link}}
@@ -13,7 +13,7 @@
         {{/if}}
     </h3>
 
-    <p  class="readonly--info {{#if staged.description}}hide{{/if}}" id="description--readonly">
+    <p  class="readonly--info {{#exists staged 'description'}}hide{{/exists}}" id="description--readonly">
         {{#if description}}
             {{description}}
         {{else}}
@@ -22,12 +22,12 @@
     </p>
 
     {{#if permissions.can_edit}}
-        <textarea class="{{#unless staged.description}}hide{{/unless}} frm__text description js-autocommit hidden-toshow" id="description-textarea">
-            {{~#if staged.description~}}
+        <textarea class="{{#n_exists staged 'description'}}hide{{/n_exists}} frm__text description js-autocommit hidden-toshow" id="description-textarea">
+            {{~#exists staged 'description'~}}
                 {{staged.description}}
             {{~else~}}
                 {{description}}
-            {{~/if~}}
+            {{~/exists~}}
         </textarea>
     {{/if}}
 </div>

--- a/src/templates/devinfo.handlebars
+++ b/src/templates/devinfo.handlebars
@@ -4,19 +4,19 @@
             <span {{#ne_and dev_milestone 'live' 'deprecated'}}{{#if permissions.admin}}class="asterisk"{{/if}}{{/ne_and}}>ID</span>
         {{#if permissions.admin}}
             {{#ne_and dev_milestone 'live' 'deprecated'}}
-                <a href="#" class="devpage-edit {{#if staged.id}}hide{{/if}}" id="dev-edit-id">Edit</a>
-                <a href="#" class="devpage-commit sep--after {{#unless staged.id}}hide{{/unless}}" id="dev-commit-id">Commit</a>
-                <a href="#" class="devpage-cancel {{#unless staged.id}}hide{{/unless}}" id="dev-cancel-id">Cancel</a>
+                <a href="#" class="devpage-edit {{#exists staged 'id'}}hide{{/exists}}" id="dev-edit-id">Edit</a>
+                <a href="#" class="devpage-commit sep--after {{#n_exists staged 'id'}}hide{{/n_exists}}" id="dev-commit-id">Commit</a>
+                <a href="#" class="devpage-cancel {{#n_exists staged 'id'}}hide{{/n_exists}}" id="dev-cancel-id">Cancel</a>
             {{/ne_and}}
         {{/if}}
         </h3>
 
-        <span class="readonly--info {{#if staged.id}}hide{{/if}}" id="id--readonly">
+        <span class="readonly--info {{#exists staged 'id'}}hide{{/exists}}" id="id--readonly">
             {{id}}
         </span>
 
         {{#if permissions.admin}}
-            <input type="text" class="{{#unless staged.id}}hide{{/unless}} frm__input id js-autocommit hidden-toshow" id="id-input" value="{{#if staged.id}}{{#eq staged.id 'n---d'}} {{else}}{{staged.id}}{{/eq}}{{else}}{{id}}{{/if}}" />
+            <input type="text" class="{{#n_exists staged 'id'}}hide{{/n_exists}} frm__input id js-autocommit hidden-toshow" id="id-input" value="{{#exists staged 'id'}}{{staged.id}}{{else}}{{id}}{{/exists}}" />
             <span class="error-notification hide">ID can't be empty</span>
         {{/if}}
     </div>

--- a/src/templates/examples.handlebars
+++ b/src/templates/examples.handlebars
@@ -21,7 +21,7 @@
              {{#if staged.other_queries}}
                 {{#each staged.other_queries}}
                     <li {{#eq staged.other_queries '[]'}}class="hide"{{/eq}}>
-                        <span class="{{#if @first}}{{#unless ../../staged.example_query}}example_query{{else}}other_queries{{/unless}}{{else}}example_query{{/if}} left">
+                        <span class="{{#if @first}}{{#unless ../../staged.example_query}}example_query{{else}}other_queries{{/unless}}{{else}}example_query{{/if}}">
                             <input type="text" value="{{this}}" {{#if @first}}{{#unless ../../staged.example_query}}id="example_query-input"{{/unless}}{{/if}}
                             class="js-autocommit {{#if @first}}{{#unless ../../staged.example_query}}example_query{{else}}group-vals{{/unless}}{{else}}example_query{{/if}}" />
                             <span class="delete delete-tag" title="Remove example">

--- a/src/templates/top_details.handlebars
+++ b/src/templates/top_details.handlebars
@@ -14,7 +14,7 @@
             {{#if permissions.can_edit}}
                 {{#ne_and dev_milestone 'live' 'deprecated'}}
                     <div class="topic-container parent-group" id="topic-group">
-                      {{#if staged.top_fields.topic}}
+                      {{#exists_subkey staged 'top_fields' 'topic'}}
                         {{#with staged.top_fields}}
                             {{#not_eq topic 'n---d'}}
                               {{#loop_n 2 topic}}
@@ -40,9 +40,9 @@
                               <span class="delete-tag"><i class="delete ddgsi ddgsi-close"></i></span>
                             </div>
                           {{/loop_n}}
-                      {{/if}}
+                      {{/exists_subkey}}
 
-                      <div class="btn {{#if staged.top_fields.topic}}{{#gt staged.top_fields.topic 1}}hide{{/gt}}{{else}}{{#gt topic 1}}hide{{/gt}}{{/if}}" id="add_topic">
+                      <div class="btn {{#exists_subkey staged 'top_fields' 'topic'}}{{#gt staged.top_fields.topic 1}}hide{{/gt}}{{else}}{{#gt topic 1}}hide{{/gt}}{{/exists_subkey}}" id="add_topic">
                         <i class="ddgsi-plus" />
                       </div>
 
@@ -89,7 +89,7 @@
             <span class="detail-title">Type:</span>
             {{#if permissions.can_edit}}
                 {{#ne_and dev_milestone 'live' 'deprecated'}}
-                    {{#if staged.top_fields.repo}}
+                    {{#exists_subkey staged 'top_fields' 'repo'}}
                         {{#with staged.top_fields}}
                             <span class="frm__select">
                               <select class="top-details js-autocommit repo" tabindex="-1" id="repo-select">
@@ -111,7 +111,7 @@
                             {{#not_eq repo 'spice'}}<option value="4">spice</option>{{/not_eq}}
                           </select>
                         </span>
-                    {{/if}}
+                    {{/exists_subkey}}
                  {{else}}
                     {{#if repo}}
                         <a href="/ia?&repo={{repo}}">{{repo}}</a>
@@ -130,7 +130,7 @@
             <span class="detail-title">Status:</span>
             {{#if permissions.admin}}
                 {{#ne_and dev_milestone 'live' 'deprecated'}}
-                    {{#if staged.top_fields.dev_milestone}}
+                    {{#exists_subkey staged 'top_fields' 'dev_milestone'}}
                         {{#with staged.top_fields}}
                             <span class="frm__select">
                               <select class="top-details js-autocommit dev_milestone" tabindex="-1" id="dev_milestone-select">
@@ -154,7 +154,7 @@
                                 {{#not_eq dev_milestone 'live'}}<option value="5">live</option>{{/not_eq}}
                             </select>
                         </span>
-                    {{/if}}
+                    {{/exists_subkey}}
                 {{else}}
                         {{dev_milestone}}
                 {{/ne_and}}


### PR DESCRIPTION
Now details use the staged object in order to keep unsaved values when refreshing the Handlebars templates as well, in order to prevent data loss when editing details and committing some other field without first saving.

Also fixed some issues with keeping the unsaved data for example queries.