### PR TITLE
IA Pages - add ability to ghost pages

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -7,7 +7,9 @@ use Time::Local;
 use JSON;
 use Net::GitHub::V3;
 use DateTime;
+use DDGC;
 
+my $ddgc = DDGC->new;
 my $INST = DDGC::Config->new->appdir_path."/root/static/js";
 
 BEGIN {extends 'Catalyst::Controller'; }
@@ -797,6 +799,11 @@ sub save_edit :Chained('base') :PathPart('save') :Args(0) {
                     $c->stash->{x}->{result}->{msg} = $msg;
                     return $c->forward($c->view('JSON'));
                 }
+            } elsif ($field eq "dev_milestone" && $value eq "ghosted") {
+                # by changing the meta_id we allow the former one to be used again for
+                # other IA Pages
+                my $new_meta_id = $ia->meta_id . "_ghosted_" . $ddgc->uuid->create_str;
+                my $meta_id_edit = add_edit($c, $ia, "meta_id", $new_meta_id);
             } elsif ($field eq "src_id") {
                 if ($c->d->rs('InstantAnswer')->find({src_id => $value})) {
                     $msg = "ID already in use";

--- a/src/js/ia/IADeprecated.js
+++ b/src/js/ia/IADeprecated.js
@@ -13,9 +13,13 @@
 
             $.getJSON(url, function(data) { 
                 // console.log(window.location.pathname);
-                var ia_deprecated;
-                ia_deprecated = Handlebars.templates.dev_pipeline_deprecated(data.repos);
+                var ia_deprecated = Handlebars.templates.dev_pipeline_deprecated(data.deprecated);
                 $("#deprecated").html(ia_deprecated);
+
+                if (data.ghosted) {
+                    var ia_ghosted = Handlebars.templates.dev_pipeline_deprecated(data.ghosted);
+                    $("#ghosted").html(ia_ghosted);
+                }
             });
         }
     };

--- a/src/js/ia/IADeprecated.js
+++ b/src/js/ia/IADeprecated.js
@@ -21,6 +21,12 @@
                     $("#ghosted").html(ia_ghosted);
                 }
             });
+
+            $(".toggle-ghosted").click(function() {
+                $(this).children("i").toggleClass("icon-check-empty");
+                $(this).children("i").toggleClass("icon-check");
+                $("#ghosted").toggleClass("hide");
+            });
         }
     };
 })(DDH);

--- a/src/scss/ia/_deprecated.scss
+++ b/src/scss/ia/_deprecated.scss
@@ -8,4 +8,5 @@
     .repo-none { padding-left: 0; }
 }
 
+#ghosted, #ghosted .dev_pipeline-column__list li a { color: $grey-light; }
 

--- a/src/scss/ia/_deprecated.scss
+++ b/src/scss/ia/_deprecated.scss
@@ -1,0 +1,11 @@
+#deprecated, #ghosted {
+    .dev_pipeline-column {
+        width: 15.5%;
+        text-align: left;
+        padding: 1em;
+    }
+
+    .repo-none { padding-left: 0; }
+}
+
+

--- a/src/scss/ia/_ia.scss
+++ b/src/scss/ia/_ia.scss
@@ -1184,52 +1184,7 @@ input.not_saved, select.not_saved, .button.not_saved {
 
 .ia-single .dev_milestone-container__body__complete {
     margin-top: 1em;
-}
-
-#deprecated .dev_pipeline-column {
-    width: 21%;
-    text-align: left;
-    padding: 0 1em;
-}
-
-#dev_pipeline .dev_pipeline-column:not(#pipeline-planning),
-#deprecated .dev_pipeline-column:not(#pipeline-fathead){
-    margin-left: 0.5em;
-}
-
-#dev_pipeline .dev_pipeline-column__title,
-#deprecated .dev_pipeline-column__title {
-    font-weight: 600;
-    font-size: 1.87em;
-}
-
-#dev_pipeline .dev_pipeline-column__list li,
-#deprecated .dev_pipeline-column__list li {
-    list-style: none;
-    padding: 0.3em 0;
-    font-size: 1.1em;
-    border-bottom: 1px solid #cdcdcd;
-}
-
-#dev_pipeline .dev_pipeline-column__list li a,
-#deprecated  .dev_pipeline-column__list li a {
-    color: #333;
-}
-
-#dev_pipeline .dev_pipeline-column__list li .item-name,
-#deprecated .dev_pipeline-column__list li .item-name {
-    max-width: 9em;
-}
-
-#dev_pipeline .dev_pipeline-column__list .ia-item--stamp,
-#deprecated .dev_pipeline-column__list .ia-item--stamp {
-    width: 20px;
-    height: 20px;
-    position: inherit;
-    font-size: 0.8em;
-}
-
-#dev_pipeline #pipeline-planning, #deprecated #pipeline-fathead { padding-left: 0; }
+}#dev_pipeline #pipeline-planning, #deprecated #pipeline-fathead { padding-left: 0; }
 
 #pipeline-live-container {
     width: 70%;

