### PR TITLE
github.handlebars - mention maintainer in new issues

### DIFF
--- a/src/templates/github.handlebars
+++ b/src/templates/github.handlebars
@@ -8,7 +8,7 @@
       {{/if}}
   </h3>
   <a id="create-issue--link" class="btn btn--primary right" 
-  href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/new?&title={{name}}%3A%20&body={{#if maintainer}}{{#if maintainer.github}}@{{maintainer.github}}{{/if}}{{/if}} %0A%0A------%0AIA%20Page%3A%20%20http%3A%2F%2Fduck.co%2Fia%2Fview%2F{{id}}">Create Issue</a>
+  href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/new?&title={{name}}%3A%20&body= %0A%0A------%0AIA%20Page%3A%20%20http%3A%2F%2Fduck.co%2Fia%2Fview%2F{{id}} %0AMaintainer%3A {{#if maintainer}}{{#if maintainer.github}}@{{maintainer.github}}{{/if}}{{/if}}">Create Issue</a>
   {{#if issues.length}}
     <ul class="clear">
       {{#each issues}}

--- a/src/templates/github.handlebars
+++ b/src/templates/github.handlebars
@@ -8,7 +8,7 @@
       {{/if}}
   </h3>
   <a id="create-issue--link" class="btn btn--primary right" 
-  href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/new?&title={{name}}%3A%20&body= %0A%0A------%0AIA%20Page%3A%20%20http%3A%2F%2Fduck.co%2Fia%2Fview%2F{{id}} %0AMaintainer%3A {{#if maintainer}}{{#if maintainer.github}}@{{maintainer.github}}{{/if}}{{/if}}">Create Issue</a>
+  href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/new?&title={{name}}%3A%20&body= %0A%0A------%0AIA%20Page%3A%20%20http%3A%2F%2Fduck.co%2Fia%2Fview%2F{{id}} {{#if maintainer}}{{#if maintainer.github}}%0AMaintainer%3A @{{maintainer.github}}{{/if}}{{/if}}">Create Issue</a>
   {{#if issues.length}}
     <ul class="clear">
       {{#each issues}}

--- a/src/templates/github.handlebars
+++ b/src/templates/github.handlebars
@@ -8,7 +8,7 @@
       {{/if}}
   </h3>
   <a id="create-issue--link" class="btn btn--primary right" 
-  href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/new?&title={{name}}%3A%20&body={{#if maintainer}}{{#if maintainer.github}}@{{maintainer.github}}{{/if}}{{/if}} {{#each developer}}{{#eq type 'github'}}@{{final_path url}} {{/eq}}{{/each}}%0A%0A------%0AIA%20Page%3A%20%20http%3A%2F%2Fduck.co%2Fia%2Fview%2F{{id}}">Create Issue</a>
+  href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/new?&title={{name}}%3A%20&body={{#if maintainer}}{{#if maintainer.github}}@{{maintainer.github}}{{/if}}{{/if}} %0A%0A------%0AIA%20Page%3A%20%20http%3A%2F%2Fduck.co%2Fia%2Fview%2F{{id}}">Create Issue</a>
   {{#if issues.length}}
     <ul class="clear">
       {{#each issues}}

--- a/src/templates/github.handlebars
+++ b/src/templates/github.handlebars
@@ -8,7 +8,7 @@
       {{/if}}
   </h3>
   <a id="create-issue--link" class="btn btn--primary right" 
-  href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/new?&title={{name}}%3A%20&body={{#each developer}}{{#eq type 'github'}}@{{final_path url}} {{/eq}}{{/each}}%0A%0A------%0AIA%20Page%3A%20%20http%3A%2F%2Fduck.co%2Fia%2Fview%2F{{id}}">Create Issue</a>
+  href="https://github.com/duckduckgo/zeroclickinfo-{{repo}}/issues/new?&title={{name}}%3A%20&body={{#if maintainer}}{{#if maintainer.github}}@{{maintainer.github}}{{/if}}{{/if}} {{#each developer}}{{#eq type 'github'}}@{{final_path url}} {{/eq}}{{/each}}%0A%0A------%0AIA%20Page%3A%20%20http%3A%2F%2Fduck.co%2Fia%2Fview%2F{{id}}">Create Issue</a>
   {{#if issues.length}}
     <ul class="clear">
       {{#each issues}}


### PR DESCRIPTION
If the maintainer is a github user or a duckco user with a github account linked, he will be mentioned on any GitHub issue created using the button inside the IA Page.
![screenshot-maria duckduckgo com 5001 2016-02-26 21-02-24](https://cloud.githubusercontent.com/assets/3652195/13364080/2a0870d0-dccd-11e5-97a6-39c7cf8383f9.png)
![screenshot-github com 2016-02-26 21-02-02](https://cloud.githubusercontent.com/assets/3652195/13364087/32fbd808-dccd-11e5-8905-4c33ab17df22.png)
