### PR TITLE
Track IA updated timestamp for IA table and its relationships

### DIFF
--- a/lib/DDGC/DB/Result/InstantAnswer.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer.pm
@@ -487,6 +487,7 @@ after insert => sub {
 };
 
 after update => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
+after delete => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
 
 sub create_update_activity {
     my ( $self, $meta3, $description ) = @_;

--- a/lib/DDGC/DB/Result/InstantAnswer.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer.pm
@@ -482,7 +482,11 @@ after insert => sub {
         description  => sprintf('Instant Answer Page [%s](%s) created!',
             $self->name, $self->uri( { activity_feed => 1 } ) ),
     } );
+
+    $schema->resultset('InstantAnswer::LastUpdated')->touch;
 };
+
+after update => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
 
 sub create_update_activity {
     my ( $self, $meta3, $description ) = @_;

--- a/lib/DDGC/DB/Result/InstantAnswer/Blockgroup.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer/Blockgroup.pm
@@ -26,6 +26,7 @@ primary_key ('id');
 
 after insert => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
 after update => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
+after delete => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
 
 no Moose;
 __PACKAGE__->meta->make_immutable ( inline_constructor => 0 );

--- a/lib/DDGC/DB/Result/InstantAnswer/Blockgroup.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer/Blockgroup.pm
@@ -24,5 +24,8 @@ column blockgroup => {
 
 primary_key ('id');
 
+after insert => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
+after update => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
+
 no Moose;
 __PACKAGE__->meta->make_immutable ( inline_constructor => 0 );

--- a/lib/DDGC/DB/Result/InstantAnswer/Issues.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer/Issues.pm
@@ -62,6 +62,9 @@ column status => {
 
 primary_key (qw/issue_id repo/);
 
+after insert => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
+after update => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
+
 belongs_to 'instant_answer', 'DDGC::DB::Result::InstantAnswer', 'instant_answer_id', {on_delete => 'cascade'};
 
 no Moose;

--- a/lib/DDGC/DB/Result/InstantAnswer/Issues.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer/Issues.pm
@@ -64,6 +64,7 @@ primary_key (qw/issue_id repo/);
 
 after insert => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
 after update => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
+after delete => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
 
 belongs_to 'instant_answer', 'DDGC::DB::Result::InstantAnswer', 'instant_answer_id', {on_delete => 'cascade'};
 

--- a/lib/DDGC/DB/Result/InstantAnswer/LastUpdated.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer/LastUpdated.pm
@@ -1,0 +1,19 @@
+package DDGC::DB::Result::InstantAnswer::LastUpdated;
+# ABSTRACT: Tracking IA updates across all relationships
+
+use Moose;
+use MooseX::NonMoose;
+extends 'DDGC::DB::Base::Result';
+use DBIx::Class::Candy;
+use namespace::autoclean;
+
+table 'instant_answer_last_updated';
+
+# Token can be anything. It's just some data to ensure we have
+# a write transaction and set_on_update kicks in.
+#
+# See touch RS method.
+primary_column token => { data_type => 'text' };
+column updated => { data_type => 'timestamp with time zone', set_on_create => 1, set_on_update => 1 };
+
+1;

--- a/lib/DDGC/DB/Result/InstantAnswer/Topics.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer/Topics.pm
@@ -22,6 +22,7 @@ primary_key (qw/instant_answer_id topics_id/);
 
 after insert => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
 after update => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
+after delete => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
 
 belongs_to 'instant_answer', 'DDGC::DB::Result::InstantAnswer', 'instant_answer_id', {on_delete => 'cascade'};
 belongs_to 'topic', 'DDGC::DB::Result::Topic', 'topics_id', {on_delete => 'cascade'};

--- a/lib/DDGC/DB/Result/InstantAnswer/Topics.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer/Topics.pm
@@ -20,6 +20,9 @@ column topics_id => {
 
 primary_key (qw/instant_answer_id topics_id/);
 
+after insert => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
+after update => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
+
 belongs_to 'instant_answer', 'DDGC::DB::Result::InstantAnswer', 'instant_answer_id', {on_delete => 'cascade'};
 belongs_to 'topic', 'DDGC::DB::Result::Topic', 'topics_id', {on_delete => 'cascade'};
 

--- a/lib/DDGC/DB/Result/InstantAnswer/Users.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer/Users.pm
@@ -25,6 +25,7 @@ belongs_to 'user', 'DDGC::DB::Result::User', 'users_id';
 
 after insert => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
 after update => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
+after delete => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
 
 no Moose;
 __PACKAGE__->meta->make_immutable ( inline_constructor => 0 );

--- a/lib/DDGC/DB/Result/InstantAnswer/Users.pm
+++ b/lib/DDGC/DB/Result/InstantAnswer/Users.pm
@@ -23,6 +23,8 @@ primary_key (qw/instant_answer_id users_id/);
 belongs_to 'instant_answer', 'DDGC::DB::Result::InstantAnswer', 'instant_answer_id', {on_delete => 'cascade'};
 belongs_to 'user', 'DDGC::DB::Result::User', 'users_id';
 
+after insert => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
+after update => sub { $_[0]->schema->resultset('InstantAnswer::LastUpdated')->touch; };
 
 no Moose;
 __PACKAGE__->meta->make_immutable ( inline_constructor => 0 );

--- a/lib/DDGC/DB/ResultSet/InstantAnswer/LastUpdated.pm
+++ b/lib/DDGC/DB/ResultSet/InstantAnswer/LastUpdated.pm
@@ -1,0 +1,16 @@
+package DDGC::DB::ResultSet::InstantAnswer::LastUpdated;
+# ABSTRACT: Tracking IA updates across all relationships
+
+use Moose;
+extends 'DDGC::DB::Base::ResultSet';
+use namespace::autoclean;
+
+sub touch {
+    my ( $self ) = @_;
+    my $row = $self->search->one_row;
+    my $token = $self->ddgc->uid;
+    return $row->update({ token => $token }) if $row;
+    $self->create({ token => $token });
+}
+
+1;

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -104,7 +104,7 @@ sub iarepo_json :Chained('iarepo') :PathPart('json') :Args(0) {
               ),
     });
 
-    $c->return_if_not_modified( $iarepo->last_modified );
+    $c->return_if_not_modified( $c->d->rs('InstantAnswer::LastUpdated')->search->last_modified );
 
     $iarepo = $iarepo->prefetch( { instant_answer_topics => 'topic' });
     my %iah;

--- a/sql/1.110/instant_answer_last_updated.sql
+++ b/sql/1.110/instant_answer_last_updated.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+CREATE TABLE "instant_answer_last_updated" (
+  "token" text NOT NULL,
+  "updated" timestamp with time zone NOT NULL,
+  PRIMARY KEY ("token")
+);
+
+COMMIT;


### PR DESCRIPTION
- Before any updates:
```
$ curl -I http://localhost:5002/ia/repo/all/json 2>&1 | grep Last
Last-Modified: Thu, 01 Jan 1970 00:00:00 GMT
```

- After updating dev milestone of an IA to deprecated:
```
$ curl -I http://localhost:5002/ia/repo/all/json 2>&1 | grep Last
Last-Modified: Tue, 15 Dec 2015 16:34:25 GMT
```

- After updating the topics of an IA
```
$ curl -I http://localhost:5002/ia/repo/all/json 2>&1 | grep Last
Last-Modified: Tue, 15 Dec 2015 16:35:21 GMT
```

- After updating the description of an IA
```
$ curl -I http://localhost:5002/ia/repo/all/json 2>&1 | grep Last
Last-Modified: Tue, 15 Dec 2015 16:36:26 GMT
```

@jkv Do these cover the failure conditions we discovered?