### PR TITLE
Dev Pipeline - sort by priority

### DIFF
--- a/src/js/ia/Helpers.js
+++ b/src/js/ia/Helpers.js
@@ -2,14 +2,15 @@
     // Handlebars helpers for IA Pages
     
     // Return elapsed time expressed as days from now (e.g. 5 days, 1 day, today)
-    Handlebars.registerHelper("timeago", function(date) {
+    Handlebars.registerHelper("timeago", function(date, full) {
+        var timestring = full? " days ago" : "d";
         if (date) {
             // expected date format: YYYY-MM-DDTHH:mm:ssZ e.g. 2011-04-22T13:33:48Z
             date = date.replace("/T.*Z/", " ");
             date = moment.utc(date, "YYYY-MM-DD");
             
             var elapsed = parseInt(moment().diff(date, "days", true));
-            date = elapsed + "d";
+            date = elapsed + timestring;
 
             return date;
         }

--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -14,7 +14,7 @@
 
         current_filter: '',
 
-        by_priority: true,
+        by_priority: false,
 
         query: '',
 
@@ -34,6 +34,8 @@
                 if ($("#create-new-ia").length) {
                     data.permissions = {};
                     data.permissions.admin = 1;
+                    $("#sort_pipeline select option:selected").val(0);
+                    dev_p.by_priority = true;
                 }
 
                 // Get username for the at mentions filter
@@ -43,9 +45,8 @@
                 dev_p.data = data;
                 
                 var stats = Handlebars.templates.dev_pipeline_stats(data.dev_milestones);
-                $("#sort_pipeline select option:selected").val(0);
-                sort_pipeline();
 
+                sort_pipeline();
 
                 $("#pipeline-stats").html(stats);
 

--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -14,6 +14,8 @@
 
         current_filter: '',
 
+        by_priority: true,
+
         query: '',
 
         data: {},
@@ -41,11 +43,11 @@
                 dev_p.data = data;
                 
                 var stats = Handlebars.templates.dev_pipeline_stats(data.dev_milestones);
-                //var iadp = Handlebars.templates.dev_pipeline(data);
-                sort_priority();
+                $("#sort_pipeline select option:selected").val(0);
+                sort_pipeline();
+
 
                 $("#pipeline-stats").html(stats);
-                //$("#dev_pipeline").html(iadp);
 
                 if ($.trim($("#select-action option:selected").text()) === "type") {
                     $("#select-milestone").addClass("hide");
@@ -56,7 +58,6 @@
                 $(".site-main > .content-wrap").first().removeClass("content-wrap").addClass("wrap-pipeline");
 		        $(".breadcrumb-nav").remove();
 
-                filterCounts();
                 var parameters = window.location.search.replace("?", "");
                 parameters = $.trim(parameters.replace(/\/$/, ''));
                 if (parameters) {
@@ -105,6 +106,14 @@
              $("body").on("click", "#create-new-ia", function(evt) {
                 $(this).hide();
                 $("#create-new-ia-form").removeClass("hide");
+            });
+
+            $("body").on("change", "#sort_pipeline select", function(evt) {
+                var option = parseInt($(this).find("option:selected").val());
+                console.log("option: " + option);
+                dev_p.by_priority = option? false : true;
+                console.log("priority: " + dev_p.by_priority);
+                sort_pipeline();
             });
 
             $("body").on('click', "#new-ia-form-cancel", function(evt) {
@@ -234,8 +243,7 @@
 
                         //var iadp = Handlebars.templates.dev_pipeline(data);
                         //$("#dev_pipeline").html(iadp);
-                        sort_priority();
-                        filterCounts();
+                        sort_pipeline();
                         filter();
                     });
                 }
@@ -394,82 +402,92 @@
             }
 
             // Sort each milestone array by priority
-            function sort_priority() {
+            function sort_pipeline() {
                 $.each(dev_p.data.dev_milestones, function (key, val) {
                     $.each(dev_p.data.dev_milestones[key], function (temp_ia) {
                         var priority_val = 0;
 
                         var ia = dev_p.data.dev_milestones[key][temp_ia];
 
-                        // Priority is higher when:
-                        // - last activity (especially comment) is by a contributor (non-admin)
-                        // - last activity happened long ago (the older the activity, the higher the priority)
-                        if (ia.pr && ia.pr.issue_id) {
-                            if (ia.last_comment) {
-                                priority_val += ia.last_comment.admin? -20 : 20;
-                                var idle_comment = elapsed_time(ia.last_comment.date);
-                                if (ia.last_comment.admin) {
-                                    priority_val -= 20;
-                                    priority_val += idle_comment;
-                                } else {
-                                    priority_val += 20;
-                                    priority_val += (2 * idle_comment);
-                                }
-                            } if (ia.last_commit) {
-                                var idle_commit = elapsed_time(ia.last_commit.date);
-                                if (ia.last_comment &&  moment.utc(ia.last_comment.date).isBefore(ia.last_commit.date)) {
-                                    priority_val += idle_commit;
-                                } else if ((!ia.last_comment) && (!ia.last_commit.admin)) {
-                                    priority_val += (2 * idle_commit);
-                                }
-                            }
-
-                            // Priority drops if the PR is on hold
+                        if (dev_p.by_priority) {
+                            // Priority is higher when:
+                            // - last activity (especially comment) is by a contributor (non-admin)
+                            // - last activity happened long ago (the older the activity, the higher the priority)
                             if (ia.pr && ia.pr.issue_id) {
-                                var tags = ia.pr.tags;
-
-                                $.each(tags, function(idx) {
-                                    var tag = tags[idx];
-                                    if (tag.name.toLowerCase() === "on hold") {
-                                        priority_val -= 100;
-                                    } else if (tag.name.toLowerCase() === "priority: high") {
+                                if (ia.last_comment) {
+                                    priority_val += ia.last_comment.admin? -20 : 20;
+                                    var idle_comment = elapsed_time(ia.last_comment.date);
+                                    if (ia.last_comment.admin) {
+                                        priority_val -= 20;
+                                        priority_val += idle_comment;
+                                    } else {
                                         priority_val += 20;
+                                        priority_val += (2 * idle_comment);
                                     }
-                                });
+                                } if (ia.last_commit) {
+                                    var idle_commit = elapsed_time(ia.last_commit.date);
+                                    if (ia.last_comment &&  moment.utc(ia.last_comment.date).isBefore(ia.last_commit.date)) {
+                                        priority_val += idle_commit;
+                                    } else if ((!ia.last_comment) && (!ia.last_commit.admin)) {
+                                        priority_val += (2 * idle_commit);
+                                    }
+                                }
+
+                                // Priority drops if the PR is on hold
+                                if (ia.pr && ia.pr.issue_id) {
+                                    var tags = ia.pr.tags;
+
+                                    $.each(tags, function(idx) {
+                                        var tag = tags[idx];
+                                        if (tag.name.toLowerCase() === "on hold") {
+                                            priority_val -= 100;
+                                        } else if (tag.name.toLowerCase() === "priority: high") {
+                                            priority_val += 20;
+                                        }
+                                    });
+                                }
+
+                                // Priority is higher if the user has been mentioned in the last comment
+                                if (ia.at_mentions && ia.at_mentions.indexOf(dev_p.data.username) !== -1) {
+                                    priority_val += 50;
+                                }
+
+                                // Has a PR, so it still has more priority than IAs which don't have one
+                                if (priority_val <= 0) {
+                                    priority_val = 1;
+                                }
                             }
 
-                            // Priority is higher if the user has been mentioned in the last comment
-                            if (ia.at_mentions && ia.at_mentions.indexOf(dev_p.data.username) !== -1) {
-                                priority_val += 50;
-                            }
-
-                            // Has a PR, so it still has more priority than IAs which don't have one
-                            if (priority_val <= 0) {
-                                priority_val = 1;
-                            }
+                            dev_p.data.dev_milestones[key][temp_ia].priority = priority_val;
+                            console.log(ia.name + ": " + dev_p.data.dev_milestones[key][temp_ia].priority);
+                        }
+                    });
+                        
+                    dev_p.data.dev_milestones[key].sort(function (l, r) {
+                        var a, b;
+                        if (dev_p.by_priority) {
+                            a = l.priority;
+                            b = r.priority;
+                        } else {
+                            a = l.last_update? - elapsed_time(l.last_update) : -100;
+                            b = r.last_update? - elapsed_time(r.last_update) : -100;
+                            console.log(a + ", " + b);
                         }
 
-                        dev_p.data.dev_milestones[key][temp_ia].priority = priority_val;
-                        console.log(ia.name + ": " + dev_p.data.dev_milestones[key][temp_ia].priority);
-                    });
-                    
-                    dev_p.data.dev_milestones[key].sort(function (l, r) {
-                        var a = l;
-                        var b = r;
-                        console.log(a.priority + ", " + b.priority);
-
-                        if (a.priority > b.priority) {
+                        if (a > b) {
                             return -1;
-                        } else if (b.priority > a.priority) {
+                        } else if (b > a) {
                             return 1;
                         }
                             
                         return 0;
                     });
                 });
-            
+
+                dev_p.data.by_priority = dev_p.by_priority;
                 var iadp = Handlebars.templates.dev_pipeline(dev_p.data);
                 $("#dev_pipeline").html(iadp);
+                filterCounts();
             }
 
             // Add counts to filters

--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -386,6 +386,37 @@
                 }
             }
 
+            // Sort each milestone array by priority
+            function sort_priority() {
+                $.each(dev_p.data.dev_milestones, function (key, val) {
+                    $.each(dev_p.data.dev_milestones[key], function (ia) {
+                        var priority_val = 0;
+                        $.each(dev_p.priority_fields, function(idx) {
+                            var temp_val = dev_p.data.dev_milestones[key][idx];
+                            priority_val += dev_p.priority_vals[temp_val];
+                        });
+
+                        dev_p.data.dev_milestones[key][ia]["priority"] = priority_val;
+
+                        dev_p.data.dev_milestones[key].sort(function l, r) {
+                            var a = l;
+                            var b = r;
+
+                            if (a["priority"] > b["priority"]) {
+                                return 1;
+                            } else if (b["priority"] > a["priority"]) {
+                                return -1;
+                            }
+                                
+                            return 0;
+                        });
+                    });
+                });
+            
+                var iadp = Handlebars.templates.dev_pipeline(data);
+                $("#dev_pipeline").html(iadp);
+            }
+
             function filter(which_filter) {
                 var query = dev_p.query? dev_p.query.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&") : '';
                 var url = "";

--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -54,15 +54,9 @@
 
                 // 100% width
                 $(".site-main > .content-wrap").first().removeClass("content-wrap").addClass("wrap-pipeline");
-		$(".breadcrumb-nav").remove();
+		        $(".breadcrumb-nav").remove();
 
-                // Add counts to filters
-                $(".pipeline-filter").each(function(idx) {
-                    var temp_filter = $(this).attr("id").replace("filter-", "");
-                    var temp_count = $(".dev_pipeline-column__list li." + temp_filter).length;
-                    $("#count-" + temp_filter).text(temp_count);
-                });
-
+                filterCounts();
                 var parameters = window.location.search.replace("?", "");
                 parameters = $.trim(parameters.replace(/\/$/, ''));
                 if (parameters) {
@@ -238,8 +232,11 @@
                         dev_p.saved = false;
                         dev_p.data.dev_milestones = data.dev_milestones;
 
-                        var iadp = Handlebars.templates.dev_pipeline(data);
-                        $("#dev_pipeline").html(iadp);
+                        //var iadp = Handlebars.templates.dev_pipeline(data);
+                        //$("#dev_pipeline").html(iadp);
+                        sort_priority();
+                        filterCounts();
+                        filter();
                     });
                 }
             });
@@ -473,6 +470,15 @@
             
                 var iadp = Handlebars.templates.dev_pipeline(dev_p.data);
                 $("#dev_pipeline").html(iadp);
+            }
+
+            // Add counts to filters
+            function filterCounts() {
+                $(".pipeline-filter").each(function(idx) {
+                    var temp_filter = $(this).attr("id").replace("filter-", "");
+                    var temp_count = $(".dev_pipeline-column__list li." + temp_filter).length;
+                    $("#count-" + temp_filter).text(temp_count);
+                });
             }
 
             function filter(which_filter, reset) {

--- a/src/scss/ia/_pipeline.scss
+++ b/src/scss/ia/_pipeline.scss
@@ -121,10 +121,12 @@
 
     #sidebar-pr, #pr, .primary-label {
         color: $grey-light;
-	font-size: 0.95em;
-	font-weight: 500;
-	padding-top: 2em;
-	padding-bottom: 0.5em;
+	    font-size: 0.95em;
+	    font-weight: 500;
+	    padding-top: 2em;
+	    padding-bottom: 0.5em;
+
+        a { color: $grey-light; }
     }
 
     #sidebar-pr .comment {

--- a/src/templates/dev_pipeline.handlebars
+++ b/src/templates/dev_pipeline.handlebars
@@ -32,9 +32,21 @@
       </span> 
 
       
-      <span class="toggle-details right">
+      <!--- <span class="toggle-details right">
         <i class="icon-check-empty"></i>
         Show activity details
+      </span> --->
+
+      <span class="right" id="sort_pipeline">
+        <select>
+            {{#if by_priority}}
+                <option value="0">Sort by Priority</option>
+                <option value="1">Sort by Recently Updated</option>
+            {{else}}
+                <option value="1">Sort by Recently Updated</option>
+                <option value="0">Sort by Priority</option>
+            {{/if}}
+        </select>
       </span>
           
       <span class="button fix-float"></span>

--- a/src/templates/dev_pipeline.handlebars
+++ b/src/templates/dev_pipeline.handlebars
@@ -37,6 +37,7 @@
         Show activity details
       </span> --->
 
+    {{#if permissions.admin}}
       <span class="right" id="sort_pipeline">
         <select>
             {{#if by_priority}}
@@ -48,6 +49,7 @@
             {{/if}}
         </select>
       </span>
+    {{/if}}
           
       <span class="button fix-float"></span>
     </span>

--- a/src/templates/dev_pipeline.handlebars
+++ b/src/templates/dev_pipeline.handlebars
@@ -76,11 +76,11 @@
                     <div class="right item-activity">
                       {{#exists pr 'issue_id'}}
                           <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr" title="{{format_time last_update}}">
-                            {{timeago last_update}}
+                            {{timeago last_update 0}}
                           </a>
                       {{else}}
                           <span title="{{format_time last_update}}">
-                            {{timeago last_update}}
+                            {{timeago last_update 0}}
                           </span>
                       {{/exists}}
                     </div>
@@ -126,11 +126,11 @@
                     <div class="right item-activity">
                       {{#exists pr 'issue_id'}}
                           <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr" title="{{format_time last_update}}">
-                            {{timeago last_update}}
+                            {{timeago last_update 0}}
                           </a>
                       {{else}}
                           <span title="{{format_time last_update}}">
-                            {{timeago last_update}}
+                            {{timeago last_update 0}}
                           </span>
                       {{/exists}}
                     </div>
@@ -176,11 +176,11 @@
                     <div class="right item-activity">
                       {{#exists pr 'issue_id'}}
                           <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr" title="{{format_time last_update}}">
-                            {{timeago last_update}}
+                            {{timeago last_update 0}}
                           </a>
                       {{else}}
                           <span title="{{format_time last_update}}">
-                            {{timeago last_update}}
+                            {{timeago last_update 0}}
                           </span>
                       {{/exists}}
                     </div>
@@ -226,11 +226,11 @@
                     <div class="right item-activity">
                       {{#exists pr 'issue_id'}}
                           <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr" title="{{format_time last_update}}">
-                            {{timeago last_update}}
+                            {{timeago last_update 0}}
                           </a>
                       {{else}}
                           <span title="{{format_time last_update}}">
-                            {{timeago last_update}}
+                            {{timeago last_update 0}}
                           </span>
                       {{/exists}}
                     </div>

--- a/src/templates/dev_pipeline_detail.handlebars
+++ b/src/templates/dev_pipeline_detail.handlebars
@@ -151,7 +151,7 @@
                     {{text}}
                 </a>
             </p>
-            <div>{{timeago date}}</div>
+            <div>by <a href="https://github.com/{{user}}">{{user}}</a> {{timeago date 1}}</div>
         {{/each}}
     </div>        
 {{/if}}


### PR DESCRIPTION
This is just an experiment! I connected the TestOne account to one of the admins accounts on github, so whenever you see an IA with not so much elapsed time compared to the others on top, it means the admin was mentioned in the last PR comment.
Right now the parameters taken into account are:
- Last comment author (higher priority if non-admin)
- Elapsed time since last comment (again, more points if non-admin): the older, the higher the priority
- Elapsed time since last commit if made after last comment or if no comments
- User has been at mentioned in the last comment
- Tags (on hold: -100; high priority: +50)
- Has a PR (any IA with a PR is higher priority than IAs without one)
![screenshot-maria duckduckgo com 5001 2015-10-28 12-41-32](https://cloud.githubusercontent.com/assets/3652195/10787488/930b7d18-7d71-11e5-943e-94d4a82e50de.png)
