### PR TITLE
Contributor Database for Engagement Testing

### DIFF
--- a/lib/DDGC/DB/Result/GitHub/Event.pm
+++ b/lib/DDGC/DB/Result/GitHub/Event.pm
@@ -9,19 +9,14 @@ use namespace::autoclean;
 table 'github_event';
 
 primary_column id        => {data_type => 'bigint', is_auto_increment => 1};
-column github_event_id   => {data_type => 'bigint', is_nullable => 0};
+unique_column github_id  => {data_type => 'bigint', is_nullable => 0};
 column github_user_id    => {data_type => 'bigint', is_nullable => 0};
 column github_repo_id    => {data_type => 'bigint', is_nullable => 0};
 column github_event_type => {data_type => 'text', is_nullable => 0};
-column created_at        => {data_type => 'timestamp with time zone', is_nullable => 0};
+column github_event_date => {data_type => 'timestamp with time zone', is_nullable => 0};
 
-belongs_to github_repo => 'DDGC::DB::Result::GitHub::Repo',
-    { 'foreign.id' => 'self.github_repo_id' },
-    { on_delete    => 'cascade' };
-
-belongs_to github_user => 'DDGC::DB::Result::GitHub::User',
-    { 'foreign.id' => 'self.github_user_id' },
-    { on_delete    => 'cascade' };
+has_one 'repo', 'DDGC::DB::Result::GitHub::Repo', 'github_repo_id';
+has_one 'user', 'DDGC::DB::Result::GitHub::User', 'github_user_id';
 
 no Moose;
 __PACKAGE__->meta->make_immutable( inline_constructor => 0 );

--- a/lib/DDGC/DB/Result/GitHub/Event.pm
+++ b/lib/DDGC/DB/Result/GitHub/Event.pm
@@ -1,0 +1,26 @@
+package DDGC::DB::Result::GitHub::Event;
+# ABSTRACT:
+
+use Moose;
+extends 'DDGC::DB::Base::Result';
+use DBIx::Class::Candy;
+use namespace::autoclean;
+
+table 'github_event';
+
+primary_column id        => {data_type => 'bigint', is_auto_increment => 1};
+column github_user_id    => {data_type => 'bigint', is_nullable => 0};
+column github_repo_id    => {data_type => 'bigint', is_nullable => 0};
+column github_event_type => {data_type => 'text', is_nullable => 0};
+column created_at        => {data_type => 'timestamp with time zone', is_nullable => 0};
+
+belongs_to github_repo => 'DDGC::DB::Result::GitHub::Repo',
+    { 'foreign.id' => 'self.github_repo_id' },
+    { on_delete    => 'cascade' };
+
+belongs_to github_user => 'DDGC::DB::Result::GitHub::User',
+    { 'foreign.id' => 'self.github_user_id' },
+    { on_delete    => 'cascade' };
+
+no Moose;
+__PACKAGE__->meta->make_immutable( inline_constructor => 0 );

--- a/lib/DDGC/DB/Result/GitHub/Event.pm
+++ b/lib/DDGC/DB/Result/GitHub/Event.pm
@@ -9,7 +9,7 @@ use namespace::autoclean;
 table 'github_event';
 
 primary_column id        => {data_type => 'bigint', is_auto_increment => 1};
-column github_id         => {data_type => 'bigint', is_nullable => 0};
+column github_event_id   => {data_type => 'bigint', is_nullable => 0};
 column github_user_id    => {data_type => 'bigint', is_nullable => 0};
 column github_repo_id    => {data_type => 'bigint', is_nullable => 0};
 column github_event_type => {data_type => 'text', is_nullable => 0};

--- a/lib/DDGC/DB/Result/GitHub/Event.pm
+++ b/lib/DDGC/DB/Result/GitHub/Event.pm
@@ -9,6 +9,7 @@ use namespace::autoclean;
 table 'github_event';
 
 primary_column id        => {data_type => 'bigint', is_auto_increment => 1};
