### PR TITLE
Have ddgc_upload_metadata's force upload option also force re-get

### DIFF
--- a/script/ddgc_upload_metadata.sh
+++ b/script/ddgc_upload_metadata.sh
@@ -11,6 +11,7 @@ FORCE_UPLOAD=0
   export DDGC_REPO_JSON_S3URL='s3://ddg-community/metadata/repo_all.json.bz2'
 DDGC_REPO_BZIP2_OUT="$DDGC_REPO_JSON_OUT.bz2"
 
+[ $FORCE_UPLOAD ] && rm $DDGC_REPO_JSON_OUT
 LAST_MODIFIED_TIME=0
 if [ -f $DDGC_REPO_JSON_OUT ]
 then

--- a/script/ddgc_upload_metadata.sh
+++ b/script/ddgc_upload_metadata.sh
@@ -11,7 +11,7 @@ FORCE_UPLOAD=0
   export DDGC_REPO_JSON_S3URL='s3://ddg-community/metadata/repo_all.json.bz2'
 DDGC_REPO_BZIP2_OUT="$DDGC_REPO_JSON_OUT.bz2"
 
-[ $FORCE_UPLOAD ] && rm $DDGC_REPO_JSON_OUT
+[ $FORCE_UPLOAD ] && [ -f $DDGC_REPO_JSON_OUT ] && rm $DDGC_REPO_JSON_OUT
 LAST_MODIFIED_TIME=0
 if [ -f $DDGC_REPO_JSON_OUT ]
 then


### PR DESCRIPTION
Because I can't be trusted to tell you what's new, let's make the "force upload" option also re-fetch the data.

This is probably useful as an option to run on the shell when things don't look right on release.

Cc: @bsstoner @russellholt 