### PR TITLE
change ddg attribution name

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -1067,7 +1067,7 @@ sub save_edit :Chained('base') :PathPart('save') :Args(0) {
                             $temp_url = 'https://github.com/'.$temp_username;
                         } elsif ($temp_type eq 'ddg') {
                             #IA was developed internally - set default values
-                            $temp_fullname = "DDG Team";
+                            $temp_fullname = "DuckDuckGo";
                             $temp_url = "http://www.duckduckhack.com";
                         } else {
                             # Type is 'legacy', so the username contains the url to 

--- a/sql/1.101/ddg-attribution.sql
+++ b/sql/1.101/ddg-attribution.sql
@@ -1,0 +1,3 @@
+BEGIN;
+    UPDATE instant_answer SET developer = '[{"name":"DuckDuckGo", "url":"http://www.duckduckhack.com", "type":"ddg"}]' where developer = '[{"name":"DDG Team","url":"http://www.duckduckhack.com","type":"ddg"}]';
+COMMIT;


### PR DESCRIPTION
Change ddg attribution name from "DDG Team" to "DuckDuckGo".  The sql only fixes IAs where the only dev is DDG Team.  There are a few with multiple devs that I'll have to fix by hand.  I need to wait for the  change to InstantAnswer.pm for that though. 
