### PR TITLE
Dev Pipeline - always show PR info and comments in the detail sidebar

### DIFF
--- a/src/scss/ia/_pipeline.scss
+++ b/src/scss/ia/_pipeline.scss
@@ -396,7 +396,6 @@ textarea.edit-sidebar {
 	}
 
         .item-name {
-            .no-pr { text-decoration: line-through; }
 
 	    .item-activity a {
 		color: $blue;
@@ -549,3 +548,5 @@ textarea.edit-sidebar {
 .filter-count {
     padding-left: 0.4em;
 }
+
+.no-pr { text-decoration: line-through; }

--- a/src/templates/dev_pipeline_detail.handlebars
+++ b/src/templates/dev_pipeline_detail.handlebars
@@ -174,37 +174,35 @@
 {{/if}}
 
 {{#if pr.status}}
-    {{#eq pr.status 'open'}}
-        <hr />
+    <hr />
 
-        <div id="sidebar-pr">
-            <div class="left">
-                <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line" id="pr">
-                    PR #{{pr.issue_id}}
-                </a>
-            </div>
-            <div class="right" title="{{format_time last_update}}">
-                <i class="ddgsi ddgsi-clock" />
-                {{timeago last_update}}
-            </div>
-            {{#if last_comment}}
-                <div class="right" id="all_comments">
-                    <i class="ddgsi ddgsi-comment" />
-                    {{length all_comments}}
-                </div>
-            {{/if}}
-
-            <span class="clearfix"></span>
-            
-            {{#each all_comments}}
-                <p class="comment">
-                    <a href="https://github.com/duckduckgo/zeroclickinfo-{{../repo}}/issues/{{../pr.issue_id}}#issuecomment-{{id}}">
-                        {{text}}
-                    </a>
-                </p>
-                <div>by <a href="https://github.com/{{user}}">{{user}}</a> {{timeago date 1}}</div>
-            {{/each}}
+    <div id="sidebar-pr">
+        <div class="left">
+            <a href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/{{pr.issue_id}}" class="one-line {{#not_eq pr.status 'open'}}no-pr{{/not_eq}}" id="pr">
+                PR #{{pr.issue_id}}
+            </a>
         </div>
-    {{/eq}}
+        <div class="right" title="{{format_time last_update}}">
+            <i class="ddgsi ddgsi-clock" />
+            {{timeago last_update}}
+        </div>
+        {{#if last_comment}}
+            <div class="right" id="all_comments">
+                <i class="ddgsi ddgsi-comment" />
+                {{length all_comments}}
+            </div>
+        {{/if}}
+
+        <span class="clearfix"></span>
+        
+        {{#each all_comments}}
+            <p class="comment">
+                <a href="https://github.com/duckduckgo/zeroclickinfo-{{../repo}}/issues/{{../pr.issue_id}}#issuecomment-{{id}}">
+                    {{text}}
+                </a>
+            </p>
+            <div>by <a href="https://github.com/{{user}}">{{user}}</a> {{timeago date 1}}</div>
+        {{/each}}
+    </div>
 {{/if}}
 


### PR DESCRIPTION
//cc @jagtalon 
This shows comments even after the PR is closed or merged. 
I thought I'd use the .no-pr class for the PR link in that case:
![screenshot-maria duckduckgo com 5001 2016-01-13 16-03-14](https://cloud.githubusercontent.com/assets/3652195/12297898/ab9462c0-ba0f-11e5-8df9-a95150bbf2a2.png)
