### PR TITLE
_pipeline.scss: Add underline under the filter.

### DIFF
--- a/src/scss/ia/_pipeline.scss
+++ b/src/scss/ia/_pipeline.scss
@@ -70,10 +70,15 @@
 .pipeline-filter { 
     color: $grey-light;
     cursor: pointer;
+    padding-bottom: 4px;
 
     .platform-no-info .path2:before { margin-left: -1.5em; }
 
     #count-missing { margin-left: -0.65em; }
+
+    &.active-filter {
+	box-shadow: inset 0px -3px $blue;
+    }
 }
 
 .fix-float { visibility: hidden; }

--- a/src/scss/ia/_pipeline.scss
+++ b/src/scss/ia/_pipeline.scss
@@ -74,7 +74,7 @@
 
     .platform-no-info .path2:before { margin-left: -1.5em; }
 
-    #count-missing { margin-left: -0.65em; }
+    #count-missing { margin-left: -0.2em; }
 
     &.active-filter {
 	box-shadow: inset 0px -3px $blue;


### PR DESCRIPTION
Using `box-shadow` because using `border` takes up space. We don't want no space. 🚀