### PR TITLE
Stop emailing deleted user accounts.

### DIFF
--- a/lib/DDGC.pm
+++ b/lib/DDGC.pm
@@ -709,6 +709,7 @@ sub delete_user {
 			$_->ghosted(1);
 			$_->update({ 'updated' => $_->created });
 		}
+		$user->update({ email_verified => 0 });
 		$guard->commit;
 		($prosody_user_rs) && $prosody_user_rs->delete;
 	}


### PR DESCRIPTION
Prepare the hax klaxon.

Our account management is still inadequate (see #437). This closes a more urgent gap.

Unsetting the email verified flag will prevent mail being sent to the "deleted" user.