### PR TITLE
New IA wizard - add support for multiple queries

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -1218,13 +1218,14 @@ sub create_ia :Chained('base') :PathPart('create') :Args() {
     my $ia = $c->d->rs('InstantAnswer')->find({id => $meta_id}) || $c->d->rs('InstantAnswer')->find({meta_id => $meta_id});
 
     if ($c->user && (!$ia)) {
-       $is_admin = $c->user->admin;
+        $is_admin = $c->user->admin;
         my $dev_milestone = $data->{dev_milestone}? $data->{dev_milestone} : "planning";
         my $name = $data->{name};
         my $repo = $data->{repo}? lc $data->{repo} : undef;
+        my $other_queries = $data->{other_queries}? from_json($data->{other_queries}) : [];
 
         # Capitalize each word in the name string
-        $name =~ s/([\w']+)/\u\L$1/g; 
+        $name =~ s/([\w']+)/\u\L$1/g;
         
         if (length $meta_id) { 
             my $new_ia = $c->d->rs('InstantAnswer')->create({
@@ -1234,7 +1235,9 @@ sub create_ia :Chained('base') :PathPart('create') :Args() {
                 dev_milestone => $dev_milestone,
                 description => $data->{description},
                 repo => $repo,
-                src_url => $data->{src_url}
+                src_url => $data->{src_url},
+                example_query => $data->{example_query},
+                other_queries => $data->{other_queries}
             });
 
             save_milestone_date($new_ia, 'created');

--- a/src/js/ia/IAPageNew.js
+++ b/src/js/ia/IAPageNew.js
@@ -149,6 +149,12 @@
                     if (temp_field) {
                         temp_field = temp_field.replace(/^.+\-/, "");
                         data[temp_field] = temp_val;
+
+                        if (temp_field === "example_query") {
+                            var queries = temp_val.replace(/((\s(?:\,)\s)|((\s(?:\,))|((?:\,)\s)))/g, ",").split(",");
+                            data.example_query = queries.shift();
+                            data.other_queries = JSON.stringify(queries);
+                        }
                     }
                 });
 

--- a/src/js/ia/IAPageNew.js
+++ b/src/js/ia/IAPageNew.js
@@ -151,7 +151,7 @@
                         data[temp_field] = temp_val;
 
                         if (temp_field === "example_query") {
-                            var queries = temp_val.replace(/((\s(?:\,)\s)|((\s(?:\,))|((?:\,)\s)))/g, ",").split(",");
+                            var queries = temp_val.replace(/((\s+(?:\,)\s+)|((\s+(?:\,))|((?:\,)\s+)))/g, ",").split(",");
                             data.example_query = queries.shift();
                             data.other_queries = JSON.stringify(queries);
                         }


### PR DESCRIPTION
Multiple queries can be added using commas to separate them.
E.g. "query1, query2, query3" (doesn't matter whether you put spaces between commas or not)

Also making sure the example queries are saved on IA creation.

//cc @russellholt @jagtalon 