### PR TITLE
issues.handlebars - sort by issue creation date rather than alphabetically

### DIFF
--- a/src/scss/ia/_issues-list.scss
+++ b/src/scss/ia/_issues-list.scss
@@ -13,7 +13,7 @@
 	.issue-name {
 	    display: inline-block;
 	    vertical-align: bottom;
-	    max-width: 80%;
+	    max-width: 60%;
 	}
 
 	& > header {

--- a/src/templates/issues.handlebars
+++ b/src/templates/issues.handlebars
@@ -10,8 +10,7 @@
       </span>
     </header>
     <ul>
-      {{#each ia}}
-      {{#each issues}}
+      {{#each by_date}}
       <li class="{{#each tags}}tag-{{slug name}} {{/each}}" data-repo="{{repo}}">
 	<span class="pull-left">
 	  <a class="tx-clr--dk one-line issue-name" href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{issue_id}}">
@@ -25,7 +24,6 @@
           <a href="/ia/view/{{ia_id}}" class="tx-clr--lt tx-size--small">{{ia_name}}</a>
         </span>
       </li>
-      {{/each}}
       {{/each}}
     </ul>
   </section>

--- a/src/templates/issues.handlebars
+++ b/src/templates/issues.handlebars
@@ -11,8 +11,8 @@
     </header>
     <ul>
       {{#each by_date}}
-      <li class="{{#each tags}}tag-{{slug name}} {{/each}}" data-repo="{{repo}}">
-	<span class="pull-left">
+      <li class="{{#each tags}}tag-{{slug name}} {{/each}} clearfix" data-repo="{{repo}}">
+	<span>
 	  <a class="tx-clr--dk one-line issue-name" href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{issue_id}}">
             {{title}}
           </a>

--- a/src/templates/overview.handlebars
+++ b/src/templates/overview.handlebars
@@ -63,7 +63,7 @@
       <ul class="list-container--left__issues issues_col main-tag__left__list">
         {{#loop_n 5 list}}
         <li class="clearfix">
-          <span class="pull-left">
+          <span>
 	    <a class="tx-clr--dk one-line issue-name" href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{issue_id}}">
               {{title}}
             </a>


### PR DESCRIPTION
//cc @jagtalon 
Since right now we don't have the "grouped by IA" view it makes more sense to sort the issues in the Live Issues page by creation date rather than by IA name.
![screenshot-maria duckduckgo com 5001 2015-12-23 19-04-53](https://cloud.githubusercontent.com/assets/3652195/11982022/13182df0-a9a8-11e5-9c59-b789a15dcfea.png)
