### PR TITLE
Remove fatheads/longtails from blockgroup data

### DIFF
--- a/sql/1.126/rm-fat-long-block.sql
+++ b/sql/1.126/rm-fat-long-block.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+update instant_answer set blockgroup = null where repo in ('fathead', 'longtail'); 
+delete from instant_answer_blockgroup where blockgroup in ('fathead', 'longtail');
+
+COMMIT;


### PR DESCRIPTION
Fatheads and Longtails don't need to be loaded into blocks:

1. Set all fathead/longtail blockgroups to null in instant_answer
2. Remove the option to select those blockgroups

@jdorweiler 