### PR TITLE
IA Pages - disable editing on the template field for fatheads and longtails

### DIFF
--- a/src/templates/advanced.handlebars
+++ b/src/templates/advanced.handlebars
@@ -117,9 +117,9 @@
                         <label class="details__label">
                             Template
                         </label>
-                        <input type="text" class="js-autocommit frm__input template" id="template-input" value="{{#exists_subkey staged 'details' 'template'}}{{staged.details.template}}{{else}}{{template}}{{/exists_subkey}}">
+                        <input disabled type="text" class="js-autocommit frm__input frm__input--disabled template" id="template-input" value="Fathead default">
                     </div>
-
+                    
                     <div class="half">
                         <label  class="details__label">
                             Source ID
@@ -246,7 +246,7 @@
                     <label class="details__label">
                         Template
                     </label>
-                    <input type="text" class="js-autocommit frm__input template" id="template-input" value="{{#exists_subkey staged 'details' 'template'}}{{staged.details.template}}{{else}}{{template}}{{/exists_subkey}}">
+                    <input disabled type="text" class="js-autocommit frm__input frm__input--disabled template" id="template-input" value="Longtail default">
                 </div>
             </div>
 

--- a/src/templates/pre_edit_template.handlebars
+++ b/src/templates/pre_edit_template.handlebars
@@ -1,37 +1,39 @@
-<div class="row-diff" id="row-diff-template">
-    <div class="column-left-labels left">
-        <div class="column-left-labels__child">
-            <p class="column-left-labels__child__p">
-                Template
-            </p>
+{{#ne_and live.repo 'fathead' 'longtail'}}
+    <div class="row-diff" id="row-diff-template">
+        <div class="column-left-labels left">
+            <div class="column-left-labels__child">
+                <p class="column-left-labels__child__p">
+                    Template
+                </p>
+            </div>
         </div>
-    </div>
-    <div class="column-center-live left">
-        <div class="column-center-live__child">
-            <p class="column-center-live__child__p">
-                {{#if live.template}}
-                    {{live.template}}
-                {{else}}
-                    —
-                {{/if}}
-            </p>
+        <div class="column-center-live left">
+            <div class="column-center-live__child">
+                <p class="column-center-live__child__p">
+                    {{#if live.template}}
+                        {{live.template}}
+                    {{else}}
+                        —
+                    {{/if}}
+                </p>
+            </div>
         </div>
-    </div>
-    <div class="column-right-edits left" id="column-edits-template">
-        <div class="column-right-edits__child">
-            <p class="column-right-edits__child__p">
-                {{edited.template}}
-            </p>
+        <div class="column-right-edits left" id="column-edits-template">
+            <div class="column-right-edits__child">
+                <p class="column-right-edits__child__p">
+                    {{edited.template}}
+                </p>
+            </div>
         </div>
-    </div>
 
-    <div class="button js-pre-editable" name="template">
-        <i class="js-pre-editable__icon icon-edit"></i>
-        <span class="js-pre-editable__text">Edit</span>
-    </div>
+        <div class="button js-pre-editable" name="template">
+            <i class="js-pre-editable__icon icon-edit"></i>
+            <span class="js-pre-editable__text">Edit</span>
+        </div>
 
-    <div class="button hide js-editable" name="template">
-        <i class="js-editable__icon icon-check"></i>
-        <span class="js-editable__text">Done</span>
+        <div class="button hide js-editable" name="template">
+            <i class="js-editable__icon icon-check"></i>
+            <span class="js-editable__text">Done</span>
+        </div>
     </div>
-</div>
+{{/ne_and}}


### PR DESCRIPTION
On the live editable page is not shown at all (there's no point in showing it if it can't be edited)

On the dev pages it's shown but disabled (can't remove it without reorganizing the whole details section layout).
Fathead:
![screenshot-maria duckduckgo com 5001 2016-01-19 21-47-27](https://cloud.githubusercontent.com/assets/3652195/12432050/3340836e-bef9-11e5-8ab7-4b3c90c5aa02.png)
