### PR TITLE
New IA Wizard - better error message when IA Page already exists

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -1277,7 +1277,9 @@ sub create_ia_from_pr :Chained('base') :PathPart('create_from_pr') :Args() {
     my $url = $c->req->params->{pr};
     my ($id, $result) = '';
     my $user = $c->user;
-
+    my $name;
+    my $exists;
+    
     if ($user) {
         if(my ($repo, $pr_number) = $url =~ /https?:\/\/github.com\/duckduckgo\/zeroclickinfo-(.+)\/pull\/(.+)$/){
             # get data form this pr
@@ -1368,6 +1370,10 @@ sub create_ia_from_pr :Chained('base') :PathPart('create_from_pr') :Args() {
                     if (!$user->admin) {
                         $new_ia->add_to_users($user);
                     }
+                } else {
+                    $id = $ia->meta_id;
+                    $name = $ia->name;
+                    $exists = 1;
                 }
             }
         }
@@ -1375,7 +1381,9 @@ sub create_ia_from_pr :Chained('base') :PathPart('create_from_pr') :Args() {
     
     $c->stash->{x} = {
         result => $result,
-        id => $id
+        id => $id,
+        exists => $exists,
+        name => $name
     };
 
     $c->stash->{not_last_url} = 1;

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -1221,6 +1221,8 @@ sub create_ia :Chained('base') :PathPart('create') :Args() {
     my $meta_id = format_id($data->{id});
     warn $meta_id;
     my $ia = $c->d->rs('InstantAnswer')->find({id => $meta_id}) || $c->d->rs('InstantAnswer')->find({meta_id => $meta_id});
+    my $name;
+    my $exists;
 
     if ($c->user && (!$ia)) {
         $is_admin = $c->user->admin;
@@ -1262,10 +1264,17 @@ sub create_ia :Chained('base') :PathPart('create') :Args() {
 
             $result = 1;
         }
+    } elsif ($ia) {
+        $meta_id = $ia->meta_id;
+        $name = $ia->name;
+        $exists = 1;
     }
+    
     $c->stash->{x} = {
         result => $result,
-        id => $meta_id
+        id => $meta_id,
+        name => $name,
+        exists => $exists
     };
 
     $c->stash->{not_last_url} = 1;

--- a/src/js/ia/IAPageNew.js
+++ b/src/js/ia/IAPageNew.js
@@ -209,7 +209,14 @@
                     })
                     .done(function(result) {
                        console.log(result);
-                       checkRedirect(result, $("#id-error"));
+                       var $id_error = $("#id-error");
+                       if (result) {
+                           var $link = $id_error.find("a");
+                           $link.text(result.name);
+                           $link.attr("href", "/ia/view/" + result.id);
+                       }
+                       
+                       checkRedirect(result, $id_error);
                     });
                 } else if (!data.id) {
                     $("#id-empty-error").removeClass("hide");

--- a/src/js/ia/IAPageNew.js
+++ b/src/js/ia/IAPageNew.js
@@ -184,7 +184,16 @@
                     })
                     .done(function(data) {
                         console.log(data);
-                        checkRedirect(data, $("#pr-error"));
+                        var $id_error = $("#pr-id-error");
+                        var $msg = $("#pr-error");
+                        if (data) {
+                            var $link = $id_error.find("a");
+                            $link.text(data.name);
+                            $link.attr("href", "/ia/view/" + data.id);
+                            $msg = data.exists? $id_error : $("#pr-error");
+                        }
+                        
+                        checkRedirect(data, $msg);
                     });
                 } else if (!pr.length) {
                     $("#pr-empty-error").removeClass("hide");

--- a/templates/instantanswer/new_ia.tx
+++ b/templates/instantanswer/new_ia.tx
@@ -74,7 +74,7 @@
     <div class="twothirds">
 	    <div class="wizard_field">
 		<div class="ia-new__title tx-clr--dk">Title</div>
-        <p class="error-message hide" id="id-error">An Instant Answer with this title already exists: </p>
+        <p class="error-message hide" id="id-error">An Instant Answer with this title already exists: <a href=""></a></p>
         <p class="error-message hide" id="id-empty-error">The value for this field can't be empty</p>
 		<input class="frm__input wizard_field_insert" id="name-input" placeholder="e.g., AlternativeTo" />
 	    </div>   

--- a/templates/instantanswer/new_ia.tx
+++ b/templates/instantanswer/new_ia.tx
@@ -12,6 +12,7 @@
             </div>
             <p class="clearfix tx-clr--lt">The IA Page will be created from the details within your pull request.</p>
             <p class="error-msg hide" id="pr-error">Incorrect URL</p>
+            <p class="error-msg hide" id="pr-id-error">IA Page already exists: <a href=""></a></p>
             <p class="error-msg hide" id="pr-empty-error">This field can't be empty</p>
             <input id="pr-input" class="new-ia-input frm__input" placeholder="e.g., https://github.com/duckduckgo/zeroclickinfo-spice/pull/2328"/>
         </div>
@@ -73,7 +74,7 @@
     <div class="twothirds">
 	    <div class="wizard_field">
 		<div class="ia-new__title tx-clr--dk">Title</div>
-        <p class="error-message hide" id="id-error">An Instant Answer with this title already exists</p>
+        <p class="error-message hide" id="id-error">An Instant Answer with this title already exists: </p>
         <p class="error-message hide" id="id-empty-error">The value for this field can't be empty</p>
 		<input class="frm__input wizard_field_insert" id="name-input" placeholder="e.g., AlternativeTo" />
 	    </div>   


### PR DESCRIPTION
When creating an IA Page from a PR link:
![screenshot-maria duckduckgo com 5001 2016-01-20 20-04-03](https://cloud.githubusercontent.com/assets/3652195/12460510/56e38968-bfb4-11e5-8954-72c3c25f21c3.png)

When manually filling in the fields:
![screenshot-maria duckduckgo com 5001 2016-01-20 20-26-20](https://cloud.githubusercontent.com/assets/3652195/12460517/61caa546-bfb4-11e5-9499-912392087a97.png)
