### PR TITLE
Gruntfile.js - add task for removing old static release files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -289,7 +289,7 @@ module.exports = function(grunt) {
             revert: "./script/revert_pkg_version.pl",
             revert_release: "./script/revert_pkg_version.pl release",
             deleteBuildFiles: "mkdir -p build && rm -r build",
-            commit_static: "git commit root/static -m 'Release IA pages version: <%= pkg.version %>'",
+            commit_static: "git commit root/static package.json -m 'Release IA pages version: <%= pkg.version %>'",
             bower: "bower install"
         },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -222,29 +222,6 @@ module.exports = function(grunt) {
         },
 
         /*
-         * commits the ia.js version file and package.json
-         * still needs to be pushed
-         */
-        gitcommit: {
-            ia_pages: {
-                options: {
-                    message: 'Release IA pages version: <%= pkg.version %>'
-                },
-                files: {
-                    src: [
-                        static_dir + 'js/ia0.*.0.js',
-                        static_dir + 'js/ddgc0.*.0.js',
-                        static_dir + 'css/ddgc0.*.0.css',
-                        static_dir + 'css/ia0.*.0.css',
-                        static_dir + 'css/ddgc.css',
-                        'package.json'
-                    ]
-                }
-            }
-
-        },
-
-        /*
          * removes console.log
          */
         removelogging: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,12 +18,13 @@ module.exports = function(grunt) {
 	    'concat_tasks',
 	    'concat:libs_release',
         'remove:dev',
-        'bump:minor'
+        'bump:minor',
+        'gitadd'
     ];
 
     // commit files for release
     var commit_tasks = [
-        'gitcommit'
+        'exec:commit_static'
     ];
 
     // Short-hand for the common concat tasks.
@@ -90,8 +91,8 @@ module.exports = function(grunt) {
                     groups: {
                         'Utils:': ['watch'],
                         'Build:' : ['handlebars', 'concat:libs_build', 'concat_tasks'],
-                        'Release:' : ['handlebars', 'concat', 'cssmin', 'removelogging', 'uglify', 'remove:dev', 'gitrm:old_releases', 'version'],
-                        'Commit:' : ['gitcommit'],
+                        'Release:' : ['handlebars', 'concat', 'cssmin', 'removelogging', 'uglify', 'remove:dev', 'gitrm:old_releases', 'version', 'gitadd'],
+                        'Commit:' : ['exec:commit_static'],
                         'Revert:' : ['exec:revert']
                     }
                 }
@@ -194,6 +195,20 @@ module.exports = function(grunt) {
             }
         },
 
