### PR TITLE
Helpers: Fix faulty timeago helper.

### DIFF
--- a/src/js/ia/Helpers.js
+++ b/src/js/ia/Helpers.js
@@ -30,7 +30,7 @@
         var timestring = full? " days ago" : "d";
         if (date) {
             // expected date format: YYYY-MM-DDTHH:mm:ssZ e.g. 2011-04-22T13:33:48Z
-            date = date.replace("/T.*Z/", "");
+            date = date.replace(/T.*Z/, "");
             date = moment.utc(date, format);
             
             var elapsed = parseInt(moment().diff(date, "days", true));

--- a/src/templates/dev_pipeline.handlebars
+++ b/src/templates/dev_pipeline.handlebars
@@ -142,12 +142,12 @@
                       {{#exists pr 'issue_id'}}
                         {{#eq pr.status 'open'}}
                               <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr" title="{{format_time last_update}}">
-                                {{timeago last_update 0}}
+                                {{timeago last_update false false}}
                               </a>
                           {{else}}
                               {{#if last_update}}<i class="{{#eq pr.status 'merged'}} platform-pr-merged {{else}} platform-pr-closed {{/eq}}"></i>{{/if}}
                               <span class="no-pr" title="{{format_time last_update}}">
-                                {{timeago last_update 0}}
+                                {{timeago last_update false false}}
                               </span>
                           {{/eq}}
                       {{/exists}}

--- a/src/templates/dev_pipeline.handlebars
+++ b/src/templates/dev_pipeline.handlebars
@@ -142,12 +142,12 @@
                       {{#exists pr 'issue_id'}}
                         {{#eq pr.status 'open'}}
                               <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr" title="{{format_time last_update}}">
-                                {{timeago last_update false false}}
+                                {{timeago last_update}}
                               </a>
                           {{else}}
                               {{#if last_update}}<i class="{{#eq pr.status 'merged'}} platform-pr-merged {{else}} platform-pr-closed {{/eq}}"></i>{{/if}}
                               <span class="no-pr" title="{{format_time last_update}}">
-                                {{timeago last_update false false}}
+                                {{timeago last_update}}
                               </span>
                           {{/eq}}
                       {{/exists}}

--- a/src/templates/dev_pipeline.handlebars
+++ b/src/templates/dev_pipeline.handlebars
@@ -88,12 +88,12 @@
                       {{#exists pr 'issue_id'}}
                         {{#eq pr.status 'open'}}
                               <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr" title="{{format_time last_update}}">
-                                {{timeago last_update 0}}
+                                {{timeago last_update false false}}
                               </a>
                           {{else}}
                               {{#if last_update}}<i class="{{#eq pr.status 'merged'}} platform-pr-merged {{else}} platform-pr-closed {{/eq}}"></i>{{/if}}
                               <span class="no-pr" title="{{format_time last_update}}">
-                                {{timeago last_update 0}}
+                                {{timeago last_update false false}}
                               </span>
                           {{/eq}}
                       {{/exists}}
@@ -142,12 +142,12 @@
                       {{#exists pr 'issue_id'}}
                         {{#eq pr.status 'open'}}
                               <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr" title="{{format_time last_update}}">
-                                {{timeago last_update}}
+                                {{timeago last_update false false}}
                               </a>
                           {{else}}
                               {{#if last_update}}<i class="{{#eq pr.status 'merged'}} platform-pr-merged {{else}} platform-pr-closed {{/eq}}"></i>{{/if}}
                               <span class="no-pr" title="{{format_time last_update}}">
-                                {{timeago last_update}}
+                                {{timeago last_update false false}}
                               </span>
                           {{/eq}}
                       {{/exists}}
@@ -196,12 +196,12 @@
                       {{#exists pr 'issue_id'}}
                         {{#eq pr.status 'open'}}
                               <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr" title="{{format_time last_update}}">
-                                {{timeago last_update 0}}
+                                {{timeago last_update false false}}
                               </a>
                           {{else}}
                               {{#if last_update}}<i class="{{#eq pr.status 'merged'}} platform-pr-merged {{else}} platform-pr-closed {{/eq}}"></i>{{/if}}
                               <span class="no-pr" title="{{format_time last_update}}">
-                                {{timeago last_update 0}}
+                                {{timeago last_update false false}}
                               </span>
                           {{/eq}}
                       {{/exists}}
@@ -250,12 +250,12 @@
                       {{#exists pr 'issue_id'}}
                         {{#eq pr.status 'open'}}
                               <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr" title="{{format_time last_update}}">
-                                {{timeago last_update 0}}
+                                {{timeago last_update false false}}
                               </a>
                           {{else}}
                               {{#if last_update}}<i class="{{#eq pr.status 'merged'}} platform-pr-merged {{else}} platform-pr-closed {{/eq}}"></i>{{/if}}
                               <span class="no-pr" title="{{format_time last_update}}">
-                                {{timeago last_update 0}}
+                                {{timeago last_update false false}}
                               </span>
                           {{/eq}}
                       {{/exists}}

--- a/src/templates/issues.handlebars
+++ b/src/templates/issues.handlebars
@@ -18,7 +18,7 @@
             {{title}}
           </a>
 	  <span class="tx-clr--lt tx-size--small">
-            opened {{timeago date}} ago by <a class="tx-clr--lt" href="https://github.com/{{author}}">{{author}}</a> 
+            opened {{timeago date false false}} ago by <a class="tx-clr--lt" href="https://github.com/{{author}}">{{author}}</a> 
 	  </span>
 	</span>
         <span class="issue-details pull-right">

--- a/src/templates/overview.handlebars
+++ b/src/templates/overview.handlebars
@@ -28,11 +28,11 @@
               {{#if most_recent}}
                 {{#eq @key 'live'}}
                   {{#if live_date}}
-                    <span class="tx-clr--lt tx-size--small ia_date right">{{timeago live_date}}</span>
+                    <span class="tx-clr--lt tx-size--small ia_date right">{{timeago live_date false false}}</span>
                   {{/if}}
                 {{else}}
                   {{#if beta_date}}
-                    <span class="tx-clr--lt tx-size--small ia_date right">{{timeago beta_date 1}}</span>
+                    <span class="tx-clr--lt tx-size--small ia_date right">{{timeago beta_date false true}}</span>
                   {{/if}}
                 {{/eq}}
               {{/if}}
@@ -68,7 +68,7 @@
               {{title}}
             </a>
 	    <span class="tx-clr--lt tx-size--small">
-              opened {{timeago date}} ago by <a class="tx-clr--lt" href="https://github.com/{{author}}">{{author}}</a> 
+              opened {{timeago date false false}} ago by <a class="tx-clr--lt" href="https://github.com/{{author}}">{{author}}</a> 
 	    </span>
 	  </span>
           <span class="issue-details pull-right">


### PR DESCRIPTION
Two things that's faulty with the `timeago` helper:

1. `.replace` method should be a regex in the first parameter and not a string.
2. We can't have implicit variables in the handlebars helpers. ~~Perl idioms seem to have seeped into our JavaScript! `0` isn't the same as `false`. `0 ? 1 : 2` will always result to `2`.~~

Please review, @MariagraziaAlastra.