### PR TITLE
Removing CSRF mitigation from feedback

### DIFF
--- a/lib/DDGC/Web/Controller/Feedback.pm
+++ b/lib/DDGC/Web/Controller/Feedback.pm
@@ -135,7 +135,6 @@ sub step :Chained('feedback') :PathPart('') :Args(1) {
   $c->stash->{steps} = \@steps;
   $c->stash->{step} = $current_step;
   if ($submit) {
-    $c->require_action_token;
     my $step_session_key_base = $c->stash->{feedback_name}.'/';
     my %data = defined $c->session->{feedback}->{$step_session_key_base}
       ? %{$c->session->{feedback}->{$step_session_key_base}}


### PR DESCRIPTION
Since I noticed a drop in feedback and we are getting reports of breakage, I am removing the CSRF check from feedback.

We can consider an alternative approach to this.