### PR TITLE
Return 1:0, not result instance for $user->is

### DIFF
--- a/lib/DDGC/DB/Result/User.pm
+++ b/lib/DDGC/DB/Result/User.pm
@@ -258,7 +258,7 @@ sub is {
 	$role = normalise_role( $role );
 	return 1 if ( $role eq 'user' );
 	return 1 if $self->roles->find({ role => $self->ddgc->config->id_for_role('admin') });
-	return $self->roles->find({ role => $self->ddgc->config->id_for_role( $role ) });
+	return ( $self->roles->find({ role => $self->ddgc->config->id_for_role( $role ) }) ) ? 1 : 0;
 }
 
 sub add_role {


### PR DESCRIPTION
@jdorweiler @MariagraziaAlastra My bad, I thought we were just looking for truthiness from this test - didn't consider the result would be assigned for other stuff. This should resolve the useless Result instances finding their way into ghIssues.