### PR TITLE
Pipeline: Extend horizontal line beyond the sidebar.

### DIFF
--- a/src/scss/ia/_pipeline.scss
+++ b/src/scss/ia/_pipeline.scss
@@ -203,6 +203,10 @@ textarea.edit-sidebar {
     border: 1px solid rgba(200,200,200,0.2);
     padding-top: 16.8em;
 
+    hr {
+	@include scaleX(2);
+    }
+    
     .sidebar-field {
         margin-top: 1em;
     }


### PR DESCRIPTION
The horizontal line looks like it has some padding because its parent element has padding. An easy way to extend it beyond its parents constraints, we can use `transform: scaleX(2)`.

Tested Safari, Chrome, IE 10, and Firefox.

Before:
<img width="459" alt="screen shot 2015-11-04 at 7 29 13 am" src="https://cloud.githubusercontent.com/assets/81969/10938130/cb8a477e-82c5-11e5-9fcb-f88aeb8778d7.png">

After:
<img width="475" alt="screen shot 2015-11-04 at 7 29 20 am" src="https://cloud.githubusercontent.com/assets/81969/10938133/ce707aee-82c5-11e5-904a-cd000108bcb3.png">

For @MariagraziaAlastra 