### PR TITLE
Dev Pipeline - add activity details for each IA with a PR

### DIFF
--- a/src/js/ia/Helpers.js
+++ b/src/js/ia/Helpers.js
@@ -1,6 +1,7 @@
 (function(env) {
     // Handlebars helpers for IA Pages
     
+    // Return elapsed time expressed as days from now (e.g. 5 days, 1 day, today)
     Handlebars.registerHelper("timeago", function(date) {
         if (date) {
             // expected date format: YYYY-MM-DDTHH:mm:ssZ e.g. 2011-04-22T13:33:48Z
@@ -20,6 +21,7 @@
         }
     });
 
+    // Format the full date and convert time to local timezone time
     Handlebars.registerHelper("format_time", function(date) {
         if (date) {
             var offset = moment().local().utcOffset();
@@ -31,7 +33,16 @@
             date = date.format('D MMM YYYY HH:mm');
             return date;
         }
-    });
+     });
+
+     // Return true if date1 is before date2
+     Handlebars.registerHelper("is_before", function(date1, date2, options) {
+        if (moment.utc(date1).isBefore(date2)) {
+            return options.fn(this);
+        } else {
+            return options.inverse(this);
+        }
+     });
 
     /**
      * @function plural

--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -85,8 +85,7 @@
             });
 
             $("#filter-team_checkbox").click(function(evt) {
-                $(this).toggleClass("icon-check");
-                $(this).toggleClass("icon-check-empty");
+                 toggleCheck($(this));
 
                 if ($(this).hasClass("icon-check-empty")) {
                     $(".dev_pipeline-column__list li").show();
@@ -105,6 +104,12 @@
                 }
             });
 
+            $(".toggle-details i").click(function(evt) {
+                toggleCheck($(this));
+
+                $(".activity-details").toggleClass("hide");
+            });
+
             $("#select-teamrole").change(function(evt) {
                 if ($("#filter-team_checkbox").hasClass("icon-check")) {
                     $(".dev_pipeline-column__list li").hide();
@@ -113,6 +118,11 @@
                     $(".dev_pipeline-column__list li." + teamrole + "-" + username).show();
                 }
             });
+
+            function toggleCheck($obj) {
+                $obj.toggleClass("icon-check");
+                $obj.toggleClass("icon-check-empty");
+            }
         }
     };
 })(DDH);

--- a/src/scss/ia/_pipeline.scss
+++ b/src/scss/ia/_pipeline.scss
@@ -7,10 +7,28 @@
 
     .item-activity { 
         color: $grey-light; 
+    }
 
-        a {
-            color: $blue;
-        }
+    .item-activity, .activity-details {
+        a { color: $blue; }
+    }
+
+    .activity-details {
+        font-size: 0.75em;
+        margin-left: 2.3em;
+    }
+
+    .icon-circle {
+        color: $red;
+    }
+
+    .icon-bubbles {
+        color: $grey-light;
+    }
+
+    .icon {
+        margin-right: 0.5em;
+        padding-left: 0.25em;
     }
 }
 

--- a/src/scss/ia/_pipeline.scss
+++ b/src/scss/ia/_pipeline.scss
@@ -1,9 +1,11 @@
 .wrap-pipeline { padding: 0 2em; }
 
+.toggle-details { margin-right: 2em; }
+
 #dev_pipeline .dev_pipeline-column {
     width: 22.5%;
     text-align: left;
-    padding: 0px 1em;
+    padding: 1em;
 
     .item-activity { 
         color: $grey-light; 

--- a/src/templates/dev_pipeline.handlebars
+++ b/src/templates/dev_pipeline.handlebars
@@ -22,7 +22,22 @@
                         {{timeago last_update}}
                     </span>
                 </div>
-                <span class="clearfix"></span>
+                <div class="clearfix activity-details">
+                    {{#is_before last_comment.date last_commit.date}}
+                        <div class="new-commit one-line">
+                            <i class="icon icon-circle" />
+                            New commit: <a href="{{last_commit.diff}}">{{last_commit.message}}</a>
+                        </div>
+                    {{/is_before}}
+                    {{#if last_comment}}
+                        <div class="last-comment one-line">
+                            <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}#issuecomment-{{last_comment.id}}">
+                                <i class="icon icon-bubbles" />
+                                Last comment by {{last_comment.user}}
+                            </a>
+                       </div>
+                    {{/if}}
+                </div>
             </li>
         {{/each}}
     </ul>

--- a/src/templates/dev_pipeline.handlebars
+++ b/src/templates/dev_pipeline.handlebars
@@ -66,7 +66,22 @@
                         {{timeago last_update}}
                     </span>
                 </div>
-                <span class="clearfix"></span>
+                <div class="clearfix activity-details">
+                    {{#is_before last_comment.date last_commit.date}}
+                        <div class="new-commit one-line">
+                            <i class="icon icon-circle" />
+                            New commit: <a href="{{last_commit.diff}}">{{last_commit.message}}</a>
+                        </div>
+                    {{/is_before}}
+                    {{#if last_comment}}
+                        <div class="last-comment one-line">
+                            <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}#issuecomment-{{last_comment.id}}">
+                                <i class="icon icon-bubbles" />
+                                Last comment by {{last_comment.user}}
+                            </a>
+                       </div>
+                    {{/if}}
+                </div>
             </li>
         {{/each}}
     </ul>
@@ -95,7 +110,22 @@
                         {{timeago last_update}}
                     </span>
                 </div>
-                <span class="clearfix"></span>
+                <div class="clearfix activity-details">
+                    {{#is_before last_comment.date last_commit.date}}
+                        <div class="new-commit one-line">
+                            <i class="icon icon-circle" />
+                            New commit: <a href="{{last_commit.diff}}">{{last_commit.message}}</a>
+                        </div>
+                    {{/is_before}}
+                    {{#if last_comment}}
+                        <div class="last-comment one-line">
+                            <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}#issuecomment-{{last_comment.id}}">
+                                <i class="icon icon-bubbles" />
+                                Last comment by {{last_comment.user}}
+                            </a>
+                       </div>
+                    {{/if}}
+                </div>
             </li>
         {{/each}}
     </ul>
@@ -124,7 +154,22 @@
                         {{timeago last_update}}
                     </span>
                 </div>
-                <span class="clearfix"></span>
+                <div class="clearfix activity-details">
+                    {{#is_before last_comment.date last_commit.date}}
+                        <div class="new-commit one-line">
+                            <i class="icon icon-circle" />
+                            New commit: <a href="{{last_commit.diff}}">{{last_commit.message}}</a>
+                        </div>
+                    {{/is_before}}
+                    {{#if last_comment}}
+                        <div class="last-comment one-line">
+                            <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}#issuecomment-{{last_comment.id}}">
+                                <i class="icon icon-bubbles" />
+                                Last comment by {{last_comment.user}}
+                            </a>
+                       </div>
+                    {{/if}}
+                </div>
             </li>
         {{/each}}
     </ul>

--- a/src/templates/dev_pipeline.handlebars
+++ b/src/templates/dev_pipeline.handlebars
@@ -22,7 +22,8 @@
                         {{timeago last_update}}
                     </span>
                 </div>
-                <div class="clearfix activity-details">
+                <span class="clearfix"></span>
+                <div class="activity-details hide">
                     {{#is_before last_comment.date last_commit.date}}
                         <div class="new-commit one-line">
                             <i class="icon icon-circle" />
@@ -66,7 +67,8 @@
                         {{timeago last_update}}
                     </span>
                 </div>
-                <div class="clearfix activity-details">
+                <span class="clearfix"></span>
+                <div class="activity-details hide">
                     {{#is_before last_comment.date last_commit.date}}
                         <div class="new-commit one-line">
                             <i class="icon icon-circle" />
@@ -110,7 +112,8 @@
                         {{timeago last_update}}
                     </span>
                 </div>
-                <div class="clearfix activity-details">
+                <span class="clearfix"></span>
+                <div class="activity-details hide">
                     {{#is_before last_comment.date last_commit.date}}
                         <div class="new-commit one-line">
                             <i class="icon icon-circle" />
@@ -154,7 +157,8 @@
                         {{timeago last_update}}
                     </span>
                 </div>
-                <div class="clearfix activity-details">
+                <span class="clearfix"></span>
+                <div class="activity-details hide">
                     {{#is_before last_comment.date last_commit.date}}
                         <div class="new-commit one-line">
                             <i class="icon icon-circle" />

--- a/templates/instantanswer/dev_pipeline.tx
+++ b/templates/instantanswer/dev_pipeline.tx
@@ -71,8 +71,14 @@
         </span>
     </div>
 
+    <span class="clearfix"></span>
+    <div class="toggle-details left">
+        <i class="icon-check-empty"></i>
+        Show activity details
+    </div>
+
     <: if $logged_in { :>
-        <div class="filter-team">
+        <div class="filter-team left">
             <i class="filter-team__checkbox icon-check-empty" id="filter-team_checkbox"></i>
             <span class="filter-team__span">
                 Show IAs of which I am the 
@@ -90,6 +96,5 @@
     <: } :>
 </div>
 
-<div id="dev_pipeline">
-    
+<div id="dev_pipeline" class="clearfix">
 </div>


### PR DESCRIPTION
Last comment is always shown, while last commit is only displayed if the user committed after the last comment was written.
Example: a staff member leaves a comment highlighting a bug in the PR, then the user fixes it, commits the changes and doesn't write a comment afterwards - in that case we show both the last commit and the last comment.

**"Show activity details" is checked**
![screenshot-maria duckduckgo com 5001 2015-09-09 22-38-14](https://cloud.githubusercontent.com/assets/3652195/9773597/82152526-5743-11e5-9f41-7ed8d7f5ff7b.png)

**These have the last commit**
![screenshot-maria duckduckgo com 5001 2015-09-09 22-39-34](https://cloud.githubusercontent.com/assets/3652195/9773643/bdc8403a-5743-11e5-9059-4eef465e9d7c.png)

**"Show activity details" is unchecked**
![screenshot-maria duckduckgo com 5001 2015-09-09 22-38-39](https://cloud.githubusercontent.com/assets/3652195/9773607/8f13144a-5743-11e5-9fa2-7f6b0feb40b5.png)
