### PR TITLE
IA Pages - handle null PR status and New IA Wizard improvements

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -1360,10 +1360,18 @@ sub create_ia_from_pr :Chained('base') :PathPart('create_from_pr') :Args() {
                 if (!$ia) {
                     $result = 1;
 
+                    my $name = $id;
+                    
+                    # Underscores to spaces
+                    $name =~ s/\_/ /g;
+                    
+                    # Capitalize each word in the name string
+                    $name =~ s/([\w']+)/\u\L$1/g;
+                    
                     my $new_ia = $c->d->rs('InstantAnswer')->update_or_create({
                         id => $id,
                         meta_id => $id,
-                        name => $id,
+                        name => $name,
                         repo => $repo,
                         dev_milestone => 'planning',
                         public => 1,
@@ -1379,6 +1387,7 @@ sub create_ia_from_pr :Chained('base') :PathPart('create_from_pr') :Args() {
                         issue_id => $pr_number,
                         is_pr => 1,
                         tags => {},
+                        status => $pr_data->{status}
                     });
 
                     # update first comment with link to IA page

--- a/src/templates/devinfo.handlebars
+++ b/src/templates/devinfo.handlebars
@@ -53,7 +53,7 @@
             {{#each issues}}
                 <li>
                     {{#eq_or status 'merged' 'closed'}} <i class="platform-pr-{{status}} left" /> {{/eq_or}}
-                    <a href="https://github.com/duckduckgo/zeroclickinfo-{{../repo}}/issues/{{id}}" class="one-line {{#not_eq status 'open'}}no-pr{{/not_eq}} left" id="pr">{{id}}</a>
+                    <a href="https://github.com/duckduckgo/zeroclickinfo-{{../repo}}/issues/{{id}}" class="one-line {{#eq_or status 'closed' 'merged'}}no-pr{{/eq_or}} left" id="pr">{{id}}</a>
                     <span class="clearfix"></span>
                 </li>
             {{/each}}


### PR DESCRIPTION
When creating an IA from a PR link the status isn't set and thus it's initially null, and in the IA Page the PR link has the strikethrough, because the status isn't "open".
This PR handles the case in which PR status is null (just show the PR as open) and stores the status when creating an IA Page.
Also, beautifies the IA name (eg if the meta_id is "example_cheat_sheet" the name will be "Example Cheat Sheet").