### PR TITLE
move to development and fix date

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -1582,7 +1582,9 @@ sub save_milestone_date {
     return unless $field;
     
     my @time = localtime(time);
-    my $date = "$time[4]/$time[3]/".($time[5]+1900);
+    my ($month, $day, $year) = ($time[4]+1, $time[3], $time[5]+1900);
+    my $date = "$month/$day/$year";
+
     update_ia($ia, $field, $date);
 
     update_ia($ia, 'test_machine', undef) if ($milestone eq 'live');

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -140,11 +140,13 @@ sub getIssues{
                 } )->hri->one_row;
                 my $new_ia = 1 if !$ia;
 
+                # no auto generating IA pages from a PR anymore
+                return unless $ia;
+
                 my @time = localtime(time);
                 my $date = "$time[4]/$time[3]/".($time[5]+1900);
 
                 $data->{body} =~ s/\n|\r//g;
-
 
                 # get the file info for the pr
                 $gh->set_default_user_repo('duckduckgo', "zeroclickinfo-$data->{repo}");
@@ -183,11 +185,17 @@ sub getIssues{
                 my $name = $data->{name};
                 $name =~ s/_/ /g;
 
+                # move status to development once we have seen the PR
+                my $dev_milestone;
+                if($ia->{dev_milestone} eq 'planning'){
+                    $dev_milestone = 'development';
+                }
+
                 my %new_data = (
                     id => $ia->{id} || $data->{name},
                     meta_id => $ia->{meta_id} || $data->{name},
                     name => $ia->{name} || ucfirst $name,
-                    dev_milestone => $ia->{dev_milestone} || 'planning',
+                    dev_milestone => $dev_milestone || $ia->{dev_milestone},
                     description => $ia->{description},
                     created_date => $ia->{created_date} || $date, 
                     repo => $ia->{repo} || $data->{repo},

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -144,7 +144,8 @@ sub getIssues{
                 return unless $ia;
 
                 my @time = localtime(time);
-                my $date = "$time[4]/$time[3]/".($time[5]+1900);
+                my ($month, $day, $year) = ($time[4]+1, $time[3], $time[5]+1900);
+                my $date = "$month/$day/$year";
 
                 $data->{body} =~ s/\n|\r//g;
 

--- a/sql/1.118/fix-date.sql
+++ b/sql/1.118/fix-date.sql
@@ -1,0 +1,3 @@
+BEGIN;
+    update instant_answer set created_date = created_date + INTERVAL '1 month';
+COMMIT;


### PR DESCRIPTION
Move IA pages to development when we see the IA page link in a PR. 
Fix date bug. Localtime months start at 0 

@jbarrett 