### PR TITLE
views/includes/head.tx: Don't set initial scale to 1.

### DIFF
--- a/views/includes/head.tx
+++ b/views/includes/head.tx
@@ -12,8 +12,6 @@
     <link href="/blog/rss" type="application/atom+xml" rel="alternate index" title="DuckDuckGo Blog" />
 : }
 
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-
 <!--[if lt IE 9]>
 <script src="/static/js/html5shiv.js"></script>
 <![endif]-->


### PR DESCRIPTION
Since the header is not made to be responsive at the moment, unsetting the initial-scale would show the "zoomed out" view which prevents breakage.