### PR TITLE
Dev Pipeline - edit fields in the sidebar

### DIFF
--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -255,6 +255,7 @@
                     var meta_id = $item.attr("id").replace("pipeline-list__", "");
                     var milestone = $item.parents(".dev_pipeline-column").attr("id").replace("pipeline-", "");
                     var page_data = getPageData(meta_id, milestone);
+                    page_data.permissions = dev_p.data.permissions;
                     console.log(page_data);
                     if (page_data) {
                         var sidebar = Handlebars.templates.dev_pipeline_detail(page_data);            

--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -145,33 +145,35 @@
             });
 
             $("body").on("click", ".dev_pipeline-column__list li", function(evt) {
-                if (dev_p.data.permissions && dev_p.data.permissions.admin) {
-                    var $items = $(".dev_pipeline-column__list .selected");
-                    var was_selected = $(this).hasClass("selected");
+                var $items = $(".dev_pipeline-column__list .selected");
+                var was_selected = $(this).hasClass("selected");
+                
+                if (evt.shiftKey || was_selected || (!dev_p.data.hasOwnProperty("permissions"))) {
+                    if ((!dev_p.data.hasOwnProperty("permissions"))) {
+                        $(".selected").removeClass("selected");
+                    }
                     
-                    if (evt.shiftKey || was_selected) {
+                    $(this).toggleClass("selected");
+                } else {
+                    $items.toggleClass("selected"); 
+                
+                    if (!was_selected) {
                         $(this).toggleClass("selected");
-                    } else {
-                        $items.toggleClass("selected"); 
-                    
-                        if (!was_selected) {
-                            $(this).toggleClass("selected");
-                        }
                     }
-                    
-                    // can't use caching here since the set of selected IAs changed
-                    // in the meantime
-                    var selected = $(".dev_pipeline-column__list .selected").length;
-                    
-                    if (selected > 1) {
-                        $(".pipeline-actions").removeClass("hide");
-                    } else {
-                        $(".pipeline-actions").addClass("hide");
-                    }
-
-                    appendSidebar(selected);
-                    $(".count-txt").text(selected);
                 }
+                
+                // can't use caching here since the set of selected IAs changed
+                // in the meantime
+                var selected = $(".dev_pipeline-column__list .selected").length;
+                
+                if (selected > 1) {
+                    $(".pipeline-actions").removeClass("hide");
+                } else {
+                    $(".pipeline-actions").addClass("hide");
+                }
+
+                appendSidebar(selected);
+                $(".count-txt").text(selected);
             });
 
             $("body").on("keypress change", ".edit-sidebar", function(evt) {

--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -174,7 +174,25 @@
                 }
             });
 
+            $("body").on("keypress change", ".edit-sidebar", function(evt) {
+                if ((evt.type === "keypress" && evt.which === 13) || (evt.type === "change" && $(this).children("select").length)) {
+                   var field = $(this).attr("id").replace("edit-sidebar-", "");
+                   var value = (evt.type === "change")? $.trim($(this).find("option:selected").text()) : $.trim($(this).val());
+                   var id = $("#page_sidebar").attr("ia_id");
+
+                   autocommit(field, value, id);
+                }
+            });
+
             $("body").on("click", "#sidebar-close, .deselect-all", function(evt) {
+                var $selected = $(".dev_pipeline-column__list .selected");
+                $selected.removeClass("selected");
+                $(".pipeline-actions").addClass("hide");
+                $(".count-txt").text("0");
+
+                // remove sidebar
+                appendSidebar(0);
+                
                 if (dev_p.saved) {
                     var jqxhr = $.getJSON(url, function (data) {
                         dev_p.saved = false;
@@ -185,17 +203,7 @@
 
                         var iadp = Handlebars.templates.dev_pipeline(data);
                         $("#dev_pipeline").html(iadp);
-
-                        // remove sidebar
-                        appendSidebar(0);
                     });
-                } else {
-                    var $selected = $(".dev_pipeline-column__list .selected");
-                    $selected.removeClass("selected");
-                    $(".pipeline-actions").addClass("hide");
-                    $(".count-txt").text("0");
-
-                    appendSidebar(0);
                 }
             });
 
@@ -290,9 +298,11 @@
                         var sidebar = Handlebars.templates.dev_pipeline_detail(page_data);            
                     
                         $("#page_sidebar").html(sidebar).removeClass("hide");
+                        $("#page_sidebar").attr("ia_id", page_data.id);
                     }
                 } else {
                     $("#page_sidebar").addClass("hide").empty();
+                    $("#page_sidebar").attr("ia_id", "");
                 }
             }
 

