### PR TITLE
IADevPipeline.js - always open actions sidebar when selected IAs > 1

### DIFF
--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -357,7 +357,7 @@
                         $("#page_sidebar").html(sidebar).removeClass("hide");
                         $("#page_sidebar").attr("ia_id", page_data.id);
                     }
-                } else if (multi && selected > 1) {
+                } else if (selected > 1) {
                    var actions_data = {};
                    actions_data.permissions = dev_p.data.permissions;
                    actions_data.selected = selected;


### PR DESCRIPTION
Bugfix - previously deselecting one IA without holding shift closed the actions sidebar.