### PR TITLE
ghIssues.pl - fetch duck.co user info for last comment and last commit

### DIFF
--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -234,9 +234,14 @@ sub get_last_commit {
 
     return unless $commit;
 
+    my $gh_user = $commit->{commit}->{committer}->{name};
+    my $result = duckco_user($gh_user);
     my $last_commit = { 
         diff => $commit->{html_url}, 
-        user => $commit->{commit}->{committer}->{name},
+        user => $gh_user,
+        duckco => $result->{gh_user},
+        admin => $result->{admin},
+        comleader => $result->{comleader},
         date => $commit->{commit}->{committer}->{date},
         message => $commit->{commit}->{message},
     };
@@ -251,9 +256,15 @@ sub get_comments {
 
     my $formatted_comments;
     foreach my $comment (@comments){
-        push(@$formatted_comments,
+ 
+    my $gh_user = $comment->{user}->{login};
+    my $result = duckco_user($gh_user);
+    push(@$formatted_comments,
             { 
-                user => $comment->{user}->{login},
+                user => $gh_user,
+                duckco => $result->{user},
+                admin => $result->{admin},
+                comleader => $result->{comleader},
                 date => $comment->{created_at},
                 text => $comment->{body},
                 id => $comment->{id}
@@ -261,6 +272,29 @@ sub get_comments {
     }
 
     return $formatted_comments;
+}
+
+sub duckco_user {
+    my ($gh_user) = @_;
+
+    my $user = $d->rs('User')->find({github_user => $gh_user});
+    my $admin = 0;
+    my $comleader = 0;
+    my $username;
+
+    if ($user) {
+        $username = $user->username;
+        $admin = $user->admin;
+        $comleader = $user->is('community_leader');
+    }
+
+    my %result = (
+        user => $username,
+        admin => $admin,
+        comleader => $comleader
+    );
+
+    return \%result;
 }
 
 # check the status of PRs in $pr_hash.  If they were merged


### PR DESCRIPTION
Takes username, admin and comleader roles info.
![screenshot-maria duckduckgo com 5001 2015-10-26 19-01-47](https://cloud.githubusercontent.com/assets/3652195/10737777/625ec552-7c14-11e5-952d-0f1f6711ad42.png)
