### PR TITLE
Fix logic error in Github check while verifying creds on email reset

### DIFF
--- a/lib/DDGC/Web/Controller/My.pm
+++ b/lib/DDGC/Web/Controller/My.pm
@@ -429,7 +429,7 @@ sub email :Chained('logged_in') :Args(0) {
 
 	$c->require_action_token;
 
-	if ($c->user->github_id || !$c->user->check_password($c->req->params->{password})) {
+	if (!$c->user->github_id && !$c->user->check_password($c->req->params->{password})) {
 		$c->stash->{wrong_password} = 1;
 		return;
 	}


### PR DESCRIPTION
The history of this is:

- Emails can be used to reset account passwords
- If you are logged in you know your password, so we require it to change email address
- This prevents someone leaving their computer logged in and having email address reset

Now we support account creation via Github and will import the public email address where it available. However, if no email address is public, we can't do that. In the scenario where a user wishes to set their XMPP password, they'll need an email address set. If you created the account with Github without a public email address, you don't have a password with which to reset the address. (I hope this is clear).

This change along with #1206 should accommodate this by not requiring passwords of Github authed users in order to set email address. This PR fixes a logic error in checking if a github ID is set before checking password, so...

- If a user has not authed with Github, they should be prompted for a password when changing email (since in this scenario email changes can be used for account hijacking).
- If a user is authed with Github, they should not be prompted for a password when changing email.