### PR TITLE
Wrong closing tag: Messes up the spacing

### DIFF
--- a/templates/instantanswer/new_ia.tx
+++ b/templates/instantanswer/new_ia.tx
@@ -92,7 +92,7 @@
 	    
 	    <div class="wizard_field">
 	      <div class="ia-new__title tx-clr--dk">Data Source</div>
-		<p class="field_desc tx-clr--lt">Link to the data source or API, if any</a>
+		<p class="field_desc tx-clr--lt">Link to the data source or API, if any</p>
 		<input class="frm__input wizard_field_insert" id="src_url-input" placeholder="http://api.alternativeto.net/" />
 	    </div>
 	    


### PR DESCRIPTION
Closing tag
Open all the doors and let you out into the world
Closing tag
Turn the lights up over every boy and every girl.
Closing tag
One last call for alcohol so finish your whiskey or beer.
Closing tag
You don't have to go home but you can't stay here.