### PR TITLE
only update template messages if IA page data has changed

### DIFF
--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -528,11 +528,10 @@ $mobile
     # remove white space and testing block of the comment.  Testing
     # has markdown clickable check boxes that we don't want to compare.
     my $tmp_message = $message;
-    map{
+    for ($tmp_message, $old_comment){
         $_ =~ s/\s//g;
         $_ =~ s/\*\*Testing\*\*.*$//g;
-    } ($tmp_message, $old_comment);
-
+    }
     return if $tmp_message eq $old_comment;
 
     my $dax = $ENV{DAX_TOKEN};

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -525,6 +525,8 @@ $mobile
 *This is an automated message which will be updated as changes are made to the [IA page](https://duck.co/ia/view/$data->{meta_id})*
 );
     # check to see if anything has been updated since the last post
+    # remove white space and testing block of the comment.  Testing
+    # has markdown clickable check boxes that we don't want to compare.
     my $tmp_message = $message;
     map{
         $_ =~ s/\s//g;

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -442,6 +442,7 @@ sub update_pr_template {
     my @comments = $gh->issue->comments($pr_number);
 
     my $comment_number;
+    my $old_comment = '';
     if(scalar @comments){
         my $comment = $comments[0];
         return unless $comment->{user}->{login} eq 'daxtheduck';
@@ -455,6 +456,7 @@ sub update_pr_template {
             }
         }else{
             $comment_number = $comment->{id};
+            $old_comment = $comment->{body};
         }
     }
 
@@ -522,12 +524,19 @@ $mobile
 ---
 *This is an automated message which will be updated as changes are made to the [IA page](https://duck.co/ia/view/$data->{meta_id})*
 );
+    # check to see if anything has been updated since the last post
+    my $tmp_message = $message;
+    map{
+        $_ =~ s/\s//g;
+        $_ =~ s/\*\*Testing\*\*.*$//g;
+    } ($tmp_message, $old_comment);
+
+    return if $tmp_message eq $old_comment;
 
     my $dax = $ENV{DAX_TOKEN};
     return unless $dax;
 
     warn "Posting comment";
-
     my $dax_comment = Net::GitHub->new(access_token => $dax);
     if(!$comment_number){
         # update the comment


### PR DESCRIPTION
Some background:
github considers the automated updates to these comments as activity on the PR
https://github.com/duckduckgo/zeroclickinfo-goodies/pull/2007#issuecomment-168799091

Which is messing up our activity dates on the pipeline page since a dax comment update shows as activity.
![selection_115](https://cloud.githubusercontent.com/assets/1882892/12100953/414f9d78-b300-11e5-8602-5d79ca09732f.jpg)

To fix:
Only post updates if there has been a change in the IA page data.