### PR TITLE
InstantAnswer.pm - don't include ghosted IAs in the overview JSON

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -554,7 +554,8 @@ sub overview_json :Chained('overview_base') :PathPart('json') :Args(0) {
             }
          } else {
             my $pr = $issue;
-            if ($pr->status && ($pr->status eq 'open' || $pr->status eq 'merged') && $resp && (($issue_ia->dev_milestone ne 'live') && ($issue_ia->dev_milestone ne 'deprecated'))) {
+            if ($pr->status && ($pr->status eq 'open' || $pr->status eq 'merged') && $resp && 
+                (($issue_ia->dev_milestone ne 'live') && ($issue_ia->dev_milestone ne 'deprecated') && ($issue_ia->dev_milestone ne 'ghosted'))) {
                 my $pr_id = $pr->issue_id;
                 my $repo = $issue_ia->repo;
                 my $beta_pr = $resp->{$repo}->{$pr_id};


### PR DESCRIPTION
Seems like ghosted IAs can be on beta as well, so we need to check in order to avoid including them in the Overview page.