### PR TITLE
Fixing 'Edit' button issue on IA Pages

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -576,8 +576,6 @@ sub ia_base :Chained('base') :PathPart('view') :CaptureArgs(1) {  # /ia/view/cal
 sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
     my ( $self, $c) = @_;
 
-    $c->return_if_not_modified( $c->stash->{ia}->updated );
-
     my $ia = $c->stash->{ia};
     my $edited;
     my @issues = $c->d->rs('InstantAnswer::Issues')->search({instant_answer_id => $ia->id},{order_by => {'-desc' => 'date'}});


### PR DESCRIPTION
@MariagraziaAlastra @jdorweiler @mrshu @russellholt 

Seems this is related to returning 304 for the "logged out" version of this JSON after you've logged in. Given this data is dynamic and user-sensitive AND doesn't get slurped in automated tasks I've just removed the header handling for this route.

Steps to reproduce on live currently:

- When logged out...
- Visit an IA Page (Private browser window should re-fetch JSON and set Last-Modified)
- Log in

You should have no 'Edit' controls until you hard-refresh. This change should fix that.