### PR TITLE
Dev Pipeline - add beta install status in the single page sidebar

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -193,8 +193,12 @@ sub dev_pipeline_json :Chained('dev_pipeline_base') :PathPart('json') :Args(0) {
             my $pr_id = $pr->{issue_id};
             my $repo = $ia->repo;
             my $beta_pr = $resp->{$repo}->{$pr_id};
+            $temp_ia->{beta_install} = 0;
             warn $beta_pr->{install_status};
-            $temp_ia->{beta_install} = $beta_pr? $beta_pr->{install_status} : 0;
+            if ($beta_pr) {
+                $temp_ia->{beta_install} = $beta_pr->{install_status};
+                $temp_ia->{beta_query} = $beta_pr->{meta}? $beta_pr->{meta}->{example_query} : 0;
+            }
        }
 
         push @{$dev_ias{$ia->$key}}, $temp_ia;

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -759,13 +759,9 @@ sub send_to_beta :Chained('base') :PathPart('send_to_beta') :Args(0) {
         $req->content(to_json($data));
 
         my $resp = $ua->request($req);
-        if ($resp->is_success) {
-            $result = 1;
-            $c->stash->{x}->{result} = $result;
-        } else {
-            $result = '';
-            $c->stash->{x}->{result} = $result;
-        }
+        
+        $result = $resp->is_success? 1 : 0;
+        $c->stash->{x}->{result} = $result;
     }
 
     return $c->forward($c->view('JSON'));

