### PR TITLE
Have If-Modified-Since check do date comparison.

### DIFF
--- a/lib/DDGC/Web.pm
+++ b/lib/DDGC/Web.pm
@@ -328,8 +328,11 @@ sub return_if_not_modified {
 	$c->response->header(
 		'Last-Modified' => "$dt",
 	);
+	return if !$if_modified_since;
 
-	if ( $if_modified_since eq "$dt" ) {
+	my $if_modified_since_dt = DateTime::Format::HTTP->parse_datetime( $if_modified_since );
+
+	if ( DateTime->compare( $dt, $if_modified_since_dt ) <= 0 ) {
 		$c->response->headers->remove_header($_)
 		    for ( qw/ Content-Type Content-Length Content-Disposition / );
 		$c->response->status('304');


### PR DESCRIPTION
Reading RFCs to design software bad, actually verifying client behaviour good. So we should now be able to use curl...

- First request

```
$ time curl -sD - -z repo.json -o repo.json http://127.0.0.1:5004/ia/repo/all/json
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
Last-Modified: Tue, 22 Sep 2015 18:02:58 GMT
X-Catalyst: 5.90085
Content-Length: 501523
Set-Cookie: ddgc_session=579a355f9ccdab96381e3bbd8f4f68fa8dfeb70f; path=/; expires=Fri, 13-Nov-2015 14:28:36 GMT; HttpOnly
Date: Fri, 13 Nov 2015 08:28:36 GMT
Connection: keep-alive


real    0m1.682s
user    0m0.000s
sys     0m0.016s
```

Thanks for the useful and tasty cookie!

- Second request

```
$ time curl -sD - -z repo.json -o repo.json http://127.0.0.1:5004/ia/repo/all/json
HTTP/1.1 304 Not Modified
Content-Type: text/html; charset=utf-8
Last-Modified: Tue, 22 Sep 2015 18:02:58 GMT
X-Catalyst: 5.90085
Set-Cookie: ddgc_session=941f2ae3b7e542d0ce8ee1e446e9aa45510caa52; path=/; expires=Fri, 13-Nov-2015 14:28:37 GMT; HttpOnly
Date: Fri, 13 Nov 2015 08:28:37 GMT
Connection: keep-alive


real    0m0.028s
user    0m0.004s
sys     0m0.008s
```

And to verify it doesn't mess with stuff that uses exact dt:

- First request
```
$ perl -MLWP::Simple -e 'printf "%s\n", mirror( "http://127.0.0.1:5004/ia/repo/all/json", "repo.json" )'
200
```

- Second request

```
$ perl -MLWP::Simple -e 'printf "%s\n", mirror( "http://127.0.0.1:5004/ia/repo/all/json", "repo.json" )'
304
```

@jkv @zachthompson Thanks!