### PR TITLE
IAPageNew.js - don't include empty examples in the array

### DIFF
--- a/src/js/ia/IAPageNew.js
+++ b/src/js/ia/IAPageNew.js
@@ -159,7 +159,7 @@
                         data[temp_field] = temp_val;
 
                         if (temp_field === "example_query") {
-                            var queries = temp_val.replace(/((\s+(?:\,)\s+)|((\s+(?:\,))|((?:\,)\s+)))/g, ",").split(",");
+                            var queries = temp_val.replace(/\,\s*\,/g, ",").replace(/((\s+(?:\,)\s+)|((\s+(?:\,))|((?:\,)\s+)))/g, ",").split(",");
                             data.example_query = queries.shift();
                             data.other_queries = JSON.stringify(queries);
                         }


### PR DESCRIPTION
Minor fix - remove any empty examples before splitting the string into an array.