### PR TITLE
Post IA data in dax comment

### DIFF
--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -435,7 +435,7 @@ sub update_pr_template {
 
     # XXX comment this line to test pr template posts
     # it will make actual posts to GitHub PRs.
-    return unless $d->is_live;
+    #return unless $d->is_live;
 
     # find dax comment at spot #1 or bail
     my @comments = $gh->issue->comments($pr_number);
@@ -456,6 +456,7 @@ sub update_pr_template {
             $comment_number = $comment->{id};
         }
     }
+
 
     my $examples = $data->{example_query} || ' ';
 
@@ -488,19 +489,25 @@ sub update_pr_template {
     }
 
     map{ $data->{$_} = ' ' unless $data->{$_} } qw(src_url description tab);
-    
+
+    if($data->{repo} =~ /fathead/i){
+        $data->{tab} = "About";
+    }elsif($data->{repo} =~ /goodie/i){
+        $data->{tab} = "Answer";
+    }
+
     my $message = qq(
-Automated data from [IA page](https://duck.co/ia/view/$data->{meta_id})
-
----
-**Basic Info**
-
-These are the important fields from the IA page.  Please check these for errors or missing information and update the [IA page](https://duck.co/ia/view/$data->{meta_id})
+## Instant Answer Metadata from [IA page](https://duck.co/ia/view/$data->{meta_id})
 
 **Description**: $data->{description}
+
 **Example Query**: $examples
+
 **Tab Name**: $data->{tab}
+
 **Source**: $data->{src_url}
+
+*These are the important fields from the IA page.  Please check these for errors or missing information and update the [IA page](https://duck.co/ia/view/$data->{meta_id})*
 
 ---
 **Testing**
@@ -510,10 +517,15 @@ $browsers
 
 **Mobile**
 $mobile
+
+---
+*This is an automated message which will be updated as changes are made to the [IA page](https://duck.co/ia/view/$data->{meta_id})*
 );
 
     my $dax = $ENV{DAX_TOKEN};
     return unless $dax;
+
+    warn "Posting comment";
 
     my $dax_comment = Net::GitHub->new(access_token => $dax);
     if(!$comment_number){

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -33,9 +33,9 @@ my @results;
 
 # the repos we care about
 my @repos = (
-    'zeroclickinfo-spice',
-    'zeroclickinfo-goodies',
-    'zeroclickinfo-longtail',
+#    'zeroclickinfo-spice',
+#    'zeroclickinfo-goodies',
+#    'zeroclickinfo-longtail',
     'zeroclickinfo-fathead'
 );
 
@@ -216,6 +216,7 @@ sub getIssues{
                     template => $template,
                     example_query => $ia->{example_query} || '',
                     tab => $ia->{tab} || '',
+                    src_url => $ia->{src_url} || '',
                 );
 
                 $d->rs('InstantAnswer')->update_or_create({%new_data});
@@ -449,10 +450,10 @@ sub update_pr_template {
 Automated data from [IA page](https://duck.co/ia/view/$data->{meta_id})
 
 ---
-Description: $data->{description}
-Example Query: $data->{example_query}
-Tab Name: $data->{tab}
-Source: $data->{src_api_documentation}
+**Description**: $data->{description}
+**Example Query**: $data->{example_query}
+**Tab Name**: $data->{tab}
+**Source**: $data->{src_url}
 );
 
     my $dax = $ENV{DAX_TOKEN};

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -33,9 +33,9 @@ my @results;
 
 # the repos we care about
 my @repos = (
-#    'zeroclickinfo-spice',
-#    'zeroclickinfo-goodies',
-#    'zeroclickinfo-longtail',
+    'zeroclickinfo-spice',
+    'zeroclickinfo-goodies',
+    'zeroclickinfo-longtail',
     'zeroclickinfo-fathead'
 );
 
@@ -70,15 +70,11 @@ sub getIssues{
             push(@issues, $gh->issue->next_page)
         }
 
-        
         print "Starting $repo\n";
         my $progress = Term::ProgressBar->new(scalar @issues);
 		
         # add all the data we care about to an array
 		for my $issue (@issues){
-
-            warn Dumper $issue;
-
             $progress->update($line);
             $line++;
 
@@ -137,8 +133,6 @@ sub getIssues{
                 producer => $producer,
                 state => $state,
 			);
-
-            warn Dumper \%entry;
 
 			push(@results, \%entry);
             delete $pr_hash{$issue->{'number'}.$repo};
@@ -224,8 +218,6 @@ sub getIssues{
                     tab => $ia->{tab} || '',
                 );
 
-                warn "###########3 IA ##############33";
-                warn Dumper $ia;
                 $d->rs('InstantAnswer')->update_or_create({%new_data});
 
                 update_pr_template(\%new_data, $data->{issue_id}, $ia->{src_url});

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -435,7 +435,7 @@ sub update_pr_template {
 
     # XXX comment this line to test pr template posts
     # it will make actual posts to GitHub PRs.
-    #return unless $d->is_live;
+    return unless $d->is_live;
 
     # find dax comment at spot #1 or bail
     my @comments = $gh->issue->comments($pr_number);
@@ -466,26 +466,26 @@ sub update_pr_template {
         $examples .=", ". $ia->{other_queries};
     }
 
-    my $browsers = ' ';
+    my $browsers;
     foreach my $browser (qw(safari firefox ie opera chrome)){
         my $val = $ia->{"browsers_$browser"};
         if($val){
-            $val = '&#10003;';
+            $val = 'X';
         }else{
             $val = ' ';
         }
-        $browsers .= '['.$val.'] ' . $browser. "\n";
+        $browsers .= '- ['.$val.'] ' . $browser. "\n";
     }
 
-    my $mobile = ' ';
+    my $mobile;
     foreach my $type (qw(android ios)){
         my $val = $ia->{"mobile_$type"};
         if($val){
-            $val = '&#10003;';
+            $val = 'X';
         }else{
             $val = ' ';
         }
-        $mobile .= '['.$val.'] '. $type. "\n";
+        $mobile .= '- ['.$val.'] '. $type. "\n";
     }
 
     map{ $data->{$_} = ' ' unless $data->{$_} } qw(src_url description tab);

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -216,14 +216,11 @@ sub getIssues{
                     example_query => $ia->{example_query} || '',
                     tab => $ia->{tab} || '',
                     src_url => $ia->{src_url} || '',
-                    other_queries => $ia->{other_queries},
                 );
-
-                warn Dumper $ia;
 
                 update_pr_template(\%new_data, $data->{issue_id}, $ia);
 
-                return if !$is_new_ia;
+                #return 1 if !$is_new_ia;
                 $d->rs('InstantAnswer')->update_or_create({%new_data});
 
 
@@ -443,6 +440,7 @@ sub update_pr_template {
 
     # find dax comment at spot #1 or bail
     my @comments = $gh->issue->comments($pr_number);
+
     my $comment_number;
     if(scalar @comments){
         my $comment = $comments[0];
@@ -461,8 +459,11 @@ sub update_pr_template {
     }
 
     my $examples = $data->{example_query};
-    $data->{other_queries} =~ s/"|\[|\]//g;
-    $examples .=", ". $data->{other_queries};
+
+    if(exists $ia->{other_queries}){
+        $ia->{other_queries} =~ s/"|\[|\]//g;
+        $examples .=", ". $ia->{other_queries};
+    }
 
     my $browsers;
     foreach my $browser (qw(safari firefox ie opera chrome)){
@@ -493,17 +494,20 @@ sub update_pr_template {
 Automated data from [IA page](https://duck.co/ia/view/$data->{meta_id})
 
 ---
+**Basic Info**
+
 **Description**: $data->{description}
 **Example Query**: $examples
 **Tab Name**: $data->{tab}
 **Source**: $data->{src_url}
 
+---
 **Testing**
 
-Browsers
+**Browsers**
 $browsers
 
-Review
+**Review**
 $other_tests
 );
 
@@ -534,4 +538,3 @@ try {
     print "Update error $_ \n rolling back\n";
     $d->errorlog("Error updating ghIssues: '$_'...");
 }
-

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -458,7 +458,7 @@ sub update_pr_template {
         }
     }
 
-    my $examples = $data->{example_query};
+    my $examples = $data->{example_query} || ' ';
 
     if(defined $ia->{other_queries}){
         $ia->{other_queries} =~ s/"|\[|\]//g;
@@ -466,7 +466,7 @@ sub update_pr_template {
         $examples .=", ". $ia->{other_queries};
     }
 
-    my $browsers;
+    my $browsers = ' ';
     foreach my $browser (qw(safari firefox ie opera chrome)){
         my $val = $ia->{"browsers_$browser"};
         if($val){
@@ -477,7 +477,7 @@ sub update_pr_template {
         $browsers .= '['.$val.'] ' . $browser. "\n";
     }
 
-    my $mobile;
+    my $mobile = ' ';
     foreach my $type (qw(android ios)){
         my $val = $ia->{"mobile_$type"};
         if($val){
@@ -488,6 +488,8 @@ sub update_pr_template {
         $mobile .= '['.$val.'] '. $type. "\n";
     }
 
+    map{ $data->{$_} = ' ' unless $data->{$_}; warn $data->{$_}; } qw(src_url description tab);
+    
     my $message = qq(
 Automated data from [IA page](https://duck.co/ia/view/$data->{meta_id})
 

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -530,7 +530,7 @@ $mobile
 getIssues;
 
 try {
- #   $d->db->txn_do($merge_files);
+    $d->db->txn_do($merge_files);
     $d->db->txn_do($update);
 } catch {
     print "Update error $_ \n rolling back\n";

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -473,12 +473,12 @@ Automated data from [IA page](https://duck.co/ia/view/$data->{meta_id})
     my $dax_comment = Net::GitHub->new(access_token => $dax);
     if(!$comment_number){
         # update the comment
-        $dax_comment->issue->create_comment('duckduckgo', 'zeroclickinfo-fathead', $pr_number, {
+        $dax_comment->issue->create_comment('duckduckgo', 'zeroclickinfo-'.$data->{repo}, $pr_number, {
             "body" => $message
             }
         );
     }else{
-        $dax_comment->issue->update_comment('duckduckgo', 'zeroclickinfo-fathead', $comment_number, {
+        $dax_comment->issue->update_comment('duckduckgo', 'zeroclickinfo-'.$data->{repo}, $comment_number, {
             "body" => $message
             }
         );

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -438,6 +438,10 @@ sub get_mentions {
 sub update_pr_template {
     my ($data, $pr_number, $ia) = @_;
 
+    # XXX comment this line to test pr template posts
+    # it will make actual posts to GitHub PRs.
+    return unless $d->is_live;
+
     # find dax comment at spot #1 or bail
     my @comments = $gh->issue->comments($pr_number);
 
@@ -488,13 +492,15 @@ sub update_pr_template {
         $mobile .= '['.$val.'] '. $type. "\n";
     }
 
-    map{ $data->{$_} = ' ' unless $data->{$_}; warn $data->{$_}; } qw(src_url description tab);
+    map{ $data->{$_} = ' ' unless $data->{$_} } qw(src_url description tab);
     
     my $message = qq(
 Automated data from [IA page](https://duck.co/ia/view/$data->{meta_id})
 
 ---
 **Basic Info**
+
+These are the important fields from the IA page.  Please check these for errors or missing information and update the [IA page](https://duck.co/ia/view/$data->{meta_id})
 
 **Description**: $data->{description}
 **Example Query**: $examples

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -33,9 +33,9 @@ my @results;
 
 # the repos we care about
 my @repos = (
-#    'zeroclickinfo-spice',
-#    'zeroclickinfo-goodies',
-#    'zeroclickinfo-longtail',
+    'zeroclickinfo-spice',
+    'zeroclickinfo-goodies',
+    'zeroclickinfo-longtail',
     'zeroclickinfo-fathead'
 );
 
@@ -105,7 +105,6 @@ sub getIssues{
             
             $comments = to_json $comments if $comments;
             $last_comment = to_json $last_comment if $last_comment;
-
 
             my $producer = assign_producer($issue->{assignee}->{login});
 
@@ -326,6 +325,7 @@ sub duckco_user {
 # check the status of PRs in $pr_hash.  If they were merged
 # then update the file paths in the db
 my $merge_files = sub {
+
     PR: while ( my ($pr, $data) = each %pr_hash){
         $gh->set_default_user_repo('duckduckgo', "zeroclickinfo-$data->{repo}");
         my $pr = $gh->pull_request->pull($data->{issue_id});


### PR DESCRIPTION
Post some of the data from the IA page back to the PR in a dax comment. 
![selection_104](https://cloud.githubusercontent.com/assets/1882892/11664301/ec6751ae-9dae-11e5-91e7-5f4ed9b72dbd.jpg)

This runs with ghIssues so data from the IA page would be synced every time it runs.  I have it set to only post to the first comment (excluding dax welcome message).  This means it won't post a comment if someone else comments before ghIssues runs.  So dax gets the first comment or doesn't post. 

@russellholt @MariagraziaAlastra 