### PR TITLE
IA Pages - update frontend to work with the latest ghIssues script changes

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -255,23 +255,18 @@ sub dev_pipeline_json :Chained('dev_pipeline_base') :PathPart('json') :Args(0) {
             $temp_ia->{asana} = $result->{$ia->id};
         }
         
-        if ($ia->last_update && $ia->last_commit && (!$pr->{issue_id})) {
+        if ($ia->last_update && $ia->last_commit && $pr->{issue_id}) {
             my $last_commit = from_json($ia->last_commit);
-            my $closed_pr = $c->d->rs('GitHub::Pull')->search({github_id => $last_commit->{issue_id}}, {result_class => 'DBIx::Class::ResultClass::HashRefInflator'})->first;
-            if ($closed_pr->{merged_at}) {
-                $temp_ia->{pr_merged} = 1;
-            } elsif ($closed_pr->{closed_at}) {
-                $temp_ia->{pr_closed} = 1;
-            }
-       } elsif ($pr->{issue_id} && $resp) {
-            my $pr_id = $pr->{issue_id};
-            my $repo = $ia->repo;
-            my $beta_pr = $resp->{$repo}->{$pr_id};
-            $temp_ia->{beta_install} = 0;
-            warn $beta_pr->{install_status};
-            if ($beta_pr) {
-                $temp_ia->{beta_install} = $beta_pr->{install_status};
-                $temp_ia->{beta_query} = $beta_pr->{meta}? $beta_pr->{meta}->{example_query} : 0;
+            if (($pr->{status} eq 'open' ||$pr->{status} eq 'merged') && $resp) {
+                my $pr_id = $pr->{issue_id};
+                my $repo = $ia->repo;
+                my $beta_pr = $resp->{$repo}->{$pr_id};
+                $temp_ia->{beta_install} = 0;
+                warn $beta_pr->{install_status};
+                if ($beta_pr) {
+                    $temp_ia->{beta_install} = $beta_pr->{install_status};
+                    $temp_ia->{beta_query} = $beta_pr->{meta}? $beta_pr->{meta}->{example_query} : 0;
+                }
             }
        }
 

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -551,6 +551,7 @@ sub overview_json :Chained('overview_base') :PathPart('json') :Args(0) {
             issue_id => $issue->issue_id,
             ia_id => $issue->instant_answer_id,
             repo => $issue->repo,
+            status => $issue->status? $issue->status : undef,
             author => $issue->author
         );
 
@@ -737,6 +738,7 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
                     body => $issue->body,
                     tags => $issue->tags,
                     author => $issue->author,
+                    status => $issue->status? $issue->status : undef,
                     date => $issue->date
                );
 
@@ -760,6 +762,7 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
                     body => $issue->body,
                     tags => $issue->tags,
                     author => $issue->author,
+                    status => $issue->status? $issue->status : undef,
                     date => $issue->date
                 });
             }

--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -426,7 +426,7 @@
                             // Priority is higher when:
                             // - last activity (especially comment) is by a contributor (non-admin)
                             // - last activity happened long ago (the older the activity, the higher the priority)
