### PR TITLE
Developer / IA Notification updates.

### DIFF
--- a/lib/DDGC.pm
+++ b/lib/DDGC.pm
@@ -37,6 +37,7 @@ use Time::Piece;
 use Data::UUID;
 use Digest::MD5 'md5_hex';
 use JSON;
+use URI;
 use namespace::autoclean;
 
 our $VERSION ||= '0.000';
@@ -102,6 +103,18 @@ has uuid => (
 );
 sub _build_uuid { Data::UUID->new };
 sub uid { md5_hex $_[0]->uuid->create_str . rand };
+
+sub uri_for {
+	my ( $self, $part, $params ) = @_;
+	my $uri = URI->new( $self->config->web_base );
+
+	$part =~ s{^/*}{/};
+	$uri->path("$part");
+
+	$uri->query_form($params) if $params;
+
+	return ${ $uri->canonical };
+}
 
 ############################################################
 #  ____        _    ____            _

--- a/lib/DDGC/Config.pm
+++ b/lib/DDGC/Config.pm
@@ -72,7 +72,11 @@ sub rootdir {
 	return File::Spec->rel2abs( $dir );
 }
 
-has_conf web_base => DDGC_WEB_BASE => 'https://duck.co';
+has_conf web_base => DDGC_WEB_BASE => sub {
+	( $_[0]->is_live )
+		? 'https://duck.co'
+		: 'https://view.dukgo.com';
+};
 
 sub prosody_db_samplefile { File::Spec->rel2abs( File::Spec->catfile( dist_dir('DDGC'), 'ddgc.prosody.sqlite' ) ) }
 sub duckpan_cdh_template { File::Spec->rel2abs( File::Spec->catfile( dist_dir('DDGC'), 'perldoc', 'duckpan.html' ) ) }

--- a/lib/DDGC/DB/Result/InstantAnswer.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer.pm
@@ -12,6 +12,13 @@ use JSON;
 table 'instant_answer';
 
 sub u { [ 'InstantAnswer', 'view', $_[0]->id ] }
+sub uri {
+    my ( $self, $params ) = @_;
+    $self->ddgc->uri_for(
+        sprintf( '/ia/view/%s', $self->meta_id ),
+        $params
+    );
+}
 
 column id => {
 	data_type => 'text',

--- a/lib/DDGC/DB/Result/InstantAnswer.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer.pm
@@ -446,12 +446,12 @@ after insert => sub {
 
 sub create_update_activity {
     my ( $self, $meta3, $description ) = @_;
-    $self->result_source->schema->resultset('ActivityFeed')->updated_ia(
+    $self->result_source->schema->resultset('ActivityFeed')->updated_ia( {
         meta1        => $self->id,
         meta2        => $self->topics->join_for_activity_meta( 'name' ),
         meta3        => $meta3,
         description  => $description,
-    );
+    } );
 }
 
 sub _generate_updates {

--- a/lib/DDGC/DB/Result/InstantAnswer.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer.pm
@@ -440,8 +440,7 @@ after insert => sub {
         meta2        => join('', map { sprintf ':%s:', $_ }
             $self->topics->columns([qw/ name /])->all),
         description  => sprintf('Instant Answer Page [%s](%s) created!',
-            $self->name, sprintf('https://duck.co/ia/view/%s',
-                $self->meta_id)),
+            $self->name, $self->uri( { activity_feed => 1 } ) ),
     } );
 };
 

--- a/lib/DDGC/DB/Result/InstantAnswer.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer.pm
@@ -464,10 +464,10 @@ sub _generate_updates {
                 $column,
                 sprintf( 'Instant Answer [%s](%s) dev milestone changed to %s',
                     $self->name,
-                    $self->uri( { activity_feed => 1 } )
+                    $self->uri( { activity_feed => 1 } ),
                     $value
                 ),
-            )
+            );
         }
 
     }

--- a/lib/DDGC/DB/Result/InstantAnswer.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer.pm
@@ -446,14 +446,11 @@ around update => sub {
     return $ret if (!$ret);
     return $ret if $ENV{DDGC_IA_AUTOUPDATES};
 
-    my $meta3 = _updates_to_meta( $extra[0] );
-
     if ($meta3) {
         my $schema = $self->result_source->schema;
         $schema->resultset('ActivityFeed')->updated_ia( {
             meta1        => $self->id,
             meta2        => $self->topics->join_for_activity_meta( 'name' ),
-            meta3        => $meta3,
             description  => sprintf('Instant Answer Page [%s](%s) updated!',
                 $self->name, sprintf('https://duck.co/ia/view/%s',
                     $self->meta_id)),
@@ -462,19 +459,6 @@ around update => sub {
 
     return $ret;
 };
-
-sub _updates_to_meta {
-    my ( $updates ) = @_;
-    my $meta;
-    while ( my ($column, $value) = each $updates ) {
-        # Add updates we are not interested in to this array
-        next if grep { $column eq $_ }
-            (qw/ created_date /);
-        $meta .= sprintf ':%s:',
-            join ',', ( $column, $value );
-    }
-    return $meta;
-}
 
 # returns a hash ref of all IA data.  Same idea as hashRefInflator
 # but this takes care of deserialization for you.

--- a/lib/DDGC/DB/Result/InstantAnswer.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer.pm
@@ -438,6 +438,16 @@ after insert => sub {
     } );
 };
 
+sub create_update_activity {
+    my ( $self, $meta3, $description ) = @_;
+    $self->result_source->schema->resultset('ActivityFeed')->updated_ia(
+        meta1        => $self->id,
+        meta2        => $self->topics->join_for_activity_meta( 'name' ),
+        meta3        => $meta3,
+        description  => $description,
+    );
+}
+
 around update => sub {
     my ( $next, $self, @extra ) = @_;
     my $update = $extra[0];

--- a/lib/DDGC/DB/Result/InstantAnswer.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer.pm
@@ -464,7 +464,7 @@ sub _generate_updates {
                 $column,
                 sprintf( 'Instant Answer [%s](%s) dev milestone changed to %s',
                     $self->name,
-                    $self->uri( { activity_feed => 1 } ),
+                    $self->uri( { from => 'notification' } ),
                     $value
                 ),
             );

--- a/lib/DDGC/Schema/Role/Result/ActivityFeed/AdvancedDescription.pm
+++ b/lib/DDGC/Schema/Role/Result/ActivityFeed/AdvancedDescription.pm
@@ -24,16 +24,4 @@ sub describe {
     return $self->render_description;
 }
 
-sub describe_instant_answer_updated {
-    my ( $self ) = @_;
-    my $updates = { map { split ',', $_, 2 } ( $self->meta3 =~ /:(.*?):/g ) };
-
-    $self->xslate->render(
-        'includes/activity_feed/instant_answer_updated.tx', {
-            activity => $self,
-            updates  => join( ', ', keys $updates ),
-        }
-    );
-}
-
 1;

--- a/script/ddgc_dev_server.sh
+++ b/script/ddgc_dev_server.sh
@@ -4,6 +4,7 @@ SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 PSGI_SCRIPT=$SCRIPTDIR/ddgc_dev_server.psgi
 LIBDIR=$SCRIPTDIR/../lib
 PORT=5001
+HOSTNAME=$(hostname)
 
 [ "$DDGC_UNSUB_KEY" == "" ]          && export DDGC_UNSUB_KEY="asdfasdf"
 [ "$DDGC_SHARED_SECRET" == "" ]      && export DDGC_SHARED_SECRET="asdfasdf"
@@ -57,5 +58,7 @@ if [ "$m" == "1" ] ; then
     # python -m smtpd -n -c DebuggingServer localhost:1025
     export DDGC_SMTP_HOST="localhost:1025"
 fi
+
+export DDGC_WEB_BASE=$( printf 'http://%s:%s' $HOSTNAME $PORT )
 
 plackup -R $LIBDIR -p $PORT -s Starman $PSGI_SCRIPT

--- a/t/activity_feed.t
+++ b/t/activity_feed.t
@@ -151,11 +151,11 @@ ok( $admin_email_body =~ /donuts created/i,
     'admin knows about donuts created' );
 ok( $admin_email_body =~ /bananas created/i,
     'admin knows about bananas created' );
-ok( $admin_email_body =~ /apples updated/i,
-    'admin knows about apples updated' );
-ok( $admin_email_body =~ /pokemon updated/i,
-    'admin knows about pokemon updated' );
-ok( $admin_email_body !~ /bananas updated/i,
+ok( $admin_email_body =~ /apples.*dev milestone changed/i,
+    'admin knows about apples dev milestone update' );
+ok( $admin_email_body =~ /pokemon.*dev milestone changed/i,
+    'admin knows about pokemon dev milestone update' );
+ok( $admin_email_body !~ /bananas.*dev milestone changed/i,
     'admin not subscribed to banana updates' );
 
 my $comleader_delivery = (grep {
@@ -170,12 +170,12 @@ ok( $comleader_email_body =~ /donuts created/i,
     'comleader knows about donuts created' );
 ok( $comleader_email_body =~ /bananas created/i,
     'comleader gets activity for privileged role' );
-ok( $comleader_email_body !~ /apples updated/i,
+ok( $comleader_email_body !~ /apples.*dev milestone changed/i,
     'comleader not subscribed to apples updates' );
-ok( $comleader_email_body !~ /pokemon updated/i,
+ok( $comleader_email_body !~ /pokemon.*dev milestone changed/i,
     'comleader not subscribed to pokemon updates' );
-ok( $comleader_email_body =~ /bananas updated/i,
-    'comleader knows about banana updates' );
+ok( $comleader_email_body =~ /bananas.*dev milestone changed/i,
+    'comleader knows about banana dev milestone update' );
 
 my $user1_delivery = (grep {
     'user1@example.org' eq lc($_->{envelope}->{to}->[0])
@@ -189,9 +189,9 @@ ok( $user1_email_body =~ /donuts created/i,
     'user1 knows about donuts created' );
 ok( $user1_email_body !~ /bananas created/i,
     'user1 not getting created activity for privileged role' );
-ok( $user1_email_body !~ /apples updated/i,
+ok( $user1_email_body !~ /apples.*dev milestone changed/i,
     'user1 not subscribed to apples updates' );
-ok( $user1_email_body =~ /pokemon updated/i,
-    'user1 knows about pokemon updated' );
+ok( $user1_email_body =~ /pokemon.*dev milestone changed/i,
+    'user1 knows about pokemon dev milestone update' );
 
 done_testing;

--- a/views/includes/activity_feed/instant_answer_updated.tx
+++ b/views/includes/activity_feed/instant_answer_updated.tx
@@ -1,7 +1,1 @@
-<p>
     : $activity.render_description | raw
-</p>
-<p>
-    Updated fields :
-    : $updates
-</p>


### PR DESCRIPTION
I meant to push this Friday to start discussing it. Anyway, so far there are a couple of changes here:

- We no longer generate "activity" for every update
- URLs have been "fixed" to use the current host - I found everything being 'duck.co' confusing

Since we don't (that I am aware of) have a ref to the current request there, doing reliable URL stuff from the model is a little funky. This fleshes out the `web_base` config option and adds a wrapper around [`URI`](https://metacpan.org/pod/URI) to generate full URLs for paths and request parameters.

Cc @MariagraziaAlastra 