### PR TITLE
IA Overview Page - create IA Page from PR link (front-end)

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -1249,8 +1249,6 @@ sub create_ia_from_pr :Chained('base') :PathPart('create_from_pr') :Args() {
         my @files = $gh->pull_request->files($pr_number);
         my $pr_data = $gh->pull_request->pull($pr_number);
 
-        # try to find an id in the files
-        my $id;
             # spice
         if($repo =~ /spice/i){
             foreach my $file (@files){

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -10,6 +10,7 @@ use Net::GitHub::V3;
 use DateTime;
 use LWP::UserAgent;
 use Digest::SHA;
+use Date::Parse;
 
 my $INST = DDGC::Config->new->appdir_path."/root/static/js";
 
@@ -1237,8 +1238,80 @@ sub create_ia :Chained('base') :PathPart('create') :Args() {
 sub create_ia_from_pr :Chained('base') :PathPart('create_from_pr') :Args() {
     my ( $self, $c ) = @_;
 
-    my $result = '';
-    my $id = '';
+    use Data::Dumper;
+
+    my $url = $c->req->params->{pr};
+    my ($id, $result) = '';
+
+    if(my ($repo, $pr_number) = $url =~ /https?:\/\/github.com\/duckduckgo\/zeroclickinfo-(.+)\/pull\/(.+)$/){
+        warn "Got valid link";
+
+        # get data form this pr
+        my $token = $ENV{DDGC_GITHUB_TOKEN} || $ENV{DDG_GITHUB_BASIC_OAUTH_TOKEN};
+        my $gh = Net::GitHub->new(access_token => $token);
+
+        my @files = $gh->pull_request->files('duckduckgo', 'zeroclickinfo-'.$repo, $pr_number);
+        my $pr_data = $gh->pull_request->pull('duckduckgo', 'zeroclickinfo-'.$repo, $pr_number);
+        
+        # warn Dumper @files;
+
+        # try to find an id in the files
+        my $id;
+            # spice
+        if($repo =~ /spice/i){
+            foreach my $file (@files){
+                ($id) = $file->{patch} =~ /id:\s?(?:'|")(.+)(?:'|")/;
+                last if $id;
+            }
+        }
+        elsif( $repo =~ /goodie/i ){
+            # check for cheat sheets
+            my $is_cheatsheet;
+            my $cheat_sheet_json;
+
+            foreach my $file (@files){
+                ($is_cheatsheet) = $file->{filename} =~ /cheat_sheets\/json/;
+                $cheat_sheet_json = $file->{patch};
+                last if $is_cheatsheet;
+            }
+
+            # cheat sheets
+            if($is_cheatsheet){
+                ($id) = $cheat_sheet_json =~ /(?:'|")id(?:'|"):\s?(?:'|")(.+)(?:'|"),/;
+            }else{
+                # find from perl module
+                foreach my $file (@files){
+                    my $tmp_repo = $repo;
+                    $tmp_repo =~ s/s$//;
+                    ($id) = $file->{filename} =~ /lib\/DDG\/$tmp_repo\/(.+)\.pm/i;
+                    last if $id;
+                }
+            }
+
+        }
+
+        if($id){
+            $c->d->rs('InstantAnswer')->update_or_create({
+                id => $id,
+                meta_id => $id,
+                name => $id,
+                repo => $repo,
+                dev_milestone => 'planning'
+            });
+
+            $c->d->rs('InstantAnswer::Issues')->update_or_create({
+                instant_answer_id => $id,
+                repo => $repo,
+                issue_id => $pr_number,
+                is_pr => 1,
+                tags => {},
+            });
+
+            # update first comment with link to IA page
+            warn Dumper $pr_data->{body};
+            warn Dumper $pr_data->{id};
+        }
+    }
 
     $c->stash->{x} = {
         result => $result,

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -1234,6 +1234,21 @@ sub create_ia :Chained('base') :PathPart('create') :Args() {
     return $c->forward($c->view('JSON'));
 }
 
+sub create_ia_from_pr :Chained('base') :PathPart('create_from_pr') :Args() {
+    my ( $self, $c ) = @_;
+
+    my $result = '';
+    my $id = '';
+
+    $c->stash->{x} = {
+        result => $result,
+        id => $id
+    };
+
+    $c->stash->{not_last_url} = 1;
+    return $c->forward($c->view('JSON'));
+}
+
 sub format_id {
     my( $id ) = @_;
 

--- a/src/js/ia/IAOverview.js
+++ b/src/js/ia/IAOverview.js
@@ -19,15 +19,13 @@
             });
 
              $("body").on("click", "#create-new-ia, #create-ia-from-pr", function(evt) {
-                $(this).hide();
+                $("#create-new-ia, #create-ia-from-pr").addClass("hide");
                 $("#" + $(this).attr("id") + "-form").removeClass("hide");
             });
 
             $("body").on('click', "#new-ia-form-cancel, #create-ia-from-pr-cancel", function(evt) {
-                var $modal = $(this).parent();
-                    
-                $modal.addClass("hide");
-                $("#" + $modal.attr("id").replace("-form", "")).show();
+                $(this).parent().addClass("hide");
+                $("#create-new-ia, #create-ia-from-pr").removeClass("hide");
             });
 
             $("body").on("click", "#create-ia-from-pr-save", function(evt) {

--- a/src/js/ia/IAOverview.js
+++ b/src/js/ia/IAOverview.js
@@ -24,12 +24,14 @@
             });
 
             $("body").on('click', "#new-ia-form-cancel, #create-ia-from-pr-cancel", function(evt) {
-                $(this).parent().addClass("hide");
+                var $modal = $(this).parent();
+                $modal.addClass("hide");
+                $modal.find("input, textarea").val("").removeClass("not_saved");
                 $("#create-new-ia, #create-ia-from-pr").removeClass("hide");
             });
 
             $("body").on("click", "#create-ia-from-pr-save", function(evt) {
-                var $pr_input = $("#pr-link");
+                var $pr_input = $("#pr-input");
                 var pr = $.trim($pr_input.val());
                 if (pr.length) {
                     var jqxhr = $.post("/ia/create_from_pr", {
@@ -63,7 +65,7 @@
                 }
             });
 
-            function checkRedirect(data) {
+            function checkRedirect(data, $input) {
                 if (data.result && data.id) {
                     window.location = '/ia/view/' + data.id;
                 } else {

--- a/src/js/ia/IAOverview.js
+++ b/src/js/ia/IAOverview.js
@@ -38,6 +38,7 @@
                         pr : pr
                     })
                     .done(function(data) {
+                        console.log(data);
                         checkRedirect(data, $pr_input);
                     });
                 }

--- a/src/js/ia/IAOverview.js
+++ b/src/js/ia/IAOverview.js
@@ -18,14 +18,29 @@
                 $("#ia-overview").html(template);
             });
 
-             $("body").on("click", "#create-new-ia", function(evt) {
+             $("body").on("click", "#create-new-ia, #create-ia-from-pr", function(evt) {
                 $(this).hide();
-                $("#create-new-ia-form").removeClass("hide");
+                $("#" + $(this).attr("id") + "-form").removeClass("hide");
             });
 
-            $("body").on('click', "#new-ia-form-cancel", function(evt) {
-                $("#create-new-ia-form").addClass("hide");
-                $("#create-new-ia").show();
+            $("body").on('click', "#new-ia-form-cancel, #create-ia-from-pr-cancel", function(evt) {
+                var $modal = $(this).parent();
+                    
+                $modal.addClass("hide");
+                $("#" + $modal.attr("id").replace("-form", "")).show();
+            });
+
+            $("body").on("click", "#create-ia-from-pr-save", function(evt) {
+                var $pr_input = $("#pr-link");
+                var pr = $.trim($pr_input.val());
+                if (pr.length) {
+                    var jqxhr = $.post("/ia/create_from_pr", {
+                        pr : pr
+                    })
+                    .done(function(data) {
+                        checkRedirect(data, $pr_input);
+                    });
+                }
             });
 
             $("body").on('click', "#new-ia-form-save", function(evt) {
@@ -45,14 +60,18 @@
                         dev_milestone : dev_milestone
                     })
                     .done(function(data) {
-                        if (data.result && data.id) {
-                            window.location = '/ia/view/' + data.id;
-                        } else {
-                            $id_input.addClass("not_saved");
-                        }
+                        checkRedirect(data, $id_input);
                     });
                 }
             });
+
+            function checkRedirect(data) {
+                if (data.result && data.id) {
+                    window.location = '/ia/view/' + data.id;
+                } else {
+                    $input.addClass("not_saved");
+                }
+            }
         }
     };
 })(DDH); 

--- a/src/scss/ia/_ia.scss
+++ b/src/scss/ia/_ia.scss
@@ -240,27 +240,6 @@
 #ia_index {
     width: 100%;
 }
-#create-new-ia-form {
-    position: fixed;
-    background-color: #fff;
-    width: 31em;
-    z-index: 1000;
-    border: 1px solid #dbdbdb;
-    top: 11em;
-    left: 33em;
-    box-shadow: 2px 5px 20px 5px #888;
-    padding: 20px 0 20px 25px;
-}
-.new-ia-form-section {
-    margin-right: 0.5em;
-}
-#new-ia-form-cancel {
-    margin-left: 0.5em;
-}
-#create-new-ia-form #description-input {
-    width: 94%;
-    margin-bottom: 0.5em;
-}
 #filters {
     width: 25%;
     text-align: center;

