### PR TITLE
_pipeline.scss: "F" and "L" content should be applied to :before element

### DIFF
--- a/src/scss/ia/_pipeline.scss
+++ b/src/scss/ia/_pipeline.scss
@@ -220,11 +220,11 @@
 		    content: "G";
 		}
 
-		&-fathead {
+		&-fathead:before {
 		    content: "F";
 		}
 
-		&-longtail {
+		&-longtail:before {
 		    content: "L";
 		}
 	    }


### PR DESCRIPTION
Labels for Fatheads and Longtails should now be correct (it was showing "N" before). 😦 For @MariagraziaAlastra.