### PR TITLE
Dev Center - hide archive

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -288,8 +288,16 @@ sub deprecated_base :Chained('overview_base') :PathPart('deprecated') :CaptureAr
     $c->stash->{ia_page} = "IADeprecated";
     $c->stash->{title} = "Deprecated IA Pages";
    
-    $c->stash->{logged_in} = $c->user;
-    $c->stash->{is_admin} = $c->user? $c->user->admin : 0;
+    my $user = $c->user;
+    my $is_admin = $c->user? $c->user->admin : 0;
+    
+    if ((!$user) || (!$is_admin)) {
+        $c->response->redirect($c->chained_uri('My','login',{ admin_required => 1 }));
+        return $c->detach;
+    }
+
+    $c->stash->{logged_in} = $user;
+    $c->stash->{is_admin} = $is_admin;
 
     $c->add_bc('Deprecated', $c->chained_uri('InstantAnswer', 'deprecated'));
 }

--- a/src/templates/dev_pipeline_stats.handlebars
+++ b/src/templates/dev_pipeline_stats.handlebars
@@ -11,9 +11,11 @@
 <a href="/ia/dev/issues" class="pipeline__toggle-view__button" id="pipeline_toggle-live">
   Issues
 </a>
-<a href="/ia/dev/deprecated" class="pipeline__toggle-view__button" id="pipeline_toggle-deprecated">
-  Deprecated
-</a>
+{{#if permissions.admin}}
+    <a href="/ia/dev/deprecated" class="pipeline__toggle-view__button" id="pipeline_toggle-deprecated">
+      Deprecated
+    </a>
+{{/if}}
 
 
 <!--


### PR DESCRIPTION
@jagtalon Done.
So, now when you go to ia/dev/deprecated you get redirected to the login form if you're not admin.
I'm also hiding the link to the page for regular users in the pipeline. I can hide it for the other pages you're putting the blue band header on after you merge your PR, or I can push to your branch if you want.
![screenshot-maria duckduckgo com 5001 2015-12-08 16-50-18](https://cloud.githubusercontent.com/assets/3652195/11660191/4439587e-9dcc-11e5-8ad7-99f16f06a058.png)
