### PR TITLE
IA Pages - last traffic date should be equivalent to the last time the data was updated

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -778,11 +778,16 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
             
             if ($is_dev || $is_admin) {
                 my $today = DateTime->today();
-                my $month_ago = $today->clone->subtract( days => 30 )->date();
+                my $monday = 1;
+                my $weekdays = 7;
+                
+                # Traffic data is updated on Mondays
+                my $last_monday = $today->subtract(days => ($today->day_of_week - $monday) %$weekdays || $weekdays);
+                my $month_ago = $last_monday->clone->subtract( days => 30 )->date();
                 my $traffic_rs = $c->d->rs('InstantAnswer::Traffic')->search(
                     {
                         answer_id => $ia->meta_id, 
-                        date => { '<' => $today->date()}, 
+                        date => { '<' => $last_monday->date()}, 
                         date => { '>' => $month_ago},
                         pixel_type => [qw( iaoi iaoe )]
                     });

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1671,8 +1671,10 @@
         normalizeTraffic: function(traffic, live_date) {
             var result = [];
 
-            var now = moment();
-            var month_ago = moment().subtract(30, "days");
+            // Data is updated every Monday
+            // so the dates array will have last Monday as last entry
+            var monday = moment(traffic.dates[traffic.dates.length - 1]);
+            var month_ago = monday.subtract(30, "days");
             var iap = this;
 
             live_date = moment(live_date);
@@ -1686,15 +1688,9 @@
                 result = iap.diffZeros(temp_date, last_date, result);
                 result.push(traffic.counts[idx]);
                 last_date = temp_date;
-
-                if (idx+1 === traffic.dates.length) {
-                    result = iap.diffZeros(now, last_date, result);
-                    result.push(0);
-                    console.log(result);
-
-                    return result;
-                }
             }
+
+            return result;
 
         },
 
@@ -1758,7 +1754,7 @@
                     var traffic_header =  ": " + this.sumCounts(ia_data.live.traffic.counts) + " queries total";
                     $("#queries_total").text(traffic_header);
                     var counts = this.normalizeTraffic(ia_data.live.traffic, ia_data.live.live_date);
-                    $("#traffic_counts").text(counts.length);
+                    $("#traffic_count").text(counts.length);
                     var empty_labels = counts.map(function(obj){return "";});
 
                     var chart_data = {

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1764,7 +1764,7 @@
                     Chart.defaults.global.scaleBeginAtZero = true;
                     var chart = new Chart(traffic).Line(chart_data);
                 } else {
-                    $("#traffic_dates, canvas").addClass("hide");
+                    $("#traffic_dates, #update_frequency, canvas").addClass("hide");
                     $("#no_traffic").removeClass("hide");
                 }
 

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1679,9 +1679,6 @@
 
             live_date = moment(live_date);
             var last_date = live_date.diff(month_ago) > 1? live_date : month_ago;
-            console.log("last date: " + last_date.format());
-            console.log("month ago: " + month_ago.format());
-            console.log("live date: " + live_date.format());
             
             for (var idx = 0; idx < traffic.dates.length; idx++) {
                 var temp_date = moment(traffic.dates[idx]);
@@ -1691,15 +1688,10 @@
             }
 
             return result;
-
         },
 
         diffZeros: function(last, previous, result) {
-            console.log("LAST: " + last.format());
-            console.log("PREVIOUS: " + previous.format());
-            console.log(result);
             var diff = last.diff(previous, "days");
-            console.log("DIFF: " + diff);
 
             if (diff > 1) {
                 var zeros = [];
@@ -1708,12 +1700,8 @@
                     zeros.push(0);
                 }
 
-                console.log(zeros);
                 result = result.concat(zeros);
-                console.log("result after zeros: " + result);
             } 
-
-            console.log(result);
 
             return result;
         },

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1672,32 +1672,52 @@
             var result = [];
 
             var now = moment();
-            var month_ago = now.subtract(30, "days");
+            var month_ago = moment().subtract(30, "days");
             var iap = this;
 
             live_date = moment(live_date);
             var last_date = live_date.diff(month_ago) > 1? live_date : month_ago;
+            console.log("last date: " + last_date.format());
+            console.log("month ago: " + month_ago.format());
+            console.log("live date: " + live_date.format());
             
-            $.each(traffic.dates, function(idx) {
-                var temp_date = traffic.dates[idx];
+            for (var idx = 0; idx < traffic.dates.length; idx++) {
+                var temp_date = moment(traffic.dates[idx]);
                 result = iap.diffZeros(temp_date, last_date, result);
-                result += traffic.counts[idx];
+                result.push(traffic.counts[idx]);
                 last_date = temp_date;
-            });
 
-            result = iap.diffZeros(now, last_date, result);
-            console.log(result);
+                if (idx+1 === traffic.dates.length) {
+                    result = iap.diffZeros(now, last_date, result);
+                    result.push(0);
+                    console.log(result);
 
-            return result;
+                    return result;
+                }
+            }
+
         },
 
         diffZeros: function(last, previous, result) {
+            console.log("LAST: " + last.format());
+            console.log("PREVIOUS: " + previous.format());
+            console.log(result);
             var diff = last.diff(previous, "days");
+            console.log("DIFF: " + diff);
 
             if (diff > 1) {
-                var zeros = new Array(diff - 1).join('0').split('').map(parseInt);
-                result += zeros;
+                var zeros = [];
+                
+                for (var i = 0; i < (diff - 1); i++) {
+                    zeros.push(0);
+                }
+
+                console.log(zeros);
+                result = result.concat(zeros);
+                console.log("result after zeros: " + result);
             } 
+
+            console.log(result);
 
             return result;
         },

--- a/src/templates/traffic.handlebars
+++ b/src/templates/traffic.handlebars
@@ -4,6 +4,7 @@
             <span>Traffic <span id="traffic_dates">from Last <span id="traffic_count">30</span> Days</span><span id="queries_total"></span></span>
         </h3>
         <p id="no_traffic" class="hide"> Not enough data. </p>
+        <p id="update_frequency">Updated weekly </p>
         <canvas class="charts" id="ia_traffic"></canvas>
     </div>
 {{/or}}


### PR DESCRIPTION
Since we're filling with zeroes the days for which we don't have any traffic data, it's important to make sure that the last day shown is the last time the data was updated.
![screenshot-maria duckduckgo com 5001 2016-02-09 15-23-16](https://cloud.githubusercontent.com/assets/3652195/12918779/1daf3416-cf41-11e5-81c7-81bf25dd44dd.png)
