### PR TITLE
IA Index - add sorting via URL params

### DIFF
--- a/lib/DDGC/DB/ResultSet/InstantAnswer.pm
+++ b/lib/DDGC/DB/ResultSet/InstantAnswer.pm
@@ -18,11 +18,13 @@ sub ia_index_hri {
                 qw/ name repo src_name
                     dev_milestone description
                     template meta_id perl_module
+                    live_date created_date
                 /, ],
              'as' => [
                 qw/ name repo src_name
                     dev_milestone description
                     template id perl_module
+                    live_date created_date
                 /, ],
             collapse => 1,
         },

--- a/src/js/ia/IAIndex.js
+++ b/src/js/ia/IAIndex.js
@@ -316,6 +316,11 @@
                 }
             }
 
+            if (sort_field.length) {
+                var direction = this.sort_asc? "sort_asc" : "sort_desc";
+                url += "&" + direction + "=" + sort_field;
+            }
+
             url = url.length? "?" + url.replace("#", "").replace("&", ""): "/ia";
             
             // Allows changing URL without reloading, since it doesn't add the new URL to history;


### PR DESCRIPTION
//cc @russellholt 
This allows to sort the index using either sort_asc (for sorting in ascending order) or sort_desc (descending) for any field we retrieve, including live_date and created_date.
Eg if you want to sort in a descending order by live_date: /ia?sort_desc=live_date
![screenshot-maria duckduckgo com 5001 2016-01-15 14-50-01](https://cloud.githubusercontent.com/assets/3652195/12355559/c58080da-bb9d-11e5-8370-9110c60ef653.png)

If you want to sort as done above and filter by repo, showing only spices:
/ia?repo=spice&sort_desc=live_date
![screenshot-maria duckduckgo com 5001 2016-01-15 15-34-00](https://cloud.githubusercontent.com/assets/3652195/12355594/f44246d8-bb9d-11e5-9505-ba4616b68353.png)
