### PR TITLE
Change old view hostnames to new staging server name.

### DIFF
--- a/lib/DDGC/Config.pm
+++ b/lib/DDGC/Config.pm
@@ -77,7 +77,7 @@ sub rootdir {
 has_conf web_base => DDGC_WEB_BASE => sub {
 	( $_[0]->is_live )
 		? 'https://duck.co'
-		: 'https://view.dukgo.com';
+		: 'https://ddgc-staging.duckduckgo.com';
 };
 
 sub prosody_db_samplefile { File::Spec->rel2abs( File::Spec->catfile( dist_dir('DDGC'), 'ddgc.prosody.sqlite' ) ) }
@@ -115,7 +115,7 @@ sub is_live {
 
 sub is_view {
 	my $self = shift;
-	$self->prosody_userhost() eq 'view.dukgo.com' ? 1 : 0
+	$self->prosody_userhost() eq 'ddgc-staging-xmpp.duckduckgo.com' ? 1 : 0
 }
 
 has_conf prosody_admin_username => DDGC_PROSODY_ADMIN_USERNAME => 'testone';

--- a/templates/view_disclaimer.tx
+++ b/templates/view_disclaimer.tx
@@ -1,7 +1,7 @@
 <: if $is_view { :>
 	<div class="notice error clickaway">
 		<i class="icn icon-warning-sign"></i>
-		Welcome to view.dukgo.com --our testing site for upcoming changes to the community platform.
+		Welcome to ddgc-staging.duckduckgo.com --our testing site for upcoming changes to the community platform.
 		<b>
 			Please note, as this site is constantly updated and can be accessed by members of the community, we ask that you use a disposable email for registration. If you need help finding one, we like
 			<a href="http://mailinator.com/">http://mailinator.com/</a> and


### PR DESCRIPTION
Detecting we are on staging will start working again!

This is currently a minor issue since we are trying to load development livereload.js stuff on staging.

Need a better solution for this function longer term.