### PR TITLE
Set Cache-Control more selectively.

### DIFF
--- a/lib/DDGC/Web.pm
+++ b/lib/DDGC/Web.pm
@@ -316,7 +316,10 @@ sub ddgcr_post {
 	return $res;
 }
 
-
+sub nocache {
+	my ( $c ) = @_;
+	$c->response->header('Cache-Control' => 'no-cache, max-age=0, must-revalidate, no-store');
+}
 
 # Start the application
 __PACKAGE__->setup();

--- a/lib/DDGC/Web/Controller/Admin.pm
+++ b/lib/DDGC/Web/Controller/Admin.pm
@@ -10,6 +10,7 @@ BEGIN {extends 'Catalyst::Controller'; }
 
 sub base :Chained('/base') :PathPart('admin') :CaptureArgs(0) {
     my ( $self, $c ) = @_;
+	$c->nocache;
 	if (!$c->user) {
 		$c->response->redirect($c->chained_uri('My','login',{ admin_required => 1 }));
 		return $c->detach;

--- a/lib/DDGC/Web/Controller/Forum/Admin.pm
+++ b/lib/DDGC/Web/Controller/Forum/Admin.pm
@@ -6,6 +6,7 @@ BEGIN { extends 'Catalyst::Controller'; }
 
 sub base : Chained('/forum/base') PathPart('admin') CaptureArgs(0) {
   my ( $self, $c ) = @_;
+  $c->nocache;
   if (!$c->user) {
     $c->response->redirect($c->chained_uri('My','login'));
     return $c->detach;

--- a/lib/DDGC/Web/Controller/My.pm
+++ b/lib/DDGC/Web/Controller/My.pm
@@ -15,6 +15,7 @@ BEGIN {extends 'Catalyst::Controller'; }
 sub base :Chained('/base') :PathPart('my') :CaptureArgs(0) {
 	my ( $self, $c ) = @_;
 	$c->stash->{page_class} = "page-account";
+	$c->nocache;
 }
 
 sub logout :Chained('base') :Args(0) {

--- a/lib/DDGC/Web/Controller/Root.pm
+++ b/lib/DDGC/Web/Controller/Root.pm
@@ -25,7 +25,6 @@ sub base :Chained('/') :PathPart('') :CaptureArgs(0) {
 	}
 
 	if ($c->user) {
-		$c->response->header('Cache-Control' => 'no-cache, max-age=0, must-revalidate, no-store');
 		$c->d->current_user($c->user);
 
 		if (


### PR DESCRIPTION
Setting no-cache in the root route handler (applying it to all requests) causes various annoyances and breakages. Let's stop doing it.