### PR TITLE
overview.handlebars - 'learn how to contribute' should link to the docs

### DIFF
--- a/src/templates/overview.handlebars
+++ b/src/templates/overview.handlebars
@@ -46,7 +46,7 @@
 
 <header>
   <span class="pull-left">Top Issues on GitHub</span>
-  <a href="https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/CONTRIBUTING.md" class="btn btn--wire__blue pull-right">Learn How To Contribute</a>
+  <a href="http://docs.duckduckhack.com/#improve-a-live-instant-answer" class="btn btn--wire__blue pull-right">Learn How To Contribute</a>
 </header>
 
 <div id="top-issues" class="issues-list clearfix">


### PR DESCRIPTION
//cc @zekiel @jagtalon Link changed, as requested