### PR TITLE
IAPage.js - check dev milestone before attempting to show traffic data

### DIFF
--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1785,7 +1785,7 @@
                     }
                 }
 
-                if (ia_data.live.hasOwnProperty("traffic") && ia_data.live.traffic.dates.length) {
+                if ((ia_data.live.dev_milestone === "live") && ia_data.live.hasOwnProperty("traffic") && ia_data.live.traffic.dates.length) {
                     var traffic = $("#ia_traffic").get(0).getContext("2d");
                     //var weekend_labels = this.getWeekends(ia_data.live.traffic.dates);
                     var traffic_header =  ": " + this.sumCounts(ia_data.live.traffic.counts) + " queries total";


### PR DESCRIPTION
Deprecated IAs can have traffic data, so we need to check dev milestone as well.