--- a/src/scss/ia/_pipeline.scss
+++ b/src/scss/ia/_pipeline.scss
@@ -34,3 +34,32 @@
     }
 }
 
+.dev_pipeline-column:not(#pipeline-planning) {
+    margin-left: 0.5em;
+}
+
+.dev_pipeline-column__title {
+    font-weight: 600;
+    font-size: 1.87em;
+}
+
+.dev_pipeline-column__list {
+    li {
+        list-style: none;
+        padding: 0.3em 0;
+        font-size: 1.1em;
+        border-bottom: 1px solid #cdcdcd;
+
+        a { color: #333; }
+
+        .item-name { max-width: 9em; }
+    }
+
+    .ia-item--stamp {
+        width: 20px;
+        height: 20px;
+        position: inherit;
+        font-size: 0.8em;
+    }
+}
+

--- a/src/scss/ia/main.scss
+++ b/src/scss/ia/main.scss
@@ -25,3 +25,4 @@
 @import "live";
 @import "overview";
 @import "pipeline";
+@import "deprecated";

--- a/src/templates/dev_pipeline_deprecated.handlebars
+++ b/src/templates/dev_pipeline_deprecated.handlebars
@@ -1,3 +1,17 @@
+<div class="dev_pipeline-column left" id="pipeline-none">
+    <h2 class="dev_pipeline-column__title">
+        None
+    </h2>
+
+    <ul class="dev_pipeline-column__list" id="pipeline-none__list">
+        {{#each none}}
+            <li id="pipeline-planning__list__{{id}}" class="producer-{{producer}} designer-{{designer}} {{#each developer}}developer-{{name}} {{/each}}">
+                <a href="/ia/view/{{id}}">{{name}}</a>
+            </li>
+        {{/each}}
+    </ul>
+</div>
+
 <div class="dev_pipeline-column left" id="pipeline-fathead">
     <h2 class="dev_pipeline-column__title">
         Fathead

--- a/src/templates/dev_pipeline_deprecated.handlebars
+++ b/src/templates/dev_pipeline_deprecated.handlebars
@@ -1,69 +1,69 @@
-<div class="dev_pipeline-column left" id="pipeline-none">
+<div class="dev_pipeline-column repo-none left">
     <h2 class="dev_pipeline-column__title">
         None
     </h2>
 
-    <ul class="dev_pipeline-column__list" id="pipeline-none__list">
+    <ul class="dev_pipeline-column__list" >
         {{#each none}}
-            <li id="pipeline-planning__list__{{id}}" class="producer-{{producer}} designer-{{designer}} {{#each developer}}developer-{{name}} {{/each}}">
+            <li >
                 <a href="/ia/view/{{id}}">{{name}}</a>
             </li>
         {{/each}}
     </ul>
 </div>
 
-<div class="dev_pipeline-column left" id="pipeline-fathead">
+<div class="dev_pipeline-column repo-fathead left" >
     <h2 class="dev_pipeline-column__title">
         Fathead
     </h2>
 
-    <ul class="dev_pipeline-column__list" id="pipeline-fathead__list">
+    <ul class="dev_pipeline-column__list" >
         {{#each fathead}}
-            <li id="pipeline-planning__list__{{id}}" class="producer-{{producer}} designer-{{designer}} {{#each developer}}developer-{{name}} {{/each}}">
+            <li >
                 <a href="/ia/view/{{id}}">{{name}}</a>
             </li>
         {{/each}}
     </ul>
 </div>
 
-<div class="dev_pipeline-column left" id="pipeline-goodies">
+<div class="dev_pipeline-column repo-goodies left" >
     <h2 class="dev_pipeline-column__title">
         Goodies
     </h2>
 
 
-    <ul class="dev_pipeline-column__list" id="pipeline-goodies__list">
+    <ul class="dev_pipeline-column__list" >
         {{#each goodies}}
-            <li id="pipeline-in_development__list__{{id}}" class="producer-{{producer}} designer-{{designer}} {{#each developer}}developer-{{name}} {{/each}}">
+            <li >
                 <a href="/ia/view/{{id}}">{{name}}</a>
             </li>
         {{/each}}
     </ul>
 </div>
 
-<div class="dev_pipeline-column left" id="pipeline-longtail">
+<div class="dev_pipeline-column repo-longtail left" >
     <h2 class="dev_pipeline-column__title">
         Longtail
     </h2>
 
 
-    <ul class="dev_pipeline-column__list" id="pipeline-longtail__list">
+    <ul class="dev_pipeline-column__list" >
         {{#each longtail}}
-            <li id="pipeline-qa__list__{{id}}" class="producer-{{producer}} designer-{{designer}} {{#each developer}}developer-{{name}} {{/each}}">
+            <li >
                 <a href="/ia/view/{{id}}">{{name}}</a>
             </li>
         {{/each}}
     </ul>
 </div>
 
-<div class="dev_pipeline-column left" id="pipeline-spice">
+<div class="dev_pipeline-column repo-spice left" >
     <h2 class="dev_pipeline-column__title">
         Spice
     </h2>
 
-    <ul class="dev_pipeline-column__list" id="pipeline-spice__list">
+    <ul class="dev_pipeline-column__list" >
         {{#each spice}}
-            <li id="pipeline-qa__list__{{id}}" class="producer-{{producer}} designer-{{designer}} {{#each developer}}developer-{{name}} {{/each}}">
+            <li >
                 <a href="/ia/view/{{id}}">{{name}}</a>
             </li>
         {{/each}}

--- a/src/templates/edit_dev_milestone.handlebars
+++ b/src/templates/edit_dev_milestone.handlebars
@@ -10,6 +10,7 @@
                     <option value="4">complete</option>
                     <option value="5">live</option>
                     <option value="6">deprecated</option>
+                    <option value="7">ghosted</option>
                 </select>
             </span>
         </div>

--- a/src/templates/test.handlebars
+++ b/src/templates/test.handlebars
@@ -1,4 +1,4 @@
-{{#ne_and dev_milestone 'live' 'deprecated'}}
+{{#ne_and dev_milestone 'live' 'deprecated'}}{{#not_eq dev_milestone 'ghosted'}}
     {{#ne_and dev_milestone 'planning' 'development'}}
         <div class="ia-single--testing {{#ne_and dev_milestone 'live' 'deprecated'}}wicked-border{{/ne_and}}">
             <h3 class="ia-single--header">Testing</h3>
@@ -61,4 +61,5 @@
             </div>
         </div>
     {{/ne_and}}
+    {{/not_eq}}
 {{/ne_and}}

--- a/src/templates/top_details.handlebars
+++ b/src/templates/top_details.handlebars
@@ -140,6 +140,7 @@
                                 {{#not_eq dev_milestone 'testing'}}<option value="3">testing</option>{{/not_eq}}
                                 {{#not_eq dev_milestone 'complete'}}<option value="4">complete</option>{{/not_eq}}
                                 {{#not_eq dev_milestone 'live'}}<option value="5">live</option>{{/not_eq}}
+                                {{#not_eq dev_milestone 'ghosted'}}<option value="6">ghosted</option>{{/not_eq}}
                               </select>
                             </span>
                         {{/with}}
@@ -152,6 +153,7 @@
                                 {{#not_eq dev_milestone 'testing'}}<option value="3">testing</option>{{/not_eq}}
                                 {{#not_eq dev_milestone 'complete'}}<option value="4">complete</option>{{/not_eq}}
                                 {{#not_eq dev_milestone 'live'}}<option value="5">live</option>{{/not_eq}}
+                                {{#not_eq dev_milestone 'ghosted'}}<option value="6">ghosted</option>{{/not_eq}}
                             </select>
                         </span>
                     {{/exists_subkey}}

--- a/templates/instantanswer/deprecated.tx
+++ b/templates/instantanswer/deprecated.tx
@@ -15,7 +15,20 @@
             </a>
         </span>
     </div>
+
+    <: if $is_admin { :>
+        <span class="clearfix"></span>
+        <div class="toggle-ghosted left">
+            <i class="icon-check-empty"></i>
+            Show ghosted pages
+        </div>
+    <: } :>
 </div>
 
-<div id="deprecated">
+<: if $is_admin { :>
+    <div id="ghosted" class="clearfix">
+    </div>
+<: } :>
+
+<div id="deprecated" class="clearfix">
 </div>

--- a/templates/instantanswer/deprecated.tx
+++ b/templates/instantanswer/deprecated.tx
@@ -26,7 +26,7 @@
 </div>
 
 <: if $is_admin { :>
-    <div id="ghosted" class="clearfix">
+    <div id="ghosted" class="clearfix hide">
     </div>
 <: } :>
 


### PR DESCRIPTION
I'm introducing a new dev milestone: "ghosted".
Pages with this milestone won't be fetched anywhere , except for inside ia/dev/deprecated, where you will be able to see them if you're an admin - just click on the "Show ghosted pages" checkbox on top. 
This is a temporary solution, since ghosted pages should be on a separate admin page.

TODO: change meta_id when the page is ghosted