+column github_id         => {data_type => 'bigint', is_nullable => 0};
 column github_user_id    => {data_type => 'bigint', is_nullable => 0};
 column github_repo_id    => {data_type => 'bigint', is_nullable => 0};
 column github_event_type => {data_type => 'text', is_nullable => 0};

--- a/lib/DDGC/DB/Result/GitHub/Event.pm
+++ b/lib/DDGC/DB/Result/GitHub/Event.pm
@@ -9,7 +9,7 @@ use namespace::autoclean;
 table 'github_event';
 
 primary_column id        => {data_type => 'bigint', is_auto_increment => 1};
-unique_column github_id  => {data_type => 'bigint', is_nullable => 0};
+unique_column github_id  => {data_type => 'text', is_nullable => 0};
 column github_user_id    => {data_type => 'bigint', is_nullable => 0};
 column github_repo_id    => {data_type => 'bigint', is_nullable => 0};
 column github_event_type => {data_type => 'text', is_nullable => 0};

--- a/lib/DDGC/DB/Result/GitHub/Repo.pm
+++ b/lib/DDGC/DB/Result/GitHub/Repo.pm
@@ -60,6 +60,10 @@ has_many github_forks => 'DDGC::DB::Result::GitHub::Fork',
     { 'foreign.github_repo_id' => 'self.id' },
     { cascade_delete => 1 };
 
+has_many github_events => 'DDGC::DB::Result::Github::Event',
+    { 'foreign.github_repo_id'=> 'self.id' },
+    { cascade_delete => 1 };
+
 sub owner_name { my @p = split('/',$_[0]->full_name); return $p[0]; }
 sub repo_name  { my @p = split('/',$_[0]->full_name); return $p[1]; }
 

--- a/lib/DDGC/DB/Result/GitHub/Repo.pm
+++ b/lib/DDGC/DB/Result/GitHub/Repo.pm
@@ -60,7 +60,7 @@ has_many github_forks => 'DDGC::DB::Result::GitHub::Fork',
     { 'foreign.github_repo_id' => 'self.id' },
     { cascade_delete => 1 };
 
-has_many github_events => 'DDGC::DB::Result::Github::Event',
+has_many github_events => 'DDGC::DB::Result::GitHub::Event',
     { 'foreign.github_repo_id'=> 'self.id' },
     { cascade_delete => 1 };
 

--- a/lib/DDGC/DB/Result/GitHub/User.pm
+++ b/lib/DDGC/DB/Result/GitHub/User.pm
@@ -63,5 +63,9 @@ has_many github_issue_events => 'DDGC::DB::Result::GitHub::Issue::Event',
     { 'foreign.github_user_id' => 'self.id' },
     { cascade_delete => 1 };
 
+has_many github_events => 'DDGC::DB::Result::Github::Event',
+    { 'foreign.github_user_id' => 'self.id' },
+    { cascade_delete => 1 };
+
 no Moose;
 __PACKAGE__->meta->make_immutable( inline_constructor => 0 );

--- a/lib/DDGC/DB/Result/GitHub/User.pm
+++ b/lib/DDGC/DB/Result/GitHub/User.pm
@@ -63,7 +63,7 @@ has_many github_issue_events => 'DDGC::DB::Result::GitHub::Issue::Event',
     { 'foreign.github_user_id' => 'self.id' },
     { cascade_delete => 1 };
 
-has_many github_events => 'DDGC::DB::Result::Github::Event',
+has_many github_events => 'DDGC::DB::Result::GitHub::Event',
     { 'foreign.github_user_id' => 'self.id' },
     { cascade_delete => 1 };
 