--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -175,13 +175,28 @@
             });
 
             $("body").on("click", "#sidebar-close, .deselect-all", function(evt) {
-                var $selected = $(".dev_pipeline-column__list .selected");
-                $selected.removeClass("selected");
-                $(".pipeline-actions").addClass("hide");
-                $(".count-txt").text("0");
+                if (dev_p.saved) {
+                    var jqxhr = $.getJSON(url, function (data) {
+                        dev_p.saved = false;
+                        dev_p.data.dev_milestones = data.dev_milestones;
+                    
+                        $(".pipeline-actions").addClass("hide");
+                        $(".count-txt").text("0");
 
-                // remove sidebar
-                appendSidebar(0);
+                        var iadp = Handlebars.templates.dev_pipeline(data);
+                        $("#dev_pipeline").html(iadp);
+
+                        // remove sidebar
+                        appendSidebar(0);
+                    });
+                } else {
+                    var $selected = $(".dev_pipeline-column__list .selected");
+                    $selected.removeClass("selected");
+                    $(".pipeline-actions").addClass("hide");
+                    $(".count-txt").text("0");
+
+                    appendSidebar(0);
+                }
             });
 
             $("body").on("change", "#select-action", function(evt) {
@@ -248,6 +263,20 @@
                     $(".dev_pipeline-column__list li." + teamrole + "-" + username).show();
                 }
             });
+
+            function autocommit(field, value, id) {
+               var jqxhr = $.post("/ia/save", {
+                   field : field,
+                   value : value,
+                   id : id,
+                   autocommit : 1
+               })
+               .done(function(data) {
+                   if (data.result.saved) {
+                       dev_p.saved = true;
+                   }
+               });
+            }
 
             function appendSidebar(selected) {
                 if (selected === 1) {

--- a/src/scss/ia/_pipeline.scss
+++ b/src/scss/ia/_pipeline.scss
@@ -4,47 +4,52 @@
     color: $grey;
 }
 
-#sidebar-name {
+#sidebar-name, #edit-sidebar-name {
     font-size: 1.1em;
     font-weight: 500;
     margin-bottom: 0;
 }
 
-#sidebar-id {
+#sidebar-id, #edit-sidebar-id {
     color: $grey;
 }
+
+.edit-sidebar {
+    border: 0;
+    width: 26em;
+}    
 
 .search-container {
     width: 20%;
 
     .ddgsi-loupe {
-	color: $grey;
-	font-weight: bold;
+        color: $grey;
+        font-weight: bold;
 
-	position: relative;
-	top: 2px;
-	padding-right: 0.5em;
+        position: relative;
+        top: 2px;
+        padding-right: 0.5em;
     }
     
     .search-thing {
-	margin-right: 1em;
-	color: $slate;
-	width: 80%;
-	
-	/* Remove some of the default styles. */
-	border: none;
-	outline: none;
+        margin-right: 1em;
+        color: $slate;
+        width: 80%;
+        
+        /* Remove some of the default styles. */
+        border: none;
+        outline: none;
     }
 
     /* Style the placeholder. */
     .search-thing::-webkit-input-placeholder {
-	opacity: 0.5;
+	    opacity: 0.5;
     }
     .search-thing::-moz-placeholder {
-	opacity: 0.5;
+	    opacity: 0.5;
     }
     .search-thing:-ms-input-placeholder { 
-	opacity: 0.5;
+	    opacity: 0.5;
     }
 }
 