+        gitadd: {
+            options: {
+                force: 'true'
+            },
+            files: {
+                src: [
+                    static_dir + 'js/ia0.*.0.js',
+                    static_dir + 'js/ddgc0.*.0.js',
+                    static_dir + 'css/ddgc0.*.0.css',
+                    static_dir + 'css/ia0.*.0.css'
+                ]
+            }
+        },
+
         /*
          * for release check ia.js to see if it has changed.  If true then
          * run the tasks.  If not then stop here.
@@ -274,6 +289,7 @@ module.exports = function(grunt) {
             revert: "./script/revert_pkg_version.pl",
             revert_release: "./script/revert_pkg_version.pl release",
             deleteBuildFiles: "mkdir -p build && rm -r build",
+            commit_static: "git commit root/static -m 'Release IA pages version: <%= pkg.version %>'",
             bower: "bower install"
         },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -205,6 +205,7 @@ module.exports = function(grunt) {
                     static_dir + 'js/ddgc0.*.0.js',
                     static_dir + 'css/ddgc0.*.0.css',
                     static_dir + 'css/ia0.*.0.css'
+                    static_dir + 'css/content.css'
                 ]
             }
         },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,15 +9,16 @@ module.exports = function(grunt) {
     // tasks that run after diff
     // to release a new version
     var release_tasks = [
+        'gitrm:old_releases',
         'build_release',
         'cssmin:ddgc_css',
         'cssmin:ia_css',
         'removelogging',
         'uglify:js',
-	'concat_tasks',
-	'concat:libs_release',
+	    'concat_tasks',
+	    'concat:libs_release',
         'remove:dev',
-        'bump:minor',
+        'bump:minor'
     ];
 
     // commit files for release
@@ -29,7 +30,7 @@ module.exports = function(grunt) {
     // This doesn't include the libraries because the 
     // inclusion of those depends on the kind of build.
     var concat_tasks = [
-	'concat:ia_pages',
+	    'concat:ia_pages',
         'concat:ddgc_pages',
         'concat:ia_css',
         'concat:ddgc_css',
@@ -42,8 +43,8 @@ module.exports = function(grunt) {
         'exec:deleteBuildFiles',
         'handlebars:compile',
         'compass',
-	'concat_tasks',
-	'concat:libs_build',
+	    'concat_tasks',
+	    'concat:libs_build',
         'jshint'
     ];
 
@@ -52,7 +53,7 @@ module.exports = function(grunt) {
         'exec:deleteBuildFiles',
         'handlebars:compile',
         'compass',
-	'concat_tasks',
+	    'concat_tasks',
         'jshint'
     ];
 
@@ -79,7 +80,7 @@ module.exports = function(grunt) {
         static_dir: static_dir,
         templates_dir: templates_dir,
         release_tasks: release_tasks,
-	concat_tasks: concat_tasks,
+	    concat_tasks: concat_tasks,
 
         availabletasks: {
             tasks: {
@@ -89,7 +90,7 @@ module.exports = function(grunt) {
                     groups: {
                         'Utils:': ['watch'],
                         'Build:' : ['handlebars', 'concat:libs_build', 'concat_tasks'],
-                        'Release:' : ['handlebars', 'concat', 'cssmin', 'removelogging', 'uglify', 'remove:dev', 'version'],
+                        'Release:' : ['handlebars', 'concat', 'cssmin', 'removelogging', 'uglify', 'remove:dev', 'gitrm:old_releases', 'version'],
                         'Commit:' : ['gitcommit'],
                         'Revert:' : ['exec:revert']
                     }
@@ -174,6 +175,22 @@ module.exports = function(grunt) {
                     static_dir + 'css/ddgc.css',
                     static_dir + 'css/ia.css'
                 ]
+            }
+        },
+        
+        gitrm: {
+            old_releases: {
+                options: { 
+                    force: 'true'
+                },
+                files: {
+                    src: [
+                        static_dir + 'js/ia0.*.0.js',
+                        static_dir + 'js/ddgc0.*.0.js',
+                        static_dir + 'css/ddgc0.*.0.css',
+                        static_dir + 'css/ia0.*.0.css'
+                    ]
+                }
             }
         },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -204,7 +204,7 @@ module.exports = function(grunt) {
                     static_dir + 'js/ia0.*.0.js',
                     static_dir + 'js/ddgc0.*.0.js',
                     static_dir + 'css/ddgc0.*.0.css',
-                    static_dir + 'css/ia0.*.0.css'
+                    static_dir + 'css/ia0.*.0.css',
                     static_dir + 'css/content.css'
                 ]
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddg_community_platform",
-  "version": "0.162.0",
+  "version": "0.146.0",
   "engines": {
     "node": ">=0.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddg_community_platform",
-  "version": "0.146.0",
+  "version": "0.162.0",
   "engines": {
     "node": ">=0.10.0"
   },
@@ -20,7 +20,7 @@
     "grunt-copy": "^0.1.0",
     "grunt-diff": "^0.1.5",
     "grunt-exec": "^0.4.6",
-    "grunt-git": "^0.2.14",
+    "grunt-git": "^0.3.7",
     "grunt-remove": "^0.1.0",
     "grunt-remove-logging": "^0.2.0",
     "grunt-version": "~0.2.2"


### PR DESCRIPTION
So, I added a gitrm task that takes care of removing all the old release files, a gitadd task that adds the newly released files, and an exec:commit_static task that commits all the new release files, plus package.json.
Can't use gitcommit anymore because it doesn't see deleted files.