### PR TITLE
IA Pages - reload page when dev milestone is changed to 'ghosted'

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -832,6 +832,10 @@ sub save_edit :Chained('base') :PathPart('save') :Args(0) {
                 
                 if ($field eq "dev_milestone" && $value eq "ghosted" && $new_meta_id) {
                     push(@update, {value => $new_meta_id, field => "meta_id"} );
+                    # we send only the meta_id field and value in the response to the front-end
+                    # so the page will be reloaded using the new meta_id
+                    $field = "id";
+                    $value = $new_meta_id;
                 }
                 
                 save($c, \@update, $ia);

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1364,7 +1364,7 @@
                                 if (data.result.saved) {
                                     if (field === "dev_milestone" && data.result[field] === "live") {
                                         location.reload();
-                                    } else if (field === "id") {
+                                    } else if (field === "id" || data.result.id) {
                                         location.href = "/ia/view/" + data.result.id;
                                     } else {
                                         ia_data.live[field] = (is_json && data.result[field])? $.parseJSON(data.result[field]) : data.result[field];


### PR DESCRIPTION
Since the meta_id is updated, so there's no need to go check out the Deprecate page to know the new URL.