### PR TITLE
Dev Pipeline - add .important class to IAs with high priority

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -163,11 +163,12 @@ sub dev_pipeline_json :Chained('dev_pipeline_base') :PathPart('json') :Args(0) {
         $temp_ia = $ia->TO_JSON('pipeline');
         
         my $pr = $c->d->rs('InstantAnswer::Issues')->search({is_pr => 1, instant_answer_id => $ia->id}, {result_class => 'DBIx::Class::ResultClass::HashRefInflator'})->first;
-        $temp_ia->{"pr"} = $pr;
+        $pr->{tags} = $pr->{tags}? from_json($pr->{tags}) : undef;
+        $temp_ia->{pr} = $pr;
 
         if ($c->user && (!$c->user->admin)) {
             my $can_edit = $ia->users->find($c->user->id)? 1 : undef;
-            $temp_ia->{"can_edit"} = $can_edit;
+            $temp_ia->{can_edit} = $can_edit;
         }
         
         push @{$dev_ias{$ia->$key}}, $temp_ia;

--- a/src/templates/dev_pipeline.handlebars
+++ b/src/templates/dev_pipeline.handlebars
@@ -9,7 +9,7 @@
     </h2>
     <ul class="dev_pipeline-column__list" id="pipeline-planning__list">
         {{#each planning}}
-            <li id="pipeline-list__{{id}}" class="{{#if can_edit}}can_edit{{/if}} producer-{{#if producer}}{{slug producer}}{{/if}} designer-{{designer}} {{#if developer}}{{#each developer}}developer-{{slug name}} {{/each}}{{else}}developer-{{/if}}
+            <li id="pipeline-list__{{id}}" class="{{#if pr}}{{#each pr.tags}}{{#eq (slug name) 'priorityhigh'}} important {{/eq}}{{/each}}{{/if}}{{#if can_edit}}can_edit{{/if}} producer-{{#if producer}}{{slug producer}}{{/if}} designer-{{designer}} {{#if developer}}{{#each developer}}developer-{{slug name}} {{/each}}{{else}}developer-{{/if}}
              {{#is_false_array perl_module name repo example_query producer developer}} missing-all {{#unless perl_module}}missing-perl_module{{/unless}} {{#unless name}}missing-name{{/unless}} 
              {{#unless repo}}missing-type{{/unless}} {{#unless example_query}}missing-example_query{{/unless}} {{#unless producer}}missing-producer{{/unless}} {{#unless developer}}missing-developer{{/unless}} {{else}}missing-{{/is_false_array}}">
                 <div class="item-name pipeline__stamp-{{repo}}">
@@ -58,7 +58,7 @@
 
     <ul class="dev_pipeline-column__list" id="pipeline-development__list">
         {{#each development}}
-            <li id="pipeline-list__{{id}}" class="{{#if can_edit}}can_edit{{/if}} producer-{{#if producer}}{{slug producer}}{{/if}} designer-{{designer}} {{#if developer}}{{#each developer}}developer-{{slug name}} {{/each}}{{else}}developer-{{/if}}
+            <li id="pipeline-list__{{id}}" class="{{#if pr}}{{#each pr.tags}}{{#eq (slug name) 'priorityhigh'}} important {{/eq}}{{/each}}{{/if}} {{#if can_edit}}can_edit{{/if}} producer-{{#if producer}}{{slug producer}}{{/if}} designer-{{designer}} {{#if developer}}{{#each developer}}developer-{{slug name}} {{/each}}{{else}}developer-{{/if}}
              {{#is_false_array perl_module name repo example_query producer developer}} missing-all {{#unless perl_module}}missing-perl_module{{/unless}} {{#unless name}}missing-name{{/unless}} 
              {{#unless repo}}missing-type{{/unless}} {{#unless example_query}}missing-example_query{{/unless}} {{#unless producer}}missing-producer{{/unless}} {{#unless developer}}missing-developer{{/unless}} {{else}}missing-{{/is_false_array}}">
                 <div class="item-name pipeline__stamp-{{repo}}">
@@ -107,7 +107,7 @@
 
     <ul class="dev_pipeline-column__list" id="pipeline-testing__list">
         {{#each testing}}
-            <li id="pipeline-list__{{id}}" class="{{#if can_edit}}can_edit{{/if}} producer-{{#if producer}}{{slug producer}}{{/if}} designer-{{designer}} {{#if developer}}{{#each developer}}developer-{{slug name}} {{/each}}{{else}}developer-{{/if}}
+            <li id="pipeline-list__{{id}}" class="{{#if pr}}{{#each pr.tags}}{{#eq (slug name) 'priorityhigh'}} important {{/eq}}{{/each}}{{/if}} {{#if can_edit}}can_edit{{/if}} producer-{{#if producer}}{{slug producer}}{{/if}} designer-{{designer}} {{#if developer}}{{#each developer}}developer-{{slug name}} {{/each}}{{else}}developer-{{/if}}
              {{#is_false_array perl_module name repo example_query producer developer}} missing-all {{#unless perl_module}}missing-perl_module{{/unless}} {{#unless name}}missing-name{{/unless}} 
              {{#unless repo}}missing-type{{/unless}} {{#unless example_query}}missing-example_query{{/unless}} {{#unless producer}}missing-producer{{/unless}} {{#unless developer}}missing-developer{{/unless}} {{else}}missing-{{/is_false_array}}">
                 <div class="item-name pipeline__stamp-{{repo}}">
@@ -156,7 +156,7 @@
 
     <ul class="dev_pipeline-column__list" id="pipeline-complete__list">
         {{#each complete}}
-            <li id="pipeline-list__{{id}}" class="{{#if can_edit}}can_edit{{/if}} producer-{{#if producer}}{{slug producer}}{{/if}} designer-{{designer}} {{#if developer}}{{#each developer}}developer-{{slug name}} {{/each}}{{else}}developer-{{/if}}
+            <li id="pipeline-list__{{id}}" class="{{#if pr}}{{#each pr.tags}}{{#eq (slug name) 'priorityhigh'}} important {{/eq}}{{/each}}{{/if}} {{#if can_edit}}can_edit{{/if}} producer-{{#if producer}}{{slug producer}}{{/if}} designer-{{designer}} {{#if developer}}{{#each developer}}developer-{{slug name}} {{/each}}{{else}}developer-{{/if}}
              {{#is_false_array perl_module name repo example_query producer developer}} missing-all {{#unless perl_module}}missing-perl_module{{/unless}} {{#unless name}}missing-name{{/unless}} 
              {{#unless repo}}missing-type{{/unless}} {{#unless example_query}}missing-example_query{{/unless}} {{#unless producer}}missing-producer{{/unless}} {{#unless developer}}missing-developer{{/unless}} {{else}}missing-{{/is_false_array}}">
                 <div class="item-name pipeline__stamp-{{repo}}">


### PR DESCRIPTION
If the IA's PR has the "priority: high" tag, the IA on the pipeline will get the yellow border on the left:
![screenshot-maria duckduckgo com 5001 2015-10-15 15-53-57](https://cloud.githubusercontent.com/assets/3652195/10515791/664b9496-7355-11e5-957f-36e6b10ff2df.png)
