### PR TITLE
IA Pages - create new endpoint for the topics page

### DIFF
--- a/templates/instantanswer/topics.tx
+++ b/templates/instantanswer/topics.tx
@@ -1,0 +1,3 @@
+<div id="ia_topics">
+</div>
+


### PR DESCRIPTION
//cc @alohaas 
Thanks @jbarrett for the help :)

Page endpoint: ia/topics
JSON endpoint: ia/topics/json

This is what the data looks like:
![screenshot-maria duckduckgo com 5001 2015-11-03 15-46-24](https://cloud.githubusercontent.com/assets/3652195/10910872/2a72a134-8242-11e5-9abe-7f874ebbd08d.png)

Additional notes: the js file for this page should be named IATopics.js (or if you want to have another name for it please let me know @alohaas :) )
Also, make sure you login with an admin account before going to ia/topics or you'll be redirected to /ia/, since it's a page meant just for admins.

Thanks!
