### PR TITLE
IA Dev Pages - link to the beta server in the example queries

### DIFF
--- a/src/js/ia/Helpers.js
+++ b/src/js/ia/Helpers.js
@@ -140,7 +140,7 @@
     });
 
     // Check if val1 matches val2 (not conditional)
-    Handlebars.registerHelper('match', function(val1, val2) {
+    Handlebars.registerHelper('match_fn', function(val1, val2) {
          var result = false;
          if (val1 && val2) {
              val2 = new RegExp(val2);

--- a/src/js/ia/Helpers.js
+++ b/src/js/ia/Helpers.js
@@ -132,11 +132,24 @@
     // Check if val1 matches val2 using a regex
     Handlebars.registerHelper('match', function(val1, val2, options) {
        val2 = new RegExp(val2);
-       if (val1.match(val2)) {
+       if ((val1 && val2) && val1.match(val2)) {
            return options.fn(this);
        } else {
            return options.inverse(this);
        }
+    });
+
+    // Check if val1 matches val2 (not conditional)
+    Handlebars.registerHelper('match', function(val1, val2) {
+         var result = false;
+         if (val1 && val2) {
+             val2 = new RegExp(val2);
+             if (val1.match(val2)) {
+                  result = true;
+             } 
+         }
+
+         return result;
     });
 
     // Check if two values are equal

--- a/src/templates/examples.handlebars
+++ b/src/templates/examples.handlebars
@@ -75,8 +75,8 @@
     <div class="readonly--info {{#or staged.example_query staged.other_queries}}hide{{/or}}" id="example_query--readonly">
         {{#if example_query}}
             {{#ne_and dev_milestone 'live' 'deprecated'}}
-                {{#or test_machine (match beta_install 'success')}}
-                    <a class="one-line" href="https://{{test_machine}}.duckduckgo.com/?q={{encodeURIComponent example_query}}{{tab_url tab}}" title="try this example on DuckDuckGo">{{example_query}}</a>
+                {{#or test_machine (match_fn beta_install 'success')}}
+                    <a class="one-line" href="https://{{#match beta_install 'success'}}beta{{else}}{{test_machine}}{{/match}}.duckduckgo.com/?q={{encodeURIComponent example_query}}{{tab_url tab}}" title="try this example on DuckDuckGo">{{example_query}}</a>
                 {{else}}
                     <span>{{example_query}}</span>
                 {{/or}}
@@ -87,11 +87,11 @@
         {{#if other_queries}}
             {{#each other_queries}}
                 {{#ne_and ../../dev_milestone 'live' 'deprecated'}}
-                    {{#if ../../test_machine}}
-                        <a class="one-line" href="https://{{../../../test_machine}}.duckduckgo.com/?q={{encodeURIComponent this}}{{tab_url ../../../tab}}" title="try this example on DuckDuckGo">{{this}}</a>
+                    {{#or ../../test_machine (match_fn ../../beta_install 'success')}}
+                        <a class="one-line" href="https://{{#match ../../../beta_install 'success'}}beta{{else}}{{../../../test_machine}}{{/match}}.duckduckgo.com/?q={{encodeURIComponent this}}{{tab_url ../../../tab}}" title="try this example on DuckDuckGo">{{this}}</a>
                     {{else}}
                         <span>{{this}}</span>
-                    {{/if}}
+                    {{/or}}
                 {{else}}
                     <a class="one-line" href="https://duckduckgo.com/?q={{encodeURIComponent this}}{{tab_url ../../tab}}" title="try this example on DuckDuckGo">{{this}}</a>
                 {{/ne_and}}

--- a/src/templates/examples.handlebars
+++ b/src/templates/examples.handlebars
@@ -75,11 +75,11 @@
     <div class="readonly--info {{#or staged.example_query staged.other_queries}}hide{{/or}}" id="example_query--readonly">
         {{#if example_query}}
             {{#ne_and dev_milestone 'live' 'deprecated'}}
-                {{#if test_machine}}
+                {{#or test_machine (match beta_install 'success')}}
                     <a class="one-line" href="https://{{test_machine}}.duckduckgo.com/?q={{encodeURIComponent example_query}}{{tab_url tab}}" title="try this example on DuckDuckGo">{{example_query}}</a>
                 {{else}}
                     <span>{{example_query}}</span>
-                {{/if}}
+                {{/or}}
             {{else}}
                 <a class="one-line" href="https://duckduckgo.com/?q={{encodeURIComponent example_query}}{{tab_url tab}}" title="try this example on DuckDuckGo">{{example_query}}</a>
             {{/ne_and}}


### PR DESCRIPTION
Fixes not showing example queries as links if they're on beta
//cc @jdorweiler 

![screenshot-maria duckduckgo com 5001 2015-12-07 21-22-10](https://cloud.githubusercontent.com/assets/3652195/11639195/a53484ba-9d2b-11e5-87cb-035955a648f1.png)
