### PR TITLE
IA Pages - more accurate graphs

### DIFF
--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1759,7 +1759,8 @@
                     Chart.defaults.global.scaleBeginAtZero = true;
                     var chart = new Chart(traffic).Line(chart_data);
                 } else {
-                    $("#traffic_wrapper").addClass("hide");
+                    $("#traffic_dates, canvas").addClass("hide");
+                    $("#no_traffic").removeClass("hide");
                 }
 
                 $(".ia-single--right").append(templates.live.devinfo);

--- a/src/templates/traffic.handlebars
+++ b/src/templates/traffic.handlebars
@@ -1,7 +1,7 @@
 {{#or permissions.can_edit permissions.admin}}
     <div id="traffic_wrapper">
         <h3 class="ia-single--header">
-            <span>Traffic from Last 30 Days</span>
+            <span>Traffic from Last <span id="traffic_count">30</span> Days</span>
         </h3>
         <canvas class="charts" id="ia_traffic"></canvas>
     </div>

--- a/src/templates/traffic.handlebars
+++ b/src/templates/traffic.handlebars
@@ -1,8 +1,9 @@
 {{#or permissions.can_edit permissions.admin}}
     <div id="traffic_wrapper">
         <h3 class="ia-single--header">
-            <span>Traffic from Last <span id="traffic_count">30</span> Days</span>
+            <span>Traffic <span id="traffic_dates">from Last <span id="traffic_count">30</span> Days</span></span>
         </h3>
+        <p id="no_traffic" class="hide"> Not enough data. </p>
         <canvas class="charts" id="ia_traffic"></canvas>
     </div>
 {{/or}}


### PR DESCRIPTION
- Fill the traffic data for missing days with zeroes
- Start from live_date instead of 30 days ago, if the IA has been deployed recently (and indicate the correct number of days in the Traffic header in that case)
- Show "not enough data" message when we don't have the data/the IA didn't trigger in the last 30 days

I need to deploy to staging to test this (I don't have the traffic data in my instance). 
In the meantime, this is how it looks when there's no data:
![screenshot-maria duckduckgo com 5001 2016-02-08 16-09-48](https://cloud.githubusercontent.com/assets/3652195/12889293/806b473e-ce7e-11e5-8fc4-e4ab1cca859c.png)
