### PR TITLE
Hax: Using PG's json encoder (Do *NOT* merge!)

### DIFF
--- a/lib/DDGC/DB/ResultSet/InstantAnswer.pm
+++ b/lib/DDGC/DB/ResultSet/InstantAnswer.pm
@@ -31,6 +31,50 @@ sub ia_index_hri {
     return $ial->all_ref;
 }
 
+sub ia_index_pg_json {
+    my ( $self, $limit, $last ) = @_;
+    my @bind;
 
+    my $query = <<'QUERY';
+        SELECT array_to_json(array_agg(row_to_json(instant_answer_row)))
+        FROM (
+            SELECT instant_answer.name, instant_answer.repo, instant_answer.src_name,
+                   instant_answer.dev_milestone, instant_answer.description,
+                   instant_answer.template, instant_answer.id, instant_answer.meta_id,
+                (
+                    SELECT array_to_json(array_agg(row_to_json(topic_row)))
+                    FROM (
+                        SELECT instant_answer_topics.instant_answer_id,
+                               instant_answer_topics.topics_id,
+                               ( SELECT row_to_json(inner_topic_row)
+                                   FROM (
+                                       SELECT inner_topics.name, inner_topics.id
+                                       FROM   topics inner_topics
+                                       WHERE  inner_topics.id = instant_answer_topics.topics_id
+                                    ) inner_topic_row
+                               ) AS topic
+                        FROM   instant_answer_topics, topics
+                        WHERE  instant_answer_topics.instant_answer_id = instant_answer.id
+                          AND  instant_answer_topics.topics_id = topics.id
+                    ) topic_row
+                ) AS instant_answer_topics
+            FROM instant_answer
+            ORDER BY instant_answer.name
+        ) instant_answer_row
+QUERY
+
+
+    if ( $last ) {
+        $query .= "WHERE instant_answer.name > ?\n";
+        push @bind, $last;
+    }
+    if ( $limit ) {
+        $query .= "LIMIT ?\n";
+        push @bind, $limit;
+    }
+
+    my $result = $self->schema->storage->dbh->selectall_arrayref($query, undef, @bind);
+    return $result;
+}
 
 1;

--- a/lib/DDGC/DB/ResultSet/InstantAnswer.pm
+++ b/lib/DDGC/DB/ResultSet/InstantAnswer.pm
@@ -53,12 +53,20 @@ sub ia_index_pg_json {
                                        WHERE  inner_topics.id = instant_answer_topics.topics_id
                                     ) inner_topic_row
                                ) AS topic
-                        FROM   instant_answer_topics, topics
+                        FROM   instant_answer_topics
                         WHERE  instant_answer_topics.instant_answer_id = instant_answer.id
-                          AND  instant_answer_topics.topics_id = topics.id
                     ) topic_row
                 ) AS instant_answer_topics
             FROM instant_answer
