### PR TITLE
_pipeline.scss - select elements should have 100% width only in the actions sidebar

### DIFF
--- a/src/scss/ia/_pipeline.scss
+++ b/src/scss/ia/_pipeline.scss
@@ -189,6 +189,10 @@ textarea.edit-sidebar {
 
 #actions_sidebar {
     width: 240px;
+
+    .frm__select {
+	width: 100%;
+    }
 }
 
 #page_sidebar, #actions_sidebar {
@@ -205,10 +209,6 @@ textarea.edit-sidebar {
 
     .frm__label {
 	font-weight: 400;
-    }
-
-    .frm__select {
-	width: 100%;
     }
 
     .sidebar-field {


### PR DESCRIPTION
Fix for type dropdown too wide in the single page sidebar