### PR TITLE
Ideas Forum - unclaim idea when the status is updated to 'live' or 'declined'

### DIFF
--- a/lib/DDGC/Web/Controller/Ideas.pm
+++ b/lib/DDGC/Web/Controller/Ideas.pm
@@ -199,8 +199,8 @@ sub idea : Chained('idea_id') PathPart('') Args(1) {
 	$c->bc_index;
 	if ($c->user && $c->user->is('idea_manager') && $c->req->params->{change_status}) {
 		$c->stash->{idea}->status($c->req->params->{status});
-		if ( lc($c->stash->{idea_statuses}->[ $c->req->params->{status} ]->[1])
-		     eq 'needs a developer') {
+        my $status_lc = lc($c->stash->{idea_statuses}->[ $c->req->params->{status} ]->[1]);
+		if ( $status_lc eq 'needs a developer' || $status_lc eq 'live' || $status_lc eq 'declined') {
 			$c->stash->{idea}->claimed_by(undef);
 		}
 		$c->stash->{idea}->update;


### PR DESCRIPTION
Fixes #923 and #917 
We might want to add more statuses to ignore, e.g. "under review", or maybe create a completely new status, e.g. "complete", for IAs merged but not yet live, like in IA Pages.

It should be sufficient for now though.
@tagawa @jbarrett (I know you're out, just adding you in the loop to let you know)