### PR TITLE
Pipeline: Prevent sidebars from scrolling horizontally

### DIFF
--- a/src/scss/ia/_pipeline.scss
+++ b/src/scss/ia/_pipeline.scss
@@ -183,7 +183,8 @@ textarea.edit-sidebar {
 }
 #page_sidebar {
     width: 395px;
-    overflow: auto;
+    overflow-x: hidden;
+    overflow-y: scroll;
     margin-bottom: 13em;
 }
 
@@ -229,6 +230,7 @@ textarea.edit-sidebar {
     #sidebar-pr .comment {
         margin-bottom: 0;
         margin-top: 1em;
+	word-wrap: break-word;
 
         a { 
 	    color: $slate; 


### PR DESCRIPTION
For @MariagraziaAlastra 

Horizontal scrolling in the sidebar:
![screen shot 2015-11-04 at 7 08 29 am](https://cloud.githubusercontent.com/assets/81969/10937729/e8a27636-82c2-11e5-918a-9db3546fa7e5.png)

Seems to happen on webkit browsers only though so please test in Chrome to verify:
<img width="1506" alt="screen shot 2015-11-04 at 7 09 20 am" src="https://cloud.githubusercontent.com/assets/81969/10937745/073718ae-82c3-11e5-9115-faca2facb4f3.png">


Tested on Chrome, Firefox, Safari, and Edge.