### PR TITLE
Change foreign key on release_version

### DIFF
--- a/lib/DDGC/DB/Result/ReleaseVersion.pm
+++ b/lib/DDGC/DB/Result/ReleaseVersion.pm
@@ -36,7 +36,7 @@ column updated => {
     set_on_update => 1,
 };
 
-has_one 'meta_id', 'DDGC::DB::Result::InstantAnswer', 'meta_id';
+has_one 'permanent_id', 'DDGC::DB::Result::InstantAnswer', 'id';
 
 no Moose;
 __PACKAGE__->meta->make_immutable ( inline_constructor => 0 );

--- a/lib/DDGC/DuckPAN.pm
+++ b/lib/DDGC/DuckPAN.pm
@@ -163,7 +163,7 @@ sub update_release_versions {
 		if(my $ia = $ias->single($where)){
 			$ia->update(\%update);
 			$rvs->create({
-				instant_answer_id => $id,
+				instant_answer_id => $ia->id,
 				release_version => $version,
 				status => $status_map{$change}
 			});

--- a/sql/1.102/relver-fkey.sql
+++ b/sql/1.102/relver-fkey.sql
@@ -1,0 +1,3 @@
+alter table release_version drop constraint release_version_instant_answer_id_fkey;
+update release_version set instant_answer_id = instant_answer.id from instant_answer where instant_answer_id = instant_answer.meta_id;
+alter table release_version add foreign key(instant_answer_id) references instant_answer(id);


### PR DESCRIPTION
The instant_answer.id column doesn't get updated, making it more suitable for the foreign key on release_version.