### PR TITLE
ghIssues.pl - merged PRs should have the 'merged' status

### DIFF
--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -110,6 +110,11 @@ sub getIssues{
 
             my $producer = assign_producer($issue->{assignee}->{login});
 
+            my $state = $issue->{state};
+            if ($state ne 'open') {
+                $state = $gh->pull_request->is_merged($issue->{number})? 'merged' : $state;
+            }
+
             # add entry to result array
 			my %entry = (
 			    name => $name_from_link || '',
@@ -127,7 +132,7 @@ sub getIssues{
                 all_comments => $comments,
                 mentions => $mentions,
                 producer => $producer,
-                state => $issue->{state},
+                state => $state,
 			);
 
 			push(@results, \%entry);


### PR DESCRIPTION
I'm using the [is_merged method from Net::GitHub::V3](https://metacpan.org/pod/Net::GitHub::V3::PullRequests#is_merged).
Dev Pipeline screenshot (the purple icon is for merged PRs, while the red icon is for closed ones):
![screenshot-maria-old duckduckgo com 5001 2015-12-03 16-07-21](https://cloud.githubusercontent.com/assets/3652195/11564179/2da8e02c-99d8-11e5-9aff-fcbedb23a1e2.png)
