### PR TITLE
IAPage.js - fix typo in the beta data hash

### DIFF
--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -149,7 +149,7 @@
                         if (!$(this).hasClass("disabled")) {
                             $(this).addClass("disabled");
                             var temp_hash = {
-                                "action" : "duck.co",
+                                "action" : "duckco",
                                 "number" : ia_data.live.pr.id,
                                 "repo" : "zeroclickinfo-" + ia_data.live.repo
                             };


### PR DESCRIPTION
//cc @jdorweiler 
Action is 'duckco', not 'duck.co'