### PR TITLE
Finishing Last-Modified implimentation

### DIFF
--- a/lib/DDGC/DB/Base/ResultSet.pm
+++ b/lib/DDGC/DB/Base/ResultSet.pm
@@ -3,6 +3,9 @@ package DDGC::DB::Base::ResultSet;
 
 use Moose;
 use namespace::autoclean;
+use DateTime;
+use DateTime::Format::Pg;
+use Try::Tiny;
 
 extends 'DBIx::Class::ResultSet';
 
@@ -50,6 +53,20 @@ sub all_ref {
 sub join_for_activity_meta {
   my ( $self, $column ) = @_;
   join( '', map { sprintf ':%s:', $_ } $self->columns( [$column] )->all );
+}
+
+sub last_modified {
+  my ( $self ) = @_;
+  my $last_modified;
+
+  try {
+    $last_modified = $self->get_column('updated')->max;
+    return DateTime::Format::Pg->parse_datetime(
+      $last_modified
+    )->truncate( to => 'second' ) if $last_modified;
+  };
+
+  return $last_modified || DateTime->new( year => 1970 );
 }
 
 1;

--- a/lib/DDGC/DB/Base/ResultSet.pm
+++ b/lib/DDGC/DB/Base/ResultSet.pm
@@ -60,13 +60,12 @@ sub last_modified {
   my $last_modified;
 
   try {
-    $last_modified = $self->get_column('updated')->max;
-    return DateTime::Format::Pg->parse_datetime(
-      $last_modified
-    )->truncate( to => 'second' ) if $last_modified;
+    $last_modified = DateTime::Format::Pg->parse_datetime(
+      $self->get_column('updated')->max
+    )->truncate( to => 'second' );
   };
 
-  return $last_modified || DateTime->new( year => 1970 );
+  return $last_modified // DateTime->new( year => 1970 );
 }
 
 1;

--- a/lib/DDGC/DB/ResultSet/InstantAnswer.pm
+++ b/lib/DDGC/DB/ResultSet/InstantAnswer.pm
@@ -4,17 +4,5 @@ package DDGC::DB::ResultSet::InstantAnswer;
 use Moose;
 extends 'DDGC::DB::Base::ResultSet';
 use namespace::autoclean;
-use DateTime;
-use DateTime::Format::Pg;
-
-sub last_modified {
-    my ( $self ) = @_;
-    my $last_modified = $self->get_column('updated')->max;
-    return DateTime::Format::Pg->parse_datetime(
-        $last_modified
-    )->truncate( to => 'second' ) if $last_modified;
-
-    return DateTime->new( year => 1970 );
-}
 
 1;

--- a/lib/DDGC/Web.pm
+++ b/lib/DDGC/Web.pm
@@ -323,10 +323,7 @@ sub return_if_not_modified {
 	my ( $c, $dt ) = @_;
 	$dt->set_formatter( 'DateTime::Format::HTTP' ) if $dt;
 	my $if_modified_since = $c->req->header('If-Modified-Since');
-
-	$if_modified_since = DateTime::Format::HTTP->parse_datetime(
-		$if_modified_since,
-	)->truncate( to => 'second' ) if $if_modified_since;
+	$if_modified_since =~ s/;.*$//;
 
 	$c->response->header(
 		'Last-Modified' => "$dt",

--- a/lib/DDGC/Web.pm
+++ b/lib/DDGC/Web.pm
@@ -329,7 +329,9 @@ sub return_if_not_modified {
 		'Last-Modified' => "$dt",
 	);
 	if ( ( $if_modified_since && $dt ) &&
-		 DateTime->compare( $if_modified_since, $dt ) >= 0 ) {
+		DateTime->compare( $if_modified_since, $dt ) >= 0 ) {
+		$c->response->headers->remove_header($_)
+		    for ( qw/ Content-Type Content-Length Content-Disposition / );
 		$c->response->status('304');
 		return $c->detach;
 	}

--- a/lib/DDGC/Web.pm
+++ b/lib/DDGC/Web.pm
@@ -36,6 +36,9 @@ use DDGC::Web::Table;
 
 use namespace::autoclean;
 
+use DateTime;
+use DateTime::Format::HTTP;
+
 our $VERSION ||= '0.0development';
 
 __PACKAGE__->config(
@@ -328,8 +331,8 @@ sub return_if_not_modified {
 	$c->response->header(
 		'Last-Modified' => "$dt",
 	);
-	if ( ( $if_modified_since && $dt ) &&
-		DateTime->compare( $if_modified_since, $dt ) >= 0 ) {
+
+	if ( $if_modified_since eq "$dt" ) {
 		$c->response->headers->remove_header($_)
 		    for ( qw/ Content-Type Content-Length Content-Disposition / );
 		$c->response->status('304');

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -7,7 +7,6 @@ use Time::Local;
 use JSON;
 use Net::GitHub::V3;
 use DateTime;
-use DateTime::Format::HTTP;
 
 my $INST = DDGC::Config->new->appdir_path."/root/static/js";
 
@@ -57,7 +56,7 @@ sub ialist_json :Chained('base') :PathPart('json') :Args() {
 
     my $rs = $c->d->rs('InstantAnswer');
 
-    $self->return_if_not_modified( $c, $rs->last_modified );
+    $c->return_if_not_modified( $rs->last_modified );
 
     my @ial = $rs->search(
         {'topic.name' => [{ '!=' => 'test' }, { '=' => undef}],
@@ -95,7 +94,7 @@ sub iarepo_json :Chained('iarepo') :PathPart('json') :Args(0) {
         {dev_milestone => 'complete'}]
     });
 
-    $self->return_if_not_modified( $c, $iarepo->last_modified );
+    $c->return_if_not_modified( $iarepo->last_modified );
 
     $iarepo = $iarepo->prefetch( { instant_answer_topics => 'topic' });
     my %iah;
@@ -577,7 +576,7 @@ sub ia_base :Chained('base') :PathPart('view') :CaptureArgs(1) {  # /ia/view/cal
 sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
     my ( $self, $c) = @_;
 
-    $self->return_if_not_modified( $c, $c->stash->{ia}->updated );
+    $c->return_if_not_modified( $c->stash->{ia}->updated );
 
     my $ia = $c->stash->{ia};
     my $edited;


### PR DESCRIPTION
I refactored this a little and fleshed it out, since I think it could be generally very useful. Ideally we could use something like [`Plack::Middleware::ConditionalGET`](https://metacpan.org/pod/Plack::Middleware::ConditionalGET) but since that only gets applied after our processing, we wouldn't get a huge time gain (just bandwidth) - processes would still manipulate the data, we just wouldn't send the result. Changes:

- `If-Modified-Since` test and header generation moved out to base controller class
- `->last_modified` moved out to base resultset class (this won't crash if the table has no updated column, but won't be accurate either - apply with care)
- Removing Content-Type etc. headers in 304 response
- Use string equality for if-modified test, since it's basically a tag and not a temporal consideration.
- Fix for IE (via `Plack::Middleware::ConditionalGET`)

This comes into its own alongside #948.

To use it, add it to your controller once you know which result or resultset class you're going to process like so:

```perl
$c->return_if_not_modified( $result->updated );
```

...or...

```perl
$c->return_if_not_modified( $resultset->last_updated );
```