+            WHERE instant_answer.id IN (
+                SELECT instant_answer.id from instant_answer
+                LEFT JOIN instant_answer_topics
+                       ON instant_answer_topics.instant_answer_id = instant_answer.id
+                LEFT JOIN topics
+                       ON instant_answer_topics.topics_id = topics.id
+                WHERE topics.name != 'test'
+                AND instant_answer.dev_milestone = 'live'
+            )
             ORDER BY instant_answer.name
         ) instant_answer_row
 QUERY

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -37,9 +37,7 @@ sub index :Chained('base') :PathPart('') :Args(0) {
      ->hri
      ->all;
 
-    $c->stash->{ia_init} = encode_json(
-        $c->d->rs('InstantAnswer')->ia_index_hri
-    );
+    $c->stash->{ia_init} = $c->d->rs('InstantAnswer')->ia_index_pg_json->[0]->[0];
     $c->stash->{ia_init} =~ s/'/\\'/g;
     $c->stash->{ia_init} =~ s/\\"/\\\\"/g;
 
@@ -51,6 +49,9 @@ sub index :Chained('base') :PathPart('') :Args(0) {
 
 sub ialist_json :Chained('base') :PathPart('json') :Args() {
     my ( $self, $c ) = @_;
+    $c->res->content_type("application/json");
+    $c->response->body( $c->d->rs('InstantAnswer')->ia_index_pg_json->[0]->[0] );
+    return $c->detach;
 
     $c->stash->{x} = $c->d->rs('InstantAnswer')->ia_index_hri(
         $c->req->params->{limit},


### PR DESCRIPTION
Following on from  #1037 ... This code is pretty crusty but another option for getting JSON is straight from Postgres itself.

**If you merge and deploy this, the server will go on fire - it needs at least postgres 9.2, it is here for demo and discussion purposes only.**

So, there are plenty of factors at play here, but let's try some basic benchmarking, see what shakes out.

- ApacheBench - This PR (DBI Handle, Postgres `*_to_json`):

```
$ ab -n 50 -c 1 http://192.168.0.10:5001/ia/json
This is ApacheBench, Version 2.3 <$Revision: 1528965 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking 192.168.0.10 (be patient).....done


Server Software:        
Server Hostname:        192.168.0.10
Server Port:            5001

Document Path:          /ia/json
Document Length:        269574 bytes

Concurrency Level:      1
Time taken for tests:   3.987 seconds
Complete requests:      50
Failed requests:        0
Total transferred:      13491450 bytes
HTML transferred:       13478700 bytes
Requests per second:    12.54 [#/sec] (mean)
Time per request:       79.731 [ms] (mean)
Time per request:       79.731 [ms] (mean, across all concurrent requests)
Transfer rate:          3304.93 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:    76   80   4.0     79      96
Waiting:       74   77   3.9     76      94
Total:         76   80   4.0     79      96

Percentage of the requests served within a certain time (ms)
  50%     79
  66%     80
  75%     81
  80%     82
  90%     84
  95%     86
  98%     96
  99%     96
 100%     96 (longest request)
```

- ApacheBench (DBIC, HRI, JSON::MaybeXS (probably Cpanel::JSON::XS))

```
$ ab -n 50 -c 1 http://192.168.0.10:5001/ia/json
This is ApacheBench, Version 2.3 <$Revision: 1528965 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking 192.168.0.10 (be patient).....done


Server Software:        
Server Hostname:        192.168.0.10
Server Port:            5001

Document Path:          /ia/json
Document Length:        187426 bytes

Concurrency Level:      1
Time taken for tests:   3.154 seconds
Complete requests:      50
Failed requests:        0
Total transferred:      9384800 bytes
HTML transferred:       9371300 bytes
Requests per second:    15.85 [#/sec] (mean)
Time per request:       63.081 [ms] (mean)
Time per request:       63.081 [ms] (mean, across all concurrent requests)
Transfer rate:          2905.74 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:    53   63   5.4     62      77
Waiting:       51   60   5.3     60      74
Total:         53   63   5.4     62      77

Percentage of the requests served within a certain time (ms)
  50%     62
  66%     64
  75%     66
  80%     68
  90%     71
  95%     72
  98%     77
  99%     77
 100%     77 (longest request)
```

DBIC appears to be faster! I am going to guess this is due to our query complexity - in order to produce JSON compatible with the current IA index code, the topic names need to be [nested under the `instant_answer_topics` key](https://github.com/duckduckgo/community-platform/blob/e21c7d1/lib/DDGC/DB/ResultSet/InstantAnswer.pm#L49-L55). If we change the query to have topic name at the same level:

```sql
        SELECT array_to_json(array_agg(row_to_json(instant_answer_row)))
        FROM (
            SELECT instant_answer.name, instant_answer.repo, instant_answer.src_name,
                   instant_answer.dev_milestone, instant_answer.description,
                   instant_answer.template, instant_answer.id, instant_answer.meta_id,
                (
                    SELECT array_to_json(array_agg(row_to_json(topic_row)))
                    FROM (
                        SELECT instant_answer_topics.instant_answer_id,
                               instant_answer_topics.topics_id,
                               topics.name, topics.id
                        FROM   instant_answer_topics, topics
                        WHERE  instant_answer_topics.instant_answer_id = instant_answer.id
                          AND  instant_answer_topics.topics_id = topics.id
                    ) topic_row
                ) AS instant_answer_topics
            FROM instant_answer
            ORDER BY instant_answer.name
        ) instant_answer_row
```

...and run it again:

```
$ ab -n 50 -c 1 http://192.168.0.10:5001/ia/json
This is ApacheBench, Version 2.3 <$Revision: 1528965 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking 192.168.0.10 (be patient).....done


Server Software:        
Server Hostname:        192.168.0.10
Server Port:            5001

Document Path:          /ia/json
Document Length:        258794 bytes

Concurrency Level:      1
Time taken for tests:   3.401 seconds
Complete requests:      50
Failed requests:        0
Total transferred:      12952450 bytes
HTML transferred:       12939700 bytes
Requests per second:    14.70 [#/sec] (mean)
Time per request:       68.024 [ms] (mean)
Time per request:       68.024 [ms] (mean, across all concurrent requests)
Transfer rate:          3718.96 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:    64   68   3.3     67      82
Waiting:       62   66   3.2     65      80
Total:         64   68   3.4     67      82

Percentage of the requests served within a certain time (ms)
  50%     67
  66%     68
  75%     69
  80%     70
  90%     72
  95%     74
  98%     82
  99%     82
 100%     82 (longest request)
```

Oh. Not enough of a difference to declare anything really. It's quite probable my query stinks and optimisations there would help but this approach appears to add quite a bit of complexity in how we handle queries for little apparent gain.

Would be interested in your thoughts @zachthompson @MariagraziaAlastra @jdorweiler @russellholt 