--- a/src/scss/ia/_overview.scss
+++ b/src/scss/ia/_overview.scss
@@ -10,6 +10,31 @@
     width: 42%;
 }
 
+#create-new-ia-form, #create-ia-from-pr-form {
+    position: fixed;
+    background-color: #fff;
+    width: 31em;
+    z-index: 1000;
+    border: 1px solid #dbdbdb;
+    top: 11em;
+    left: 33em;
+    box-shadow: 2px 5px 20px 5px #888;
+    padding: 20px 0 20px 25px;
+
+    #description-input {
+        width: 94%;
+        margin-bottom: 0.5em;
+    }
+
+    .new-ia-form-section {
+        margin-right: 0.5em;
+    }
+
+    #create-new-ia-form-cancel, #create-ia-from-pr-form-cancel {
+        margin-left: 0.5em;
+    }
+}
+
 /* General page style */
 #ia-overview { 
     margin-top: 3.5em; 

--- a/src/scss/ia/_overview.scss
+++ b/src/scss/ia/_overview.scss
@@ -20,8 +20,17 @@
 }
 
 #create-new-ia-form {
-    width: 31em;
+    width: 29.5em;
     left: 50em;
+
+    #description-input {
+        width: 100%;
+        margin-bottom: 0.5em;
+    }
+
+    #id-input { width: 18.25em; }
+
+    #name-input { width: 29em; }
 }
 
 #create-new-ia-form, #create-ia-from-pr-form {
