### PR TITLE
Work around race condition in IA last updated tracker

### DIFF
--- a/lib/DDGC/DB/ResultSet/InstantAnswer/LastUpdated.pm
+++ b/lib/DDGC/DB/ResultSet/InstantAnswer/LastUpdated.pm
@@ -9,7 +9,7 @@ sub touch {
     my ( $self ) = @_;
     my $row = $self->search->one_row;
     my $token = $self->ddgc->uid;
-    return $row->update({ token => $token }) if $row;
+    return eval { $row->update({ token => $token }) } if $row;
     $self->create({ token => $token });
 }
 


### PR DESCRIPTION
If lots of updates are occurring at once, the potential for the token in instant_answer_last_updated to be updated between your process selecting and updating it exists. This will cause an exception and your process will bail.

If the table has been updated in this time, we don't really need to update it since we don't need (or have) sub-second resolution in this time stamp.

This change wraps the row update in an eval - we don't care about the result of this operation in the case where this fatal race condition occurs.