--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -125,26 +125,35 @@
             });
 
             $("body").on("click", "#beta_install", function(evt) {
-                var prs = [];
-                $(".dev_pipeline-column__list .selected").each(function(idx) {
-                    var temp_pr = $.trim($(this).find(".item-activity a").attr("href"));
-                    var temp_pr_id = temp_pr.replace(/.*\//, "");
-                    var temp_repo = temp_pr.replace(/^.*\/duckduckgo\//, "").replace(/\/[a-zA-Z0-9]*\/[a-zA-Z0-9]*\/?/, "");
+                if (!$(this).hasClass("disabled")) {
+                    $(this).addClass("disabled");
+                    var prs = [];
+                    $(".dev_pipeline-column__list .selected").each(function(idx) {
+                        var temp_pr = $.trim($(this).find(".item-activity a").attr("href"));
+                        var temp_hash = pr_hash(temp_pr);
 
-                    if (temp_pr_id && temp_repo) {
-                        var temp_hash = 
-                            {
-                                "action" : "duckco",
-                                "number" : temp_pr_id,
-                                "repo" : temp_repo
-                            };
+                        if (temp_hash) {
+                            prs.push(temp_hash);
+                        }
+                    });
 
-                        prs.push(temp_hash);
+                    if (prs.length) {
+                        send_to_beta(JSON.stringify(prs));
                     }
-                });
+                }
+            });
 
-                if (prs.length) {
-                    send_to_beta(JSON.stringify(prs));
+            $("body").on("click", "#beta-single", function(evt) {
+                if (!$(this).hasClass("disabled")) {
+                    $(this).addClass("disabled");
+                    var prs = [];
+                    var pr = $.trim($("#pr").attr("href"));
+                    var tmp_hash = pr_hash(pr);
+
+                    if (pr_hash) {
+                        prs.push(tmp_hash);
+                        send_to_beta(JSON.stringify(prs));
+                    }
                 }
             });
 
@@ -278,11 +287,29 @@
                 }
             });
 
+            function pr_hash(href) {
+                var temp_pr_id = href.replace(/.*\//, "");
+                var temp_repo = href.replace(/^.*\/duckduckgo\//, "").replace(/\/[a-zA-Z0-9]*\/[a-zA-Z0-9]*\/?/, "");
+
+                if (temp_pr_id && temp_repo) {
+                    var temp_hash = 
+                        {
+                            "action" : "duckco",
+                            "number" : temp_pr_id,
+                            "repo" : temp_repo
+                        };
+                    return temp_hash;
+                }
+
+                return false;
+            }
+
             function send_to_beta(prs) {
                 var jqxhr = $.post("/ia/send_to_beta", {
                     data : prs
                 })
                 .done(function(data) {
+                    dev_p.saved = true;
                 });
             }
 

--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -363,7 +363,7 @@
                        var page_data = getPageData(meta_id, milestone);
                         
                        // If at least one of the selected IAs isn't on beta we show the "install on beta" button
-                       if (page_data.test_machine !== "beta") {
+                       if (page_data.beta_install !== "success") {
                            actions_data.beta = 0;
                        }
 

--- a/src/templates/dev_pipeline_actions.handlebars
+++ b/src/templates/dev_pipeline_actions.handlebars
@@ -42,7 +42,7 @@
             {{#if got_prs}}
                 <div class="field-section">
                     <div class="frm__label field-label"> Dev Machine </div>
-                    {{#if installed}}
+                    {{#if beta}}
                         Installed on <a href="https://beta.duckduckgo.com">beta</a>
                     {{else}}
                         <div class="pipeline-actions__button button btn--primary" id="beta_install">

--- a/src/templates/dev_pipeline_detail.handlebars
+++ b/src/templates/dev_pipeline_detail.handlebars
@@ -78,9 +78,9 @@
         <div class="sidebar-field">
             <div class="field-label primary-label"> Dev Machine </div>
             {{#eq beta_install 'success'}}
-                Installed on <a href="http://beta.duckduckgo.com/?={{example_query}}">beta</a>
+                Installed on <a href="http://beta.duckduckgo.com/{{#if beta_query}}?q={{beta_query}}{{/if}}">beta</a>
             {{else}}
-                {{#if beta_install}}<span class="readonly">{{beta_install}}</span>{{/if}}
+                {{#if beta_install}}Install on beta failed: <div class="readonly">{{beta_install}}</div>{{/if}}
                 <div class="button btn--primary" id="beta-single">Install on beta</div>
             {{/eq}}
         </div>

--- a/src/templates/dev_pipeline_detail.handlebars
+++ b/src/templates/dev_pipeline_detail.handlebars
@@ -74,26 +74,17 @@
         <input class="edit-sidebar" data-focus-class="frm__input" id="edit-sidebar-template" value="{{template}}" />
     </div>
 
-    <div class="sidebar-field">
-        <div class="field-label primary-label"> Dev Machine </div>
-	<span class="frm__select">
-          <select class="edit-sidebar select-sidebar" id="edit-sidebar-test_machine">
-            {{#if test_machine}}<option value="0">{{test_machine}}</option>{{/if}}
-            <option></option>
-            {{#not_eq test_machine 'ddh1'}}<option value="1">ddh1</option>{{/not_eq}}
-            {{#not_eq test_machine 'ddh2'}}<option value="2">ddh2</option>{{/not_eq}}
-            {{#not_eq test_machine 'ddh3'}}<option value="3">ddh3</option>{{/not_eq}}
-            {{#not_eq test_machine 'ddh4'}}<option value="4">ddh4</option>{{/not_eq}}
-            {{#not_eq test_machine 'ddh5'}}<option value="5">ddh5</option>{{/not_eq}}
-            {{#not_eq test_machine 'ddh6'}}<option value="6">ddh6</option>{{/not_eq}}
-            {{#not_eq test_machine 'ddh7'}}<option value="7">ddh7</option>{{/not_eq}}
-            {{#not_eq test_machine 'ddh8'}}<option value="8">ddh8</option>{{/not_eq}}
-            {{#not_eq test_machine 'ddh9'}}<option value="9">ddh9</option>{{/not_eq}}
-            {{#not_eq test_machine 'ddh10'}}<option value="10">ddh10</option>{{/not_eq}}
-            {{#not_eq test_machine 'beta'}}<option value="11">beta</option>{{/not_eq}}
-          </select>
-	</span>
-    </div>
+    {{#if pr.issue_id}}
+        <div class="sidebar-field">
+            <div class="field-label primary-label"> Dev Machine </div>
+            {{#eq beta_install 'success'}}
+                Installed on <a href="http://beta.duckduckgo.com/?={{example_query}}">beta</a>
+            {{else}}
+                {{#if beta_install}}<span class="readonly">{{beta_install}}</span>{{/if}}
+                <div class="button btn--primary" id="beta-single">Install on beta</div>
+            {{/eq}}
+        </div>
+    {{/if}}
 
     {{#if priority_msg}}
         <div class="sidebar-field">


### PR DESCRIPTION
//cc @jdorweiler 
Replaces the dev machine dropdown with an "install on beta" button if the IA is not yet installed / install failed (in this last case it also shows the error message); otherwise shows a link to the IA on the beta server.

Installed:
![screenshot-maria duckduckgo com 5001 2015-10-30 11-11-54](https://cloud.githubusercontent.com/assets/3652195/10843105/0e57a1fa-7ef7-11e5-95ba-5777a4982168.png)

Not installed:
![screenshot-maria duckduckgo com 5001 2015-10-30 11-14-01](https://cloud.githubusercontent.com/assets/3652195/10843138/5af9914e-7ef7-11e5-9e95-e97fcc8eaabc.png)

