### PR TITLE
Redirect all requests for /wear to ddg about page

### DIFF
--- a/lib/DDGC/Web/Controller/Root.pm
+++ b/lib/DDGC/Web/Controller/Root.pm
@@ -167,6 +167,7 @@ sub end : ActionClass('RenderView') {
 
 sub wear :Chained('base') :PathPart('wear') :Args(0) {
 	my ( $self, $c ) = @_;
+	goto REDIRECT;
 
 	$c->session->{wear_referer} = lc( $c->req->headers->referer ) if !$c->session->{wear_referer};
 


### PR DESCRIPTION
Short circuiting all requests to the REDIRECT maker. Using this approach so we can quickly back out the change, should we choose to. Could also do this in nginx, but this is probably easier to back out.