### PR TITLE
IA Pages - fixes for the live editable page

### DIFF
--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1035,7 +1035,9 @@
                                 is_json = true;
                             }
 
-                            if (value !== edited_value && value !== live_value) {
+                            var both_empty = checkEmpty(edited_value, value);
+                            
+                            if (value !== edited_value && value !== live_value && (!both_empty)) {
                                 save(field, value, DDH_iaid, $obj, is_json);
                             } else {
                                 $obj.replaceWith(pre_templates[field]);
@@ -1046,6 +1048,15 @@
                             }
                         }
                     });
+
+                    //Check if both the edited value and the live value are empty
+                    function checkEmpty(value, live_data) {
+                        var value_empty = (!value || value === "" || value === "[]" || value === "{}")? true : false;
+                        var live_empty = (!live_data || live_data === "" || live_data === "[]" || live_data === "{}")? true : false;
+                        var both_empty = (value_empty && live_empty)? true : false;
+
+                        return both_empty;
+                    }
 
                     // Check if username exists for the given account type (either github or duck.co)
                     function usercheck(type, username, $type, $username) {
@@ -1129,7 +1140,10 @@
                         console.log("After getUnsaved... " + field + " " + value);
                         console.log("Live data: " + live_data);
                         console.log("Live data without JSON " + ia_data.live[field]);
-                        if (field && (live_data != value)) {
+
+                        var both_empty = checkEmpty(value, live_data);
+
+                        if (field && (live_data != value) && (!both_empty)) {
                             if (parent_field) {
                                 autocommit(parent_field, value, DDH_iaid, is_json, field);
                             } else {

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1021,7 +1021,7 @@
                                 && (field === "topic" || field === "other_queries" || field === "triggers" || field === "perl_dependencies" || field === "src_options"))
                                 || (field === "answerbar") || (field === "developer")) {
                                 if (field !== "answerbar" && field !== "src_options") {
-                                    value = getGroupVals(field);
+                                    value = (field === "other_queries")? getGroupVals(field, $("#column-edits-other_queries .other_queries input")) : getGroupVals(field);
                                 } else if (field === "src_options") {
                                     value = {};
                                     value = getSectionVals(null, "src_options-group");
@@ -1049,13 +1049,12 @@
                                 }
 
                                 equal_vals = (eqArrays(temp_val, live_value) || eqArrays(temp_val, edited_value))? true : false;
+                                
                                 value = JSON.stringify(value);
                                 temp_val = JSON.stringify(temp_val);
                                 edited_value = JSON.stringify(ia_data.edited[field]);
                                 live_value = JSON.stringify(ia_data.live[field]);
-                                console.log("new val: " + temp_val);
-                                console.log("edited val: " + edited_value);
-                                console.log("live val: " + live_value);
+                                
                                 equal_vals = equal_vals? equal_vals : ((temp_val === live_value) || (temp_val === edited_value));
                                 is_json = true;
                             } else {
@@ -1268,32 +1267,34 @@
                             } else if ((ia_data.live.dev_milestone !== "live" && ia_data.live.dev_milestone !== "deprecated") && (field === "developer")) {
                                 $selector = $(".developer_username input[type='text']");
                             } else {
-                                $selector = $("." + field).children("input");
+                                $selector = $("." + field).find("input");
                             }
                         }
 
                         $selector.each(function(index) {
-                            if (field === "developer") {
-                                var $li_item = (ia_data.live.dev_milestone !== "live" && ia_data.live.dev_milestone !== "deprecated")? $(this).parent().parent().parent() : $(this).parent().parent();
+                            if ($(this).css("display") !== "none") {
+                                if (field === "developer") {
+                                    var $li_item = (ia_data.live.dev_milestone !== "live" && ia_data.live.dev_milestone !== "deprecated")? $(this).parent().parent().parent() : $(this).parent().parent();
 
-                                temp_val = {};
-                                temp_val.name = $.trim($(this).val()).replace(/"/g, "");
-                                temp_val.type = $.trim($li_item.find(".available_types").find("option:selected").text()) || "legacy";
-                                temp_val.username = $.trim($li_item.find(".developer_username input[type='text']").val().replace(/"/g, ""));
-                                
-                                if (!temp_val.username) {
-                                    return;
-                                }
-                            } else {
-                                if (field === "topic") {
-                                    temp_val = $(this).attr("value").length? $.trim($(this).text()) : "";
+                                    temp_val = {};
+                                    temp_val.name = $.trim($(this).val()).replace(/"/g, "");
+                                    temp_val.type = $.trim($li_item.find(".available_types").find("option:selected").text()) || "legacy";
+                                    temp_val.username = $.trim($li_item.find(".developer_username input[type='text']").val().replace(/"/g, ""));
+                                    
+                                    if (!temp_val.username) {
+                                        return;
+                                    }
                                 } else {
-                                    temp_val = $.trim($(this).val().replace(/"/g, ""));
+                                    if (field === "topic") {
+                                        temp_val = $(this).attr("value").length? $.trim($(this).text()) : "";
+                                    } else {
+                                        temp_val = $.trim($(this).val().replace(/"/g, ""));
+                                    }
                                 }
-                            }
 
-                            if (temp_val && $.inArray(temp_val, value) === -1) {
-                                value.push(temp_val);
+                                if (temp_val && $.inArray(temp_val, value) === -1) {
+                                    value.push(temp_val);
+                                }
                             }
                         });
 

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -996,6 +996,7 @@
                             var edited_value = ia_data.edited[field];
                             var live_value = ia_data.live[field];
                             var $obj = $("#row-diff-" + field);
+                            var equal_vals;
 
                             if ($(this).hasClass("js-input")) {
                                 value = $.trim($(this).val().replace(/"/g, ""));
@@ -1029,16 +1030,19 @@
                                     value.fallback_timeout = $("#answerbar input").val();
                                 }
 
+                                equal_vals = (eqArrays(value, live_value) || eqArrays(value, edited_value))? true : false;
                                 value = JSON.stringify(value);
                                 edited_value = JSON.stringify(ia_data.edited[field]);
                                 live_value = JSON.stringify(ia_data.live[field]);
                                 is_json = true;
+                            } else {
+                                equal_vals = ((value === live_value) || (value === edited_value))? true : false;
                             }
 
                             var both_empty = checkEmpty(value, live_value);
                             both_empty = (!both_empty)? checkEmpty(value, edited_value) : both_empty;
                             
-                            if (value !== edited_value && value !== live_value && (!both_empty)) {
+                            if ((!equal_vals) && (!both_empty)) {
                                 save(field, value, DDH_iaid, $obj, is_json);
                             } else {
                                 $obj.replaceWith(pre_templates[field]);
@@ -1049,6 +1053,11 @@
                             }
                         }
                     });
+
+                    // Check if two arrays are equal
+                    function eqArrays(arr1, arr2) {
+                        return (($(arr1).not(arr2).length === 0) && ($(arr2).not(arr1).length === 0));
+                    }
 
                     //Check if both the edited value and the live value are empty
                     function checkEmpty(value, live_data) {

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1035,7 +1035,8 @@
                                 is_json = true;
                             }
 
-                            var both_empty = checkEmpty(edited_value, value);
+                            var both_empty = checkEmpty(value, live_value);
+                            both_empty = (!both_empty)? checkEmpty(value, edited_value) : both_empty;
                             
                             if (value !== edited_value && value !== live_value && (!both_empty)) {
                                 save(field, value, DDH_iaid, $obj, is_json);

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1030,10 +1030,33 @@
                                     value.fallback_timeout = $("#answerbar input").val();
                                 }
 
-                                equal_vals = (eqArrays(value, live_value) || eqArrays(value, edited_value))? true : false;
+
+                                var temp_val = value;
+                                if (field === "developer") {
+                                    temp_val = [];
+                                    var gh_url = "https://github.com/";
+                                    var duckco_url = "/user/";
+                                    $.each(value, function(idx) {
+                                        var idx_val = value[idx];
+                                        var temp_hash = {
+                                            url: (idx_val.type === "github")? gh_url + idx_val.username : duckco_url + idx_val.username,
+                                            name: idx_val.name,
+                                            type: idx_val.type
+                                        };
+
+                                        temp_val.push(temp_hash);
+                                    });
+                                }
+
+                                equal_vals = (eqArrays(temp_val, live_value) || eqArrays(temp_val, edited_value))? true : false;
                                 value = JSON.stringify(value);
+                                temp_val = JSON.stringify(temp_val);
                                 edited_value = JSON.stringify(ia_data.edited[field]);
                                 live_value = JSON.stringify(ia_data.live[field]);
+                                console.log("new val: " + temp_val);
+                                console.log("edited val: " + edited_value);
+                                console.log("live val: " + live_value);
+                                equal_vals = equal_vals? equal_vals : ((temp_val === live_value) || (temp_val === edited_value));
                                 is_json = true;
                             } else {
                                 equal_vals = ((value === live_value) || (value === edited_value))? true : false;


### PR DESCRIPTION
- Don't save the edit if both the edit and the live value OR both the edit and the staged edit (when available) are empty;
- Better live/staged values comparison for the developer field;
- Fix saving other_queries (using a strict selector)