### PR TITLE
Dev Pipeline - minor cosmetic changes

### DIFF
--- a/src/js/ia/Helpers.js
+++ b/src/js/ia/Helpers.js
@@ -9,13 +9,7 @@
             date = moment.utc(date, "YYYY-MM-DD");
             
             var elapsed = parseInt(moment().diff(date, "days", true));
-            if (elapsed === 1) {
-                date = elapsed + " day";
-            } else if (!elapsed) {
-                date = "today";
-            } else {
-                date = elapsed + " days";
-            }
+            date = elapsed + "d";
 
             return date;
         }

--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -34,6 +34,11 @@
                 $("#pipeline-stats").html(stats);
                 $("#dev_pipeline").html(iadp);
 
+                if ($.trim($("#select-action option:selected").text()) === "type") {
+                    $("#select-milestone").addClass("hide");
+                    $("#select-type").removeClass("hide");
+                }
+
                 appendTeam(data.dev_milestones);
 
                 // 100% width

--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -290,10 +290,10 @@
                 var complete_visible = $("#dev_pipeline #pipeline-complete__list .item-name:visible").length;
                 
                 $("#pipeline-stats h1").text(all_visible + " Instant Answers in progress");
-                $("#pipeline-planning h2").text("Planning (" + planning_visible + ")");
-                $("#pipeline-development h2").text("Development (" + development_visible + ")");
-                $("#pipeline-testing h2").text("Testing (" + testing_visible + ")");
-                $("#pipeline-complete h2").text("Complete (" + complete_visible + ")");
+                $("#pipeline-planning .milestone-count").text(planning_visible);
+                $("#pipeline-development .milestone-count").text(development_visible);
+                $("#pipeline-testing .milestone-count").text(testing_visible);
+                $("#pipeline-complete .milestone-count").text(complete_visible);
             }
 
             function save_multiple(ias, field, value) {

--- a/src/templates/dev_pipeline.handlebars
+++ b/src/templates/dev_pipeline.handlebars
@@ -4,7 +4,8 @@
 <div class="dev_pipeline-column quarter g" id="pipeline-planning">
   <div class="dev_pipeline-column--container">
     <h2 class="dev_pipeline-column__title">
-        Planning ({{length planning}})
+        <span class="left">Planning </span> <span class="milestone-count right">{{length planning}}</span>
+        <span class="clearfix"></span>
     </h2>
     <ul class="dev_pipeline-column__list" id="pipeline-planning__list">
         {{#each planning}}
@@ -54,7 +55,8 @@
 <div class="dev_pipeline-column quarter g" id="pipeline-development">
   <div class="dev_pipeline-column--container">
     <h2 class="dev_pipeline-column__title">
-        Development ({{length development}})
+        <span class="left">Development </span> <span class="milestone-count right">{{length development}}</span>
+        <span class="clearfix">
     </h2>
 
     <ul class="dev_pipeline-column__list" id="pipeline-development__list">
@@ -105,7 +107,8 @@
 <div class="dev_pipeline-column quarter g" id="pipeline-testing">
   <div class="dev_pipeline-column--container">
     <h2 class="dev_pipeline-column__title">
-        Testing ({{length testing}})
+        <span class="left">Testing </span> <span class="milestone-count right"> {{length testing}} </span>
+        <span class="clearfix"></span>
     </h2>
 
     <ul class="dev_pipeline-column__list" id="pipeline-testing__list">
@@ -156,7 +159,8 @@
 <div class="dev_pipeline-column quarter g" id="pipeline-complete">
    <div class="dev_pipeline-column--container">
     <h2 class="dev_pipeline-column__title">
-        Complete ({{length complete}})
+        <span class="left">Complete </span> <span class="milestone-count right"> {{length complete}} </span>
+        <span class="clearfix"></span>
     </h2>
 
     <ul class="dev_pipeline-column__list" id="pipeline-complete__list">


### PR DESCRIPTION
- Float the milestone count on the right and get rid of parentheses
- Format the elapsed time differently (e.g. "23d" instead of "23 days", "0d" instead of "today")
- Fix mismatched action options on reload (e.g if type was selected, on reload it's still the first option, but the second dropdown is the milestones one instead of the type one - this change fixes that)
![screenshot-maria duckduckgo com 5001 2015-10-01 18-13-36](https://cloud.githubusercontent.com/assets/3652195/10226586/9e41fcde-6868-11e5-9a5e-ba48d7279156.png)