@@ -33,17 +42,8 @@
     box-shadow: 2px 5px 20px 5px #888;
     padding: 20px;
 
-    #description-input {
-        width: 94%;
-        margin-bottom: 0.5em;
-    }
-
     .new-ia-form-section {
         margin-right: 0.5em;
-    }
-
-    #create-new-ia-form-cancel, #create-ia-from-pr-form-cancel {
-        margin-left: 0.5em;
     }
     
     .button { margin-right: 1em; }

--- a/src/scss/ia/_overview.scss
+++ b/src/scss/ia/_overview.scss
@@ -10,16 +10,28 @@
     width: 42%;
 }
 
+#create-ia-from-pr { margin-right: 1em; }
+
+#create-ia-from-pr-form {
+    width: 40em;
+    left: 43em;
+
+    input { margin-bottom: 1em; }
+}
+
+#create-new-ia-form {
+    width: 31em;
+    left: 50em;
+}
+
 #create-new-ia-form, #create-ia-from-pr-form {
     position: fixed;
     background-color: #fff;
-    width: 31em;
     z-index: 1000;
     border: 1px solid #dbdbdb;
     top: 11em;
-    left: 33em;
     box-shadow: 2px 5px 20px 5px #888;
-    padding: 20px 0 20px 25px;
+    padding: 20px;
 
     #description-input {
         width: 94%;
@@ -33,6 +45,8 @@
     #create-new-ia-form-cancel, #create-ia-from-pr-form-cancel {
         margin-left: 0.5em;
     }
+    
+    .button { margin-right: 1em; }
 }
 
 /* General page style */