--- a/lib/DDGC/DB/ResultSet/GitHub/Event.pm
+++ b/lib/DDGC/DB/ResultSet/GitHub/Event.pm
@@ -7,7 +7,7 @@ use namespace::autoclean;
 
 sub with_created_at {
     my ($self, $operator, $date) = @_;
-	$self->search({ 'me.created_at' => { $operator => $date } });
+	$self->search({ 'me.github_event_date' => { $operator => $date } });
 }
 
 sub with_github_user_id {

--- a/lib/DDGC/DB/ResultSet/GitHub/Event.pm
+++ b/lib/DDGC/DB/ResultSet/GitHub/Event.pm
@@ -1,0 +1,40 @@
+package DDGC::DB::ResultSet::GitHub::Event;
+# ABSTRACT: Resultset class for GitHub Events
+
+use Moose;
+extends 'DDGC::DB::Base::ResultSet';
+use namespace::autoclean;
+
+sub with_created_at {
+    my ($self, $operator, $date) = @_;
+	$self->search({ 'me.created_at' => { $operator => $date } });
+}
+
+sub with_github_user_id {
+    my ($self, $operator, $github_user_id) = @_;
+	$self->search({ 'me.github_user_id' => { $operator => $github_user_id } });
+}
+
+# ignore users who are members of the owners team on github.  these users are
+# usually ddg employees:
+# https://github.com/orgs/duckduckgo/teams/owners
+sub ignore_staff_events {
+    my ($self) = @_;
+    $self->search(
+        { 'github_user.isa_owners_team_member' => 0 },
+        { prefetch => 'github_user' }
+    );
+}
+
+sub most_recent {
+    my ($self) = @_;
+    return $self->search(
+        {},
+        {
+            order_by => { -desc => 'updated_at' },
+        }
+    )->one_row;
+}
+
+no Moose;
+__PACKAGE__->meta->make_immutable( inline_constructor => 0 );

--- a/lib/DDGC/GitHub.pm
+++ b/lib/DDGC/GitHub.pm
@@ -563,7 +563,7 @@ sub update_github_event_from_data {
     $columns{github_event_date} = $data->{created_at};
     
     return $gh_repo
-           ->related_resultset('github_events')
+           ->related_resultset('github_event')
            ->update_or_create(\%columns, { key => 'github_event_id' });
 }
 

--- a/lib/DDGC/GitHub.pm
+++ b/lib/DDGC/GitHub.pm
@@ -207,7 +207,6 @@ sub wanted_repos {
         duckduckgo/zeroclickinfo-longtail
         duckduckgo/p5-app-duckpan
         duckduckgo/duckduckhack-docs
-        duckduckgo/duckduckgo
     |;
 }
 
@@ -527,10 +526,11 @@ sub update_repo_forks {
     push @gh_forks, $self->update_repo_fork_from_data($gh_repo, $_)
         for @$forks_data;
     
+    print "   events...\n"; 
     my @gh_events;
     push @gh_events, $self->update_github_event_from_data($gh_repo, $_, 'github_fork') 
        for @$forks_data;
-
+    
     return \@gh_forks;
 }
 
@@ -556,15 +556,15 @@ sub update_github_event_from_data {
     my ($self, $gh_repo, $data, $eventtype) = @_;
 
     my %columns;
-    $columns{github_id}         = $data{id};
+    $columns{github_id}         = $data->{id};
     $columns{github_user_id}    = $self->find_or_update_user($data->{owner}->{login})->id;
-    $columns{github_repo_id}    = $gh_repo{id};
+    $columns{github_repo_id}    = $gh_repo->{id};
     $columns{github_event_type} = $eventtype;
-    $columns{github_event_date} = $data{created_at};
+    $columns{github_event_date} = $data->{created_at};
     
     return $gh_repo
            ->related_resultset('github_events')
-           ->update_or_create(\%columns, { key => 'github_event__id' });
+           ->update_or_create(\%columns, { key => 'github_event_id' });
 }
 
 

--- a/lib/DDGC/GitHub.pm
+++ b/lib/DDGC/GitHub.pm
@@ -536,7 +536,7 @@ sub update_repo_forks {
 
 sub update_repo_fork_from_data {
     my ($self, $gh_repo, $fork) = @_;
-
+    
     my %columns;
     $columns{github_id}      = $fork->{id};
     $columns{github_user_id} = $self->find_or_update_user($fork->{owner}->{login})->id;
@@ -554,17 +554,18 @@ sub update_repo_fork_from_data {
 # populate the github_event table separately while filling in the others
 sub update_github_event_from_data {
     my ($self, $gh_repo, $data, $eventtype) = @_;
-
-    my %columns;
-    $columns{github_event_id}   = $data->{id};
-    $columns{github_user_id}    = $self->find_or_update_user($data->{owner}->{login})->id;
-    $columns{github_repo_id}    = $gh_repo->{id};
-    $columns{github_event_type} = $eventtype;
-    $columns{github_event_date} = $data->{created_at};
     
+    my %columns;
+    $columns{github_id}         = $data->{id};
+    $columns{github_user_id}    = $self->find_or_update_user($data->{owner}->{login})->id;
+    $columns{github_repo_id}    = $gh_repo->id;
+    $columns{github_event_type} = $eventtype;
+    $columns{github_event_date} = parse_datetime($data->{created_at});
+
+      
     return $gh_repo
-           ->related_resultset('github_event')
-           ->update_or_create(\%columns, { key => 'github_event_id' });
+           ->related_resultset('github_events')
+           ->update_or_create(\%columns, { key => 'github_event_github_id' });
 }
 
 

--- a/lib/DDGC/GitHub.pm
+++ b/lib/DDGC/GitHub.pm
@@ -205,6 +205,9 @@ sub wanted_repos {
         duckduckgo/zeroclickinfo-fathead
         duckduckgo/zeroclickinfo-goodies
         duckduckgo/zeroclickinfo-longtail
+        duckduckgo/p5-app-duckpan
+        duckduckgo/duckduckhack-docs
+        duckduckgo/duckduckgo
     |;
 }
 
@@ -237,7 +240,7 @@ sub update_repo_from_data {
     my $gh_repo = $gh_user
         ->related_resultset('github_repos')
         ->update_or_create(\%columns, { key => 'github_repo_github_id' });
-
+    
     printf "Updating %s/%s\n", $gh_repo->owner_name, $gh_repo->repo_name;
     print "   commits...\n";
     $self->update_repo_commits($gh_repo);

--- a/lib/DDGC/GitHub.pm
+++ b/lib/DDGC/GitHub.pm
@@ -556,7 +556,7 @@ sub update_github_event_from_data {
     my ($self, $gh_repo, $data, $eventtype) = @_;
 
     my %columns;
-    $columns{github_id}         = $data->{id};
+    $columns{github_event_id}   = $data->{id};
     $columns{github_user_id}    = $self->find_or_update_user($data->{owner}->{login})->id;
     $columns{github_repo_id}    = $gh_repo->{id};
     $columns{github_event_type} = $eventtype;

--- a/sql/1.107/github_event_table.sql
+++ b/sql/1.107/github_event_table.sql
@@ -2,8 +2,8 @@ BEGIN;
 
 CREATE TABLE github_event (
     id serial NOT NULL PRIMARY KEY,
-    github_id bigint NOT NULL,
-    github_user_id bigint NOT NULL REFERENCES github_user(github_id) ON DELETE CASCADE,
+    github_event_id bigint NOT NULL,
+    github_user_id bigint NOT NULL REFERENCES github_user(id) ON DELETE CASCADE,
     github_repo_id bigint REFERENCES github_repo(id) ON DELETE CASCADE,
     github_event_type text NOT NULL,
     github_event_date timestamp with time zone  NOT NULL 

--- a/sql/1.107/github_event_table.sql
+++ b/sql/1.107/github_event_table.sql
@@ -2,9 +2,10 @@ BEGIN;
 
 CREATE TABLE github_event (
     id serial NOT NULL PRIMARY KEY,
+    github_id bigint NOT NULL,
     github_user_id bigint NOT NULL REFERENCES github_user(github_id) ON DELETE CASCADE,
     github_repo_id bigint REFERENCES github_repo(id) ON DELETE CASCADE,
-    github_event_type text  NOT NULL,
+    github_event_type text NOT NULL,
     github_event_date timestamp with time zone  NOT NULL 
 );
 

--- a/sql/1.107/github_event_table.sql
+++ b/sql/1.107/github_event_table.sql
@@ -2,7 +2,7 @@ BEGIN;
 
 CREATE TABLE github_event (
     id serial NOT NULL PRIMARY KEY,
-    github_id bigint NOT NULL UNIQUE,
+    github_id text NOT NULL UNIQUE,
     github_user_id integer NOT NULL REFERENCES github_user(id) ON DELETE CASCADE,
     github_repo_id integer  NOT NULL REFERENCES github_repo(id) ON DELETE CASCADE,
     github_event_type text NOT NULL,

--- a/sql/1.107/github_event_table.sql
+++ b/sql/1.107/github_event_table.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+CREATE TABLE github_event (
+    id serial NOT NULL PRIMARY KEY,
+    github_user_id bigint NOT NULL REFERENCES github_user(github_id) ON DELETE CASCADE,
+    github_repo_id bigint REFERENCES github_repo(id) ON DELETE CASCADE,
+    github_event_type string NOT NULL,
+    github_event_date timestamp with time zone  NOT NULL 
+);
+
+COMMIT;

--- a/sql/1.107/github_event_table.sql
+++ b/sql/1.107/github_event_table.sql
@@ -4,7 +4,7 @@ CREATE TABLE github_event (
     id serial NOT NULL PRIMARY KEY,
     github_user_id bigint NOT NULL REFERENCES github_user(github_id) ON DELETE CASCADE,
     github_repo_id bigint REFERENCES github_repo(id) ON DELETE CASCADE,
-    github_event_type string NOT NULL,
+    github_event_type text  NOT NULL,
     github_event_date timestamp with time zone  NOT NULL 
 );
 

--- a/sql/1.107/github_event_table.sql
+++ b/sql/1.107/github_event_table.sql
@@ -2,9 +2,9 @@ BEGIN;
 
 CREATE TABLE github_event (
     id serial NOT NULL PRIMARY KEY,
-    github_event_id bigint NOT NULL,
-    github_user_id bigint NOT NULL REFERENCES github_user(id) ON DELETE CASCADE,
-    github_repo_id bigint REFERENCES github_repo(id) ON DELETE CASCADE,
+    github_id bigint NOT NULL UNIQUE,
+    github_user_id integer NOT NULL REFERENCES github_user(id) ON DELETE CASCADE,
+    github_repo_id integer  NOT NULL REFERENCES github_repo(id) ON DELETE CASCADE,
     github_event_type text NOT NULL,
     github_event_date timestamp with time zone  NOT NULL 
 );


### PR DESCRIPTION
### Overview: 
This PR is a first pass at consolidating engagement-test-relevant (sorry for that elaborate compound word :v:) data from GitHub commits, pull requests, issues, and comments into the `github_event` table.

### Notes:
- I've added the `update_github_event_from_data` subroutine to the `GitHub.pm` module in DDGC. It selectively inserts data from it's parent sub into the `github_event` table.
- GitHub commits have SHAs as unique identifiers, which are alpha-numeric strings; other GitHub events have unique integer ids. Because the event's user and date are the most important for our tests now, I've chosen to consolidate the unique identifies as `text` values for the `github_id` key, accommodating both SHAs and numeric ids.

### Issues, Considerations, and Next Steps:
- This implementation does not account for events prior to the last repo events already in the database. 
- I'm recording one date for each event now – the creation date. Should non-creation dates be recorded ( PR merges, issue assignments, and issue closures) as individual events?
- Please excuse my perl etc. :grin: 

cc: @russellholt @zachthompson @kablamo @zekiel 