### PR TITLE
IADevPipeline.js - match 'success' in the beta install status using a regex

### DIFF
--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -372,7 +372,7 @@
                        var page_data = getPageData(meta_id, milestone);
                         
                        // If at least one of the selected IAs isn't on beta we show the "install on beta" button
-                       if (page_data.beta_install !== "success") {
+                       if ((page_data.beta_install && (!page_data.beta_install.match(/^success/))) || (!page_data.beta_install)) {
                            actions_data.beta = 0;
                        }
 


### PR DESCRIPTION
Sometimes the install status can have more words than just "success", so we need to use a regex.