### PR TITLE
Hax : Preload IA index JSON in template

### DIFF
--- a/lib/DDGC/DB/ResultSet/InstantAnswer.pm
+++ b/lib/DDGC/DB/ResultSet/InstantAnswer.pm
@@ -5,4 +5,32 @@ use Moose;
 extends 'DDGC::DB::Base::ResultSet';
 use namespace::autoclean;
 
+sub ia_index_hri {
+    my ( $self, $limit, $last ) = @_;
+    my $ial = $self->search( {
+            'topic.name' => { '!=' => 'test' },
+            'me.dev_milestone' => { '=' => 'live'},
+        },
+        {
+            prefetch => { instant_answer_topics => 'topic' },
+            columns => [
+                qw/ name repo src_name
+                    dev_milestone description
+                    template id meta_id
+                /, ],
+            collapse => 1,
+        },
+    )->hri
+     ->order_by( 'me.name' );
+
+    $ial = $ial->rows( $limit ) if $limit;
+    $ial = $ial->search( {
+       'me.name' => { '>' => $last },
+    } ) if $last;
+
+    return $ial->all_ref;
+}
+
+
+
 1;

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -52,11 +52,10 @@ sub index :Chained('base') :PathPart('') :Args(0) {
 sub ialist_json :Chained('base') :PathPart('json') :Args() {
     my ( $self, $c ) = @_;
 
-    my $rs = $c->d->rs('InstantAnswer');
-
-    $c->return_if_not_modified( $rs->last_modified );
-
-    $c->stash->{x} = $rs->ia_index_hri;
+    $c->stash->{x} = $c->d->rs('InstantAnswer')->ia_index_hri(
+        $c->req->params->{limit},
+        $c->req->params->{last},
+    );
 
     $c->stash->{not_last_url} = 1;
     $c->forward($c->view('JSON'));

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -701,7 +701,7 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
         }
     }
 
