### PR TITLE
Migrations: The  DB can't be created unless the local user has peer/trust auth with Postgres

### DIFF
--- a/script/ddgc_deploy_dev.pl
+++ b/script/ddgc_deploy_dev.pl
@@ -36,13 +36,13 @@ if ($kill) {
 			my $userarg = length($config->db_user) ? "-U ".$config->db_user : "";
 			print "Truncating database...\n";
 			system("dropdb $userarg ".$db);
-			if ( !WIFEXITED(${^CHILD_ERROR_NATIVE}) ) {
+			if ( !WIFEXITED(${^CHILD_ERROR_NATIVE}) || WEXITSTATUS(${^CHILD_ERROR_NATIVE}) ) {
 				my $dsn = $config->db_dsn;
 				$dsn =~ s/(database|dbname)=[\w\d]+/$1=postgres/;
 				my $dbh = DBI->connect(
 					$dsn, $config->db_user, $config->db_password
 				);
-				$dbh->do("DROP DATABASE $db") or die $dbh->errstr;
+				$dbh->do("DROP DATABASE IF EXISTS $db") or die $dbh->errstr;
 				$dbh->do("CREATE DATABASE $db") or die $dbh->errstr;
 			} else {
 				system("createdb $userarg ".$db);


### PR DESCRIPTION
So, previously it assumed that either the `dropdb` command wouldn't be available or the user running the script would have `dropdb`/`createdb` permissions using peer/trust authentication on the local install of postgres.

That's not the case for me, so if it fails to execute the `dropdb` (for example due to: `dropdb: could not connect to database template1: FATAL:  Peer authentication failed for user "ddgc"` then it will now flip over to the DBI connection.

Additionally, if the db didn't exist then the DBI path would fail, the drop is now defensive