### PR TITLE
Fixing blog test...

### DIFF
--- a/lib/Dancer2/Plugin/DDGC/Service.pm
+++ b/lib/Dancer2/Plugin/DDGC/Service.pm
@@ -46,6 +46,23 @@ on_plugin_import {
             },
         )
     );
+
+    # https://github.com/PerlDancer/Dancer2/pull/1040
+    #
+    # The version of Dancer2 which eliminated the DEPRECATED! warnings
+    # for plugins within plugins seems to have introduced a bug in
+    # Content-Length handling while using the JSON serialiser with
+    # forward.
+    #
+    # This hook has the same effect as the solution implemented in
+    # Dancer2 and can safely remain in place after we start using
+    # > v0.163000 but should be removed.
+    $dsl->app->add_hook(
+        Dancer2::Core::Hook->new(
+            name => 'before',
+            code => sub { delete $_[0]->request->env->{CONTENT_LENGTH} },
+        ),
+    );
 };
 
 register_plugin;

--- a/t/blog.t
+++ b/t/blog.t
@@ -42,13 +42,13 @@ test_psgi $app => sub {
     # Create user, get session cookie
     my $user_request = $cb->(
         POST '/testutils/new_user',
-        { username => 'adminuser', role => 'admin' }
+        { username => 'blogadminuser', role => 'admin' }
     );
     ok( $user_request->is_success, 'Creating an admin user' );
 
     my $session_request = $cb->(
         POST '/testutils/user_session',
-        { username => 'adminuser' }
+        { username => 'blogadminuser' }
     );
     ok( $session_request->is_success, 'Getting admin user Cookie' );
     my $admin_cookie_header = 'ddgc_session=' . $session_request->content;

--- a/t/blog.t
+++ b/t/blog.t
@@ -11,6 +11,8 @@ use HTTP::Request::Common;
 use Plack::Test;
 use Plack::Builder;
 use Plack::Session::State::Cookie;
+use Plack::Session::Store::File;
+use File::Temp qw/ tempdir /;
 use JSON::MaybeXS qw/:all/;
 
 use DDGC::Web::App::Blog;
@@ -20,7 +22,9 @@ use DDGC::Web::Service::Blog;
 
 my $app = builder {
     enable 'Session',
-        store => 'File',
+        store => Plack::Session::Store::File->new(
+            dir => tempdir,
+        ),
         state => Plack::Session::State::Cookie->new(
             secure => 0,
             httponly => 1,

--- a/t/blog.t
+++ b/t/blog.t
@@ -11,10 +11,12 @@ use HTTP::Request::Common;
 use Plack::Test;
 use Plack::Builder;
 use Plack::Session::State::Cookie;
-use JSON;
+use JSON::MaybeXS qw/:all/;
 
 use DDGC::Web::App::Blog;
 use DDGC::Web::Service::Blog;
+
+
 
 my $app = builder {
     enable 'Session',
@@ -48,14 +50,13 @@ test_psgi $app => sub {
     my $admin_cookie_header = 'ddgc_session=' . $session_request->content;
 
     # Posting
-    my $blog_post = JSON::to_json({
+    my $blog_post = encode_json({
         title       => 'A blog post',
         uri         => 'a-blog-post',
         teaser      => 'This is a blog post karble warble snarble',
         content     => 'This is a blog post',
         topics      => [qw/blogs posts this/],
-    },
-    { utf8 => 1 });
+    });
 
     my $new_post_request = $cb->(
         POST '/blog.json/admin/post/new',


### PR DESCRIPTION
This PR is really preparing us to start using a version of Dancer2 which does not spit out **DEPRECATED** warnings for calling plugins within plugins.

v0.163000 has a bug which causes Plack to barf when using forward with the JSON serialiser. This is resolved in https://github.com/PerlDancer/Dancer2/pull/1040 but is not yet released.

In summary:

- This should fix current Travis CI errors
- This change is not harmful to the existing deployed version (that I know of)
- If we start using Dancer2 0.163000 to get rid of deprecation errors, this is useful
- The hook will not be harmful for versions **after** 0.163000 but should be removed

@MariagraziaAlastra @zachthompson Thanks!