### PR TITLE
IE is showing some overlapping text.

### DIFF
--- a/src/scss/ia/_pipeline.scss
+++ b/src/scss/ia/_pipeline.scss
@@ -498,6 +498,12 @@ textarea.edit-sidebar {
 
     .frm__label {
 	font-size: 1em;
+	background-color: transparent;
+
+	&.overlap {
+	    position: relative;
+	    top: 26px;
+	}
     }
 }
 

--- a/src/templates/dev_pipeline_actions.handlebars
+++ b/src/templates/dev_pipeline_actions.handlebars
@@ -15,8 +15,8 @@
 
             <div class="field-section">
                 <div class="primary-label">Update </div>
+                <div class="frm__label overlap"> Dev Milestone </div>
 		<span class="frm__select">
-                  <div class="frm__label "> Dev Milestone </div>
                   <select class="pipeline-actions__select" id="select-dev_milestone">
                     <option value="0">planning</option>
                     <option value="1">development</option>
@@ -28,8 +28,8 @@
             </div>
 
             <div class="field-section">
+              <div class="frm__label overlap"> Type </div>
 		<span class="frm__select">
-                  <div class="frm__label "> Type </div>
                   <select class="pipeline-actions__select" id="select-repo">
                     <option value="0">fathead</option>
                     <option value="1">goodies</option>
@@ -40,8 +40,8 @@
             </div>
 
             {{#if got_prs}}
+            <div class="frm__label field-label"> Dev Machine </div>
                 <div class="field-section">
-                    <div class="frm__label field-label"> Dev Machine </div>
                     {{#if beta}}
                         Installed on <a href="https://beta.duckduckgo.com">beta</a>
                     {{else}}


### PR DESCRIPTION
Before:
<img width="216" alt="screen shot 2015-11-04 at 9 30 03 am" src="https://cloud.githubusercontent.com/assets/81969/10941484/9e484f18-82d9-11e5-834d-0928ffa17d30.png">

After:
<img width="182" alt="screen shot 2015-11-04 at 9 50 01 am" src="https://cloud.githubusercontent.com/assets/81969/10941487/a3074720-82d9-11e5-9ea8-d3152b6669da.png">

Tested in Safari, Chrome, FF, and IE.