-    my $server = "http://beta.duckduckgo.com/install?asana&ia=" . $ia->id;
+    $server = "http://beta.duckduckgo.com/install?asana&ia=" . $ia->id;
 
     my $result = asana_req('', $server);
     $ia_data{live}->{asana} = $result->decoded_content ? from_json($result->decoded_content) : undef;

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -40,8 +40,6 @@ sub index :Chained('base') :PathPart('') :Args(0) {
     $c->stash->{ia_init} = encode_json(
         $c->d->rs('InstantAnswer')->ia_index_hri
     );
-    $c->stash->{ia_init} =~ s/'/\\'/g;
-    $c->stash->{ia_init} =~ s/\\"/\\\\"/g;
 
     $c->stash->{title} = "Index: Instant Answers";
     $c->stash->{topic_list} = \@topics;

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -47,7 +47,6 @@ sub index :Chained('base') :PathPart('') :Args(0) {
     $c->stash->{topic_list} = \@topics;
     $c->add_bc('Instant Answers', $c->chained_uri('InstantAnswer','index'));
 
-    # @{$c->stash->{ialist}} = $c->d->rs('InstantAnswer')->all();
 }
 
 sub ialist_json :Chained('base') :PathPart('json') :Args() {
@@ -57,18 +56,8 @@ sub ialist_json :Chained('base') :PathPart('json') :Args() {
 
     $c->return_if_not_modified( $rs->last_modified );
 
-    my @ial = $rs->search(
-        {'topic.name' => [{ '!=' => 'test' }, { '=' => undef}],
-         'me.dev_milestone' => { '=' => 'live'},
-        },
-        {
-            columns => [ qw/ name repo src_name dev_milestone description template /, {id => 'meta_id'} ],
-            prefetch => { instant_answer_topics => 'topic' },
-            result_class => 'DBIx::Class::ResultClass::HashRefInflator',
-        }
-    )->all;
+    $c->stash->{x} = $rs->ia_index_hri;
 
-    $c->stash->{x} = \@ial;
     $c->stash->{not_last_url} = 1;
     $c->forward($c->view('JSON'));
 }

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -32,12 +32,10 @@ sub index :Chained('base') :PathPart('') :Args(0) {
 
     my @topics = $rs->search(
         {'name' => { '!=' => 'test' }},
-        {
-            columns => [ qw/ name id /],
-            order_by => [ qw/ name /],
-            result_class => 'DBIx::Class::ResultClass::HashRefInflator',
-        }
-    )->all;
+    )->columns( [ qw/ name id /] )
+     ->order_by( [ qw/ name /] )
+     ->hri
+     ->all;
 
     $c->stash->{title} = "Index: Instant Answers";
     $c->stash->{topic_list} = \@topics;

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -40,7 +40,7 @@ sub index :Chained('base') :PathPart('') :Args(0) {
     $c->stash->{ia_init} = encode_json(
         $c->d->rs('InstantAnswer')->ia_index_hri
     );
-    $c->stash->{ia_init} =~ s/'/&#39;/g;
+    $c->stash->{ia_init} =~ s/'/\\'/g;
     $c->stash->{ia_init} =~ s/\\"/\\\\"/g;
 
     $c->stash->{title} = "Index: Instant Answers";

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -26,14 +26,7 @@ sub index :Chained('base') :PathPart('') :Args(0) {
 
     # Retrieve / stash all IAs for index page here?
 
-    # my @x = $c->d->rs('InstantAnswer')->all();
-    # $c->stash->{ialist} = \@x;
     $c->stash->{ia_page} = "IAIndex";
-
-    #if ($field && $value) {
-    #   $c->stash->{field} = $field;
-    #   $c->stash->{value} = $value;
-    #}
 
     my $rs = $c->d->rs('Topic');
 

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -4,7 +4,7 @@ use Moose;
 use namespace::autoclean;
 use Try::Tiny;
 use Time::Local;
-use JSON;
+use JSON::MaybeXS ':legacy';
 use Net::GitHub::V3;
 use DateTime;
 use LWP::UserAgent;
@@ -36,6 +36,12 @@ sub index :Chained('base') :PathPart('') :Args(0) {
      ->order_by( [ qw/ name /] )
      ->hri
      ->all;
+
+    $c->stash->{ia_init} = to_json(
+        $c->d->rs('InstantAnswer')->ia_index_hri,
+    );
+    $c->stash->{ia_init} =~ s/'/&#39;/g;
+    $c->stash->{ia_init} =~ s/\\"/\\\\"/g;
 
     $c->stash->{title} = "Index: Instant Answers";
     $c->stash->{topic_list} = \@topics;

--- a/src/js/ia/IAIndex.js
+++ b/src/js/ia/IAIndex.js
@@ -27,51 +27,49 @@
             var window_top;
             var $dropdown_header;
             var $input_query;
-            var query = ""; 
+            var query = "";
+            ind.ia_list = ia_init;
 
-            $.getJSON(url, function(x) { 
-                ind.ia_list = x;
-                ind.sort('name');
-                $list_item = $("#ia-list .ia-item");
-                $clear_filters = $("#clear_filters");
-                $right_pane = $("#filters");
-                //right_pane_top = $right_pane.offset().top;
-                //right_pane_left = $right_pane.offset().left;
-                $dropdown_header = $right_pane.children(".dropdown").children(".dropdown_header");
-                $input_query = $('#filters input[name="query"]');
-                
-                var parameters = window.location.search.replace("?", "");
-                parameters = $.trim(parameters.replace(/\/$/, ''));
-                if (parameters) {
-                    parameters = parameters.split("&");
+            ind.sort('name');
+            $list_item = $("#ia-list .ia-item");
+            $clear_filters = $("#clear_filters");
+            $right_pane = $("#filters");
+            //right_pane_top = $right_pane.offset().top;
+            //right_pane_left = $right_pane.offset().left;
+            $dropdown_header = $right_pane.children(".dropdown").children(".dropdown_header");
+            $input_query = $('#filters input[name="query"]');
 
-                    var param_count = 0;
+            var parameters = window.location.search.replace("?", "");
+            parameters = $.trim(parameters.replace(/\/$/, ''));
+            if (parameters) {
+                parameters = parameters.split("&");
 
-                    $.each(parameters, function(idx) {
-                        var temp = parameters[idx].split("=");
-                        var field = temp[0];
-                        var value = temp[1];
-                        if (field && value && (ind.selected_filter.hasOwnProperty(field) || field === "q")) {
-                            if (ind.selected_filter.hasOwnProperty(field)) {
-                                var selector = "ia_" + field + "-" + value;
-                                selector = (field === 'topic')? "." + selector : "#" + selector;
-                                $(selector).parent().trigger("click");
-                                param_count++;
-                            } else if ((field === "q") && value) {
-                                $input_query.val(decodeURIComponent(value.replace(/\+/g, " ")));
-                                $(".filters--search-button").trigger("click");
-                                param_count++;
-                            }
+                var param_count = 0;
+
+                $.each(parameters, function(idx) {
+                    var temp = parameters[idx].split("=");
+                    var field = temp[0];
+                    var value = temp[1];
+                    if (field && value && (ind.selected_filter.hasOwnProperty(field) || field === "q")) {
+                        if (ind.selected_filter.hasOwnProperty(field)) {
+                            var selector = "ia_" + field + "-" + value;
+                            selector = (field === 'topic')? "." + selector : "#" + selector;
+                            $(selector).parent().trigger("click");
+                            param_count++;
+                        } else if ((field === "q") && value) {
+                            $input_query.val(decodeURIComponent(value.replace(/\+/g, " ")));
+                            $(".filters--search-button").trigger("click");
+                            param_count++;
                         }
-                    });
-
-                    if (param_count === 0) {
-                        ind.filter($list_item, query);
                     }
-                } else {
+                });
+
+                if (param_count === 0) {
                     ind.filter($list_item, query);
                 }
-           });
+            } else {
+                ind.filter($list_item, query);
+            }
 
             $(document).click(function(evt) {
                 if (!$(evt.target).closest(".dropdown").length) {

--- a/src/js/ia/IAIndex.js
+++ b/src/js/ia/IAIndex.js
@@ -28,7 +28,7 @@
             var $dropdown_header;
             var $input_query;
             var query = "";
-            ind.ia_list = ia_init;
+            ind.ia_list = ia_init();
 
             ind.refresh();
             $list_item = $("#ia-list .ia-item");

--- a/src/js/ia/IAIndex.js
+++ b/src/js/ia/IAIndex.js
@@ -30,7 +30,7 @@
             var query = "";
             ind.ia_list = ia_init;
 
-            ind.sort('name');
+            ind.refresh();
             $list_item = $("#ia-list .ia-item");
             $clear_filters = $("#clear_filters");
             $right_pane = $("#filters");

--- a/templates/instantanswer/index.tx
+++ b/templates/instantanswer/index.tx
@@ -1,3 +1,7 @@
+<script>
+  var ia_init = JSON.parse('<: $ia_init | raw :>');
+</script>
+
 <div class="left ia-index--left">
   <div class="ia-index-container">
     <div id="ia_index_header">

--- a/templates/instantanswer/index.tx
+++ b/templates/instantanswer/index.tx
@@ -1,5 +1,5 @@
 <script>
-  var ia_init = <: $ia_init | raw :>;
+  function ia_init() { return( <: $ia_init | raw :> ) }
 </script>
 
 <div class="left ia-index--left">

--- a/templates/instantanswer/index.tx
+++ b/templates/instantanswer/index.tx
@@ -1,5 +1,5 @@
 <script>
-  var ia_init = JSON.parse('<: $ia_init | raw :>');
+  var ia_init = <: $ia_init | raw :>;
 </script>
 
 <div class="left ia-index--left">


### PR DESCRIPTION
@MariagraziaAlastra So this "works" but I've hit a wall or two.

- Encoding - wondering what's the best way to safely get the JSON string into the template, then into the js? The manual approach here is not robust ([raw strings, yich](https://github.com/duckduckgo/community-platform/blob/e8f8e1e/templates/instantanswer/index.tx#L2)) and has problems:

![BBC IA](http://jbrt.org/ddg/BBC_IA.png)

- I return the list sorted by name, so there should be no need for [this](https://github.com/duckduckgo/community-platform/blob/e8f8e1e/src/js/ia/IAIndex.js#L33) but when I remove it the index doesn't load - I'm guessing I misunderstand the purpose of this line.

I'd be interested in your impression of the difference in load times. Another experiment based on this code should be incoming later.