--- a/templates/instantanswer/overview.tx
+++ b/templates/instantanswer/overview.tx
@@ -1,24 +1,24 @@
 <: if $is_admin { :>
     <div id="create-new-ia-form" class="new-ia-form hide">
-        <div class="new-ia-form-section left">
+        <div class="new-ia-form-section">
             <div class="label">
                 Name
             </div>
-            <input id="name-input" class="new-ia-input">
+            <input id="name-input" class="new-ia-inputi frm__input">
         </div>
 
         <div class="new-ia-form-section left">
             <div class="label">
                 ID
             </div>
-            <input id="id-input" class="new-ia-input">
+            <input id="id-input" class="new-ia-input frm__input">
         </div>
 
         <div class="new-ia-form-section left">
             <div class="label">
                 Dev Milestone
             </div>
-            <span class="new-ia-select" id="dev_milestone-select">
+            <span class="new-ia-select frm__select" id="dev_milestone-select">
                 <select class="available_dev_milestones" tabindex="-1">
                     <option value="1">planning</option>
                     <option value="2">development</option>
@@ -33,10 +33,10 @@
             <div class="label">
                 Description
             </div>
-            <textarea id="description-input" class="new-ia-input" rows="5"></textarea>
+            <textarea id="description-input" class="new-ia-input frm__text" rows="5"></textarea>
         </div>
 
-        <div class="button left" id="new-ia-form-save">
+        <div class="button btn--primary left" id="new-ia-form-save">
             Save
         </div>
 
@@ -49,10 +49,10 @@
     <div id="create-ia-from-pr-form" class="new-ia-form hide">
         <div>
             <div class="label"> PR link </div>
-            <input id="pr-input" class="new-ia-input" />
+            <input id="pr-input" class="new-ia-input frm__input" />
         </div>
 
-        <div class="button left" id="create-ia-from-pr-save">
+        <div class="button btn--primary left" id="create-ia-from-pr-save">
             Save
         </div>
 

--- a/templates/instantanswer/overview.tx
+++ b/templates/instantanswer/overview.tx
@@ -45,6 +45,22 @@
         </div>
         <span class="clearfix"></span>
     </div>
+
+    <div id="create-ia-from-pr-form" class="new-ia-form hide">
+        <div>
+            <div class="label"> PR link </div>
+            <input id="pr-input" class="new-ia-input" />
+        </div>
+
+        <div class="button left" id="create-ia-from-pr-save">
+            Save
+        </div>
+
+        <div class="button left" id="create-ia-from-pr-cancel">
+            Cancel
+        </div>
+        <span class="clearfix"></span>
+    </div>
 <: } :>
 
 <div class="pipeline__toggle-view" id="pipeline_toggle-view">
@@ -68,6 +84,10 @@
     <: if $is_admin { :>
       <div id="create-new-ia" class="button right">
         New IA Page
+      </div>
+
+      <div id="create-ia-from-pr" class="button right">
+        New IA Page from GitHub PR
       </div>
     <: } :>
 </div>


### PR DESCRIPTION
//cc @jdorweiler  Also set up a basic JSON endpoint for saving (doesn't really do anything for now).
The button is in ia/dev:
![screenshot-maria-old duckduckgo com 5001 2015-11-18 15-33-05](https://cloud.githubusercontent.com/assets/3652195/11243778/3531d92c-8e0a-11e5-9b59-198ac38780dd.png)

The modal for page creation from PR:
![screenshot-maria-old duckduckgo com 5001 2015-11-18 15-31-23](https://cloud.githubusercontent.com/assets/3652195/11243785/4881057a-8e0a-11e5-8ceb-1813117945ab.png)

On error:
![screenshot-maria-old duckduckgo com 5001 2015-11-18 15-32-20](https://cloud.githubusercontent.com/assets/3652195/11243733/f6fa021a-8e09-11e5-9970-f692c3c80127.png)

While I was at it I also improved a bit the appearance of the other modal:
![screenshot-maria-old duckduckgo com 5001 2015-11-18 15-33-37](https://cloud.githubusercontent.com/assets/3652195/11243794/5c9195a2-8e0a-11e5-8dbf-fd211ad9901f.png)