@@ -69,7 +74,7 @@
     position: absolute;
     z-index: 3000;
     right: 0px;
-    top: 15em;
+    top: 16.64em;
     background-color: $white;
     padding: 2em;
     height: 100%;

--- a/src/templates/dev_pipeline_detail.handlebars
+++ b/src/templates/dev_pipeline_detail.handlebars
@@ -3,6 +3,7 @@
     {{#if permissions.admin}}
         <span class="sep--after edit-sidebar" id="edit-sidebar-repo">
             <select>
+                <option value="0">{{repo}}</option>
                 {{#not_eq repo 'fathead'}}<option value="1">fathead</option>{{/not_eq}}
                 {{#not_eq repo 'goodies'}}<option value="2">goodies</option>{{/not_eq}}
                 {{#not_eq repo 'longtail'}}<option value="3">longtail</option>{{/not_eq}}
@@ -12,6 +13,7 @@
 
         <span class="sep--after edit-sidebar" id="edit-sidebar-dev_milestone">
             <select>
+                <option value="0">{{dev_milestone}}</option>
                 {{#not_eq dev_milestone 'planning'}}<option value="1">planning</option>{{/not_eq}}
                 {{#not_eq dev_milestone 'development'}}<option value="2">development</option>{{/not_eq}}
                 {{#not_eq dev_milestone 'testing'}}<option value="3">testing</option>{{/not_eq}}

--- a/src/templates/dev_pipeline_detail.handlebars
+++ b/src/templates/dev_pipeline_detail.handlebars
@@ -36,25 +36,24 @@
 
 {{#if permissions.admin}}
 
-    <div>
+    <h2 id="sidebar-name">
         <input class="edit-sidebar" id="edit-sidebar-name" value="{{name}}" />
+    </h2>
+
+    <input class="edit-sidebar" id="edit-sidebar-id" value="{{id}}" />
+
+    <div class="sidebar-field">
+        <div class="field-label"> Description </div>
+        <textarea rows="3" cols="50" class="edit-sidebar" id="edit-sidebar-description">{{description}}</textarea>
     </div>
 
-    <div>
-        <input class="edit-sidebar" id="edit-sidebar-id" value="{{id}}" />
-    </div>
-
-    <div>
-        <textarea class="edit-sidebar" id="edit-sidebar-description"> 
-            {{description}}
-        </textarea>
-    </div>
-
-    <div>
+    <div class="sidebar-field">
+        <div class="field-label"> Example Query </div>
         <input class="edit-sidebar" id="edit-sidebar-example_query" value="{{example_query}}" />
     </div>
 
-    <div>
+    <div class="sidebar-field">
+        <div class="field-label"> Perl Module </div>
         <input class="edit-sidebar" id="edit-sidebar-perl_module" value="{{perl_module}}" />
     </div>
 {{else}}

--- a/src/templates/dev_pipeline_detail.handlebars
+++ b/src/templates/dev_pipeline_detail.handlebars
@@ -1,43 +1,91 @@
 <div id="sidebar-top" class="clearfix">
   <span class="left">
-    {{#if repo}}
-      <span class="sep--after"> {{repo}} </span>
+    {{#if permissions.admin}}
+        <span class="sep--after edit-sidebar" id="edit-sidebar-repo">
+            <select>
+                {{#not_eq repo 'fathead'}}<option value="1">fathead</option>{{/not_eq}}
+                {{#not_eq repo 'goodies'}}<option value="2">goodies</option>{{/not_eq}}
+                {{#not_eq repo 'longtail'}}<option value="3">longtail</option>{{/not_eq}}
+                {{#not_eq repo 'spice'}}<option value="4">spice</option>{{/not_eq}}
+            </select>
+        </span>
+
+        <span class="sep--after edit-sidebar" id="edit-sidebar-dev_milestone">
+            <select>
+                {{#not_eq dev_milestone 'planning'}}<option value="1">planning</option>{{/not_eq}}
+                {{#not_eq dev_milestone 'development'}}<option value="2">development</option>{{/not_eq}}
+                {{#not_eq dev_milestone 'testing'}}<option value="3">testing</option>{{/not_eq}}
+                {{#not_eq dev_milestone 'complete'}}<option value="4">complete</option>{{/not_eq}}
+                <option value="5">live</option>
+                <option value="6">ghosted</option>
+            </select>
+        </span>
+    {{else}}
+        {{#if repo}}
+            <span class="sep--after"> {{repo}} </span>
+            
+        {{/if}}
+        <span> {{dev_milestone}} </span>
     {{/if}}
-    <span> {{dev_milestone}} </span>
   </span>
 
     <span id="sidebar-close" class="right"> <i class="ddgsi ddgsi-close"></i> </span>
 </div>
 
-{{#if name}}
-  <h2 id="sidebar-name"> {{name}} </h2>
-{{/if}}
+{{#if permissions.admin}}
 
-{{#if id}}
-    <div id="sidebar-id">
-        <span> {{id}} </span>
+    <div>
+        <input class="edit-sidebar" id="edit-sidebar-name" value="{{name}}" />
     </div>
-{{/if}}
 
-{{#if description}}
-    <div id="sidebar-desc" class="sidebar-field">
-        <div class="field-label"> Description </div>
-        <span class="readonly"> {{description}} </span>
+    <div>
+        <input class="edit-sidebar" id="edit-sidebar-id" value="{{id}}" />
     </div>
-{{/if}}
 
-{{#if example_query}}
-    <div id="sidebar-example" class="sidebar-field">
-        <div class="field-label"> Example Query </div>
-        <span class="readonly"> {{example_query}} </span>
+    <div>
+        <textarea class="edit-sidebar" id="edit-sidebar-description"> 
+            {{description}}
+        </textarea>
     </div>
-{{/if}}
 
-{{#if perl_module}}
-    <div id="sidebar-perl_module" class="sidebar-field">
-        <div class="field-label"> Perl Module </div>
-        <span class="readonly"> {{perl_module}} </span>
+    <div>
+        <input class="edit-sidebar" id="edit-sidebar-example_query" value="{{example_query}}" />
     </div>
+
+    <div>
+        <input class="edit-sidebar" id="edit-sidebar-perl_module" value="{{perl_module}}" />
+    </div>
+{{else}}
+    {{#if name}}
+      <h2 id="sidebar-name"> {{name}} </h2>
+    {{/if}}
+
+    {{#if id}}
+        <div id="sidebar-id">
+            <span> {{id}} </span>
+        </div>
+    {{/if}}
+
+    {{#if description}}
+        <div id="sidebar-desc" class="sidebar-field">
+            <div class="field-label"> Description </div>
+            <span class="readonly"> {{description}} </span>
+        </div>
+    {{/if}}
+
+    {{#if example_query}}
+        <div id="sidebar-example" class="sidebar-field">
+            <div class="field-label"> Example Query </div>
+            <span class="readonly"> {{example_query}} </span>
+        </div>
+    {{/if}}
+
+    {{#if perl_module}}
+        <div id="sidebar-perl_module" class="sidebar-field">
+            <div class="field-label"> Perl Module </div>
+            <span class="readonly"> {{perl_module}} </span>
+        </div>
+    {{/if}}
 {{/if}}
 
 {{#if pr}}


### PR DESCRIPTION
If you're an admin, with this change you can edit all the IA fields displayed in the sidebar.
They're saved on return keypress (or on selected option change, for dropdowns), and the Handlebars templates are updated when the sidebar is closed - we fetch again the data from the back-end, so it takes a bunch of seconds to update the view.
![screenshot-maria duckduckgo com 5001 2015-10-08 19-40-41](https://cloud.githubusercontent.com/assets/3652195/10374664/a811271c-6df4-11e5-9093-ac7d4f2e6133.png)
