### PR TITLE
dev_pipeline_detail.handlebars - add star icon for high priority IAs

### DIFF
--- a/src/templates/dev_pipeline_detail.handlebars
+++ b/src/templates/dev_pipeline_detail.handlebars
@@ -1,5 +1,10 @@
 <div id="sidebar-top" class="clearfix">
   <span class="left">
+    {{#if pr}}{{#each pr.tags}}{{#eq (slug name) 'priorityhigh'}} 
+        <span class="sep--after">
+            <i class="icon-star-empty" />
+        </span>
+    {{/eq}}{{/each}}{{/if}}
     {{#if permissions.admin}}
         <span class="sep--after edit-sidebar" id="edit-sidebar-repo">
             <select>


### PR DESCRIPTION
If the IA's PR is high priority, an empty star icon will be shown in the top left corner of the page sidebar.