-                            if (ia.pr && ia.pr.issue_id) {
+                            if (ia.pr && (ia.pr.status === "open")) {
                                 if (ia.last_comment) {
                                     priority_val += ia.last_comment.admin? -20 : 20;
                                     var idle_comment = elapsed_time(ia.last_comment.date);
@@ -451,7 +451,7 @@
                                 }
 
                                 // Priority drops if the PR is on hold
-                                if (ia.pr && ia.pr.issue_id) {
+                                if (ia.pr && (ia.pr.status === "open")) {
                                     var tags = ia.pr.tags;
 
                                     $.each(tags, function(idx) {

--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -376,7 +376,7 @@
                            actions_data.beta = 0;
                        }
 
-                       if (page_data.pr && page_data.pr.issue_id) {
+                       if (page_data.pr && (page_data.pr.status === "open" || page_data.pr.status === "merged")) {
                            actions_data.got_prs = 1;
                        }
 

--- a/src/templates/dev_pipeline.handlebars
+++ b/src/templates/dev_pipeline.handlebars
@@ -82,14 +82,16 @@
                   <span class="item-title">{{name}}</span>
                     <div class="right item-activity">
                       {{#exists pr 'issue_id'}}
-                          <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr" title="{{format_time last_update}}">
-                            {{timeago last_update 0}}
-                          </a>
-                      {{else}}
-                          {{#if last_update}}<i class="{{#if pr_merged}} platform-pr-merged {{else}} platform-pr-closed {{/if}}"></i>{{/if}}
-                          <span class="no-pr" title="{{format_time last_update}}">
-                            {{timeago last_update 0}}
-                          </span>
+                        {{#eq pr.status 'open'}}
+                              <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr" title="{{format_time last_update}}">
+                                {{timeago last_update 0}}
+                              </a>
+                          {{else}}
+                              {{#if last_update}}<i class="{{#eq pr.status 'merged'}} platform-pr-merged {{else}} platform-pr-closed {{/eq}}"></i>{{/if}}
+                              <span class="no-pr" title="{{format_time last_update}}">
+                                {{timeago last_update 0}}
+                              </span>
+                          {{/eq}}
                       {{/exists}}
                     </div>
                 </div>
@@ -134,14 +136,16 @@
                   <span class="item-title">{{name}}</span>
                     <div class="right item-activity">
                       {{#exists pr 'issue_id'}}
-                          <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr" title="{{format_time last_update}}">
-                            {{timeago last_update 0}}
-                          </a>
-                      {{else}}
-                          {{#if last_update}}<i class="{{#if pr_merged}} platform-pr-merged {{else}} platform-pr-closed {{/if}}"></i>{{/if}}
-                          <span class="no-pr" title="{{format_time last_update}}">
-                            {{timeago last_update 0}}
-                          </span>
+                        {{#eq pr.status 'open'}}
+                              <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr" title="{{format_time last_update}}">
+                                {{timeago last_update 0}}
+                              </a>
+                          {{else}}
+                              {{#if last_update}}<i class="{{#eq pr.status 'merged'}} platform-pr-merged {{else}} platform-pr-closed {{/eq}}"></i>{{/if}}
+                              <span class="no-pr" title="{{format_time last_update}}">
+                                {{timeago last_update 0}}
+                              </span>
+                          {{/eq}}
                       {{/exists}}
                     </div>
                 </div>
@@ -186,14 +190,16 @@
                   <span class="item-title">{{name}}</span>
                     <div class="right item-activity">
                       {{#exists pr 'issue_id'}}
-                          <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr" title="{{format_time last_update}}">
-                            {{timeago last_update 0}}
-                          </a>
-                      {{else}}
-                          {{#if last_update}}<i class="{{#if pr_merged}} platform-pr-merged {{else}} platform-pr-closed {{/if}}"></i>{{/if}}
-                          <span class="no-pr" title="{{format_time last_update}}">
-                            {{timeago last_update 0}}
-                          </span>
+                        {{#eq pr.status 'open'}}
+                              <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr" title="{{format_time last_update}}">
+                                {{timeago last_update 0}}
+                              </a>
+                          {{else}}
+                              {{#if last_update}}<i class="{{#eq pr.status 'merged'}} platform-pr-merged {{else}} platform-pr-closed {{/eq}}"></i>{{/if}}
+                              <span class="no-pr" title="{{format_time last_update}}">
+                                {{timeago last_update 0}}
+                              </span>
+                          {{/eq}}
                       {{/exists}}
                     </div>
                 </div>
@@ -238,14 +244,16 @@
                   <span class="item-title">{{name}}</span>
                     <div class="right item-activity">
                       {{#exists pr 'issue_id'}}
-                          <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr" title="{{format_time last_update}}">
-                            {{timeago last_update 0}}
-                          </a>
-                      {{else}}
-                          {{#if last_update}}<i class="{{#if pr_merged}} platform-pr-merged {{else}} platform-pr-closed {{/if}}"></i>{{/if}}
-                          <span class="no-pr" title="{{format_time last_update}}">
-                            {{timeago last_update 0}}
-                          </span>
+                        {{#eq pr.status 'open'}}
+                              <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr" title="{{format_time last_update}}">
+                                {{timeago last_update 0}}
+                              </a>
+                          {{else}}
+                              {{#if last_update}}<i class="{{#eq pr.status 'merged'}} platform-pr-merged {{else}} platform-pr-closed {{/eq}}"></i>{{/if}}
+                              <span class="no-pr" title="{{format_time last_update}}">
+                                {{timeago last_update 0}}
+                              </span>
+                          {{/eq}}
                       {{/exists}}
                     </div>
                 </div>

--- a/src/templates/dev_pipeline_detail.handlebars
+++ b/src/templates/dev_pipeline_detail.handlebars
@@ -92,8 +92,12 @@
                 <p>Installed on <a href="http://beta.duckduckgo.com/{{#if beta_query}}?q={{beta_query}}{{/if}}">beta</a></p>
                 <div class="button btn--primary" id="beta-single">Re-install on beta</div>
             {{else}}
-                {{#if beta_install}}Install on beta failed: <div class="readonly">{{beta_install}}</div>{{/if}}
-                <div class="button btn--primary" id="beta-single">Install on beta</div>
+                {{#eq pr.status 'open'}}
+                    {{#if beta_install}}Install on beta failed: <div class="readonly">{{beta_install}}</div>{{/if}}
+                    <div class="button btn--primary" id="beta-single">Install on beta</div>
+                {{else}}
+                    <span></span>
+                {{/eq}}
             {{/eq}}
         </div>
     {{/if}}
@@ -137,36 +141,38 @@
     {{/if}}
 {{/if}}
 
-{{#if pr.issue_id}}
-    <hr />
+{{#if pr.status}}
+    {{#eq pr.status 'open'}}
+        <hr />
 
-    <div id="sidebar-pr">
-        <div class="left">
-            <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr">
-                PR #{{pr.issue_id}}
-            </a>
-        </div>
-        <div class="right" title="{{format_time last_update}}">
-            <i class="ddgsi ddgsi-clock" />
-            {{timeago last_update}}
-        </div>
-        {{#if last_comment}}
-            <div class="right" id="all_comments">
-                <i class="ddgsi ddgsi-comment" />
-                {{length all_comments}}
-            </div>
-        {{/if}}
-
-        <span class="clearfix"></span>
-        
-        {{#each all_comments}}
-            <p class="comment">
-                <a href="https://github.com/duckduckgo/zeroclickinfo-{{../repo}}/issues/{{../pr.issue_id}}#issuecomment-{{id}}">
-                    {{text}}
+        <div id="sidebar-pr">
+            <div class="left">
+                <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr">
+                    PR #{{pr.issue_id}}
                 </a>
-            </p>
-            <div>by <a href="https://github.com/{{user}}">{{user}}</a> {{timeago date 1}}</div>
-        {{/each}}
-    </div>        
+            </div>
+            <div class="right" title="{{format_time last_update}}">
+                <i class="ddgsi ddgsi-clock" />
+                {{timeago last_update}}
+            </div>
+            {{#if last_comment}}
+                <div class="right" id="all_comments">
+                    <i class="ddgsi ddgsi-comment" />
+                    {{length all_comments}}
+                </div>
+            {{/if}}
+
+            <span class="clearfix"></span>
+            
+            {{#each all_comments}}
+                <p class="comment">
+                    <a href="https://github.com/duckduckgo/zeroclickinfo-{{../repo}}/issues/{{../pr.issue_id}}#issuecomment-{{id}}">
+                        {{text}}
+                    </a>
+                </p>
+                <div>by <a href="https://github.com/{{user}}">{{user}}</a> {{timeago date 1}}</div>
+            {{/each}}
+        </div>
+    {{/eq}}
 {{/if}}
 

--- a/src/templates/devinfo.handlebars
+++ b/src/templates/devinfo.handlebars
@@ -20,16 +20,18 @@
             <span class="error-notification hide">ID can't be empty</span>
         {{/if}}
     </div>
+{{/ne_and}}
 
-    {{#if pr}}
+    {{#exists pr 'id'}}
         <div class="ia-single--info">
             <h3 class="ia-single--header">PR #</h3>
             <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.id}}" class="one-line" id="pr">
                 {{pr.id}}
             </a>
         </div>
-    {{/if}}
+    {{/exists}}
 
+{{#ne_and dev_milestone 'live' 'deprecated'}}
     {{#if permissions.admin}}
         <div class="ia-single--info">
             <h3 class="ia-single--header">Blockgroup</h3>


### PR DESCRIPTION
Made some changes to the Dev Pipeline and single IA Pages, so that they keep working as they are now.
And also, now closed PRs will be visible on the single IA Page even after the dev milestone is set to "live".
//cc @jdorweiler 

