### PR TITLE
Dev Pipeline - add editable fields to the page sidebar

### DIFF
--- a/lib/DDGC/DB/Result/InstantAnswer.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer.pm
@@ -290,6 +290,7 @@ column design_review => {
 column test_machine => {
     data_type => 'text',
     is_nullable => 1,
+    pipeline => 1
 };
 
 # test results on IE 8

--- a/src/templates/dev_pipeline_detail.handlebars
+++ b/src/templates/dev_pipeline_detail.handlebars
@@ -56,6 +56,35 @@
         <div class="field-label primary-label"> Perl Module </div>
         <input class="edit-sidebar" id="edit-sidebar-perl_module" value="{{perl_module}}" />
     </div>
+
+    <div class="sidebar-field">
+        <div class="field-label primary-label"> Producer </div>
+        <input class="edit-sidebar" id="edit-sidebar-producer" value="{{producer}}" />
+    </div>
+
+    <div class="sidebar-field">
+        <div class="field-label primary-label"> Template </div>
+        <input class="edit-sidebar" id="edit-sidebar-template" value="{{template}}" />
+    </div>
+
+    <div class="sidebar-field">
+        <div class="field-label primary-label"> Dev Machine </div>
+        <select class="edit-sidebar select-sidebar" id="edit-sidebar-test_machine">
+            {{#if test_machine}}<option value="0">{{test_machine}}</option>{{/if}}
+            <option></option>
+            {{#not_eq test_machine 'ddh1'}}<option value="1">ddh1</option>{{/not_eq}}
+            {{#not_eq test_machine 'ddh2'}}<option value="2">ddh2</option>{{/not_eq}}
+            {{#not_eq test_machine 'ddh3'}}<option value="3">ddh3</option>{{/not_eq}}
+            {{#not_eq test_machine 'ddh4'}}<option value="4">ddh4</option>{{/not_eq}}
+            {{#not_eq test_machine 'ddh5'}}<option value="5">ddh5</option>{{/not_eq}}
+            {{#not_eq test_machine 'ddh6'}}<option value="6">ddh6</option>{{/not_eq}}
+            {{#not_eq test_machine 'ddh7'}}<option value="7">ddh7</option>{{/not_eq}}
+            {{#not_eq test_machine 'ddh8'}}<option value="8">ddh8</option>{{/not_eq}}
+            {{#not_eq test_machine 'ddh9'}}<option value="9">ddh9</option>{{/not_eq}}
+            {{#not_eq test_machine 'ddh10'}}<option value="10">ddh10</option>{{/not_eq}}
+            {{#not_eq test_machine 'beta'}}<option value="11">beta</option>{{/not_eq}}
+        </select>
+    </div>
 {{else}}
     {{#if name}}
       <h2 id="sidebar-name"> {{name}} </h2>


### PR DESCRIPTION
Since they can be edited in the actions sidebar, they should be editable in the page sidebar (aka for just one IA) too.
Added producer, template and dev machine.
![screenshot-maria duckduckgo com 5001 2015-10-15 21-32-58](https://cloud.githubusercontent.com/assets/3652195/10525339/741e9aa8-7384-11e5-9d18-956c4dd64c7d.png)
