### PR TITLE
Update IA page developer list when a PR is merged

### DIFF
--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -105,7 +105,6 @@ sub getIssues{
             my $state = $issue->{state};
             if ($state ne 'open') {
                 $state = $gh->pull_request->is_merged('duckduckgo','zeroclickinfo-'.$repo, $issue->{number})? 'merged' : $state;
-                # add this dev to the dev list if the pr was merged
             }
 
             # add entry to result array

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -555,7 +555,7 @@ sub add_developer {
 
     try{
         if($user){
-            my $ddgc_name = $user->user_name ;
+            my $ddgc_name = $user->username ;
             return $dev_json if $dev_json =~ /duck.co\/user\/$ddgc_name/g;
         }
 


### PR DESCRIPTION
Update IA page developer list when a PR is merged.

For testing: 
Run ghIssues.  Check github for any PR that has been merged in the last day.  You should see that developer included in the list on the IA page.