### PR TITLE
IA Pages - get rid of duck.co usernames for maintainers

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -1172,7 +1172,6 @@ sub create_ia :Chained('base') :PathPart('create') :Args() {
         };
 
         my $maintainer = { 
-            duckco => $c->user->username,
             github => $gh_id ? $c->d->rs('GitHub::User')->find({github_id => $gh_id})->login : ''
         };
 

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -1400,16 +1400,12 @@ sub format_maintainer {
 
     
     my %maintainer;
-    if ($complat_user) {
-        %maintainer = ( duckco => $complat_user->username );
-
+    if ($complat_user && (my $gh_id = $complat_user->github_id)) {
+        %maintainer = ( github => $c->d->rs('GitHub::User')->find({github_id => $gh_id})->login );
+        
         if ($commit) {
             # give edit permissions
             $ia->add_to_users($complat_user) unless ($complat_user_admin || $ia->users->find($complat_user->id));
-        }
-
-        if (my $gh_id = $complat_user->github_id) {
-            $maintainer{github} = $c->d->rs('GitHub::User')->find({github_id => $gh_id})->login;
         }
     } elsif (check_github($value)) {
         # this github account isn't tied to any duck.co account

--- a/src/templates/commit_page.handlebars
+++ b/src/templates/commit_page.handlebars
@@ -192,18 +192,14 @@
 
                 <td name="maintainer"  id="maintainer_original">
                     {{#if original.maintainer}}
-                        {{#if original.maintainer.duckco}}
-                            <a href="/user/{{original.maintainer.duckco}}">{{original.maintainer.duckco}}</a>
-                        {{else}}
+                        {{#if original.maintainer.github}}
                             <a href="https://github.com/{{original.maintainer.github}}">{{original.maintainer.github}}</a>
                         {{/if}}
                     {{/if}}
                 </td>
                 <td name="maintainer">
                     {{#if maintainer}}
-                        {{#if maintainer.duckco}}
-                            <a href="/user/{{maintainer.duckco}}">{{maintainer.duckco}}</a>
-                        {{else}}
+                        {{#if maintainer.github}}
                             <a href="https://github.com/{{maintainer.github}}">{{maintainer.github}}</a>
                         {{/if}}
                     {{/if}}

--- a/src/templates/dev_pipeline_detail.handlebars
+++ b/src/templates/dev_pipeline_detail.handlebars
@@ -71,8 +71,8 @@
     
     <div id="sidebar-maintainer" class="sidebar-field">
         <div class="field-label primary-label"> Maintainer </div>
-        {{#if maintainer}} <span class="readonly"> {{#if maintainer.duckco}} <a href="/user/{{maintainer.duckco}}">{{maintainer.duckco}}</a> {{else}} <a href="https://github.com/{{maintainer.github}}">{{maintainer.github}}</a> {{/if}} </span> {{/if}}
-        <input class="edit-sidebar {{#if maintainer}}hide{{/if}}" data-focus-class="frm__input" id="edit-sidebar-maintainer" value="{{#if maintainer.duckco}}{{maintainer.duckco}}{{else}}{{maintainer.github}}{{/if}}" />
+        {{#if maintainer}} <span class="readonly"> {{#if maintainer.github}} (github) <a href="https://github.com/{{maintainer.github}}">{{maintainer.github}}</a> {{else}} {{#if maintainer.duckco}}(duck.co) <a href="/user/{{maintainer.duckco}}"> {{maintainer.duckco}}</a>{{else}} <span></span> {{/if}} {{/if}} </span> {{/if}}
+        <input class="edit-sidebar {{#if maintainer}}hide{{/if}}" data-focus-class="frm__input" id="edit-sidebar-maintainer" value="{{#if maintainer.github}}{{maintainer.github}}{{else}}{{maintainer.duckco}}{{/if}}" />
     </div>
 
     <div  class="sidebar-field">
@@ -156,7 +156,7 @@
     {{#if maintainer}}
         <div id="sidebar-maintainer" class="sidebar-field">
             <div class="field-label primary-label"> Maintainer </div>
-            <span class="readonly"> {{#if maintainer.duckco}} <a href="/user/{{maintainer.duckco}}">{{maintainer.duckco}}</a> {{else}} <a href="https://github.com/{{maintainer.github}}">{{maintainer.github}}</a>{{/if}}</span>
+            <span class="readonly"> {{#if maintainer.github}} (github) <a href="https://github.com/{{maintainer.github}}">{{maintainer.github}}</a> {{else}} {{#if maintainer.duckco}}(duck.co) <a href="/user/{{maintainer.duckco}}"> {{maintainer.duckco}}</a>{{else}}<span></span>{{/if}}{{/if}}</span>
         </div>
     {{/if}}
 

--- a/src/templates/dev_pipeline_detail.handlebars
+++ b/src/templates/dev_pipeline_detail.handlebars
@@ -71,8 +71,8 @@
     
     <div id="sidebar-maintainer" class="sidebar-field">
         <div class="field-label primary-label"> Maintainer </div>
-        {{#if maintainer}} <span class="readonly"> {{#if maintainer.github}} (github) <a href="https://github.com/{{maintainer.github}}">{{maintainer.github}}</a> {{else}} {{#if maintainer.duckco}}(duck.co) <a href="/user/{{maintainer.duckco}}"> {{maintainer.duckco}}</a>{{else}} <span></span> {{/if}} {{/if}} </span> {{/if}}
-        <input class="edit-sidebar {{#if maintainer}}hide{{/if}}" data-focus-class="frm__input" id="edit-sidebar-maintainer" value="{{#if maintainer.github}}{{maintainer.github}}{{else}}{{maintainer.duckco}}{{/if}}" />
+        {{#if maintainer}} <span class="readonly"> {{#if maintainer.github}} <a href="https://github.com/{{maintainer.github}}">{{maintainer.github}}</a> {{/if}} </span> {{/if}}
+        <input class="edit-sidebar {{#if maintainer}}hide{{/if}}" data-focus-class="frm__input" id="edit-sidebar-maintainer" value="{{#if maintainer.github}}{{maintainer.github}}{{/if}}" />
     </div>
 
     <div  class="sidebar-field">
@@ -156,7 +156,7 @@
     {{#if maintainer}}
         <div id="sidebar-maintainer" class="sidebar-field">
             <div class="field-label primary-label"> Maintainer </div>
-            <span class="readonly"> {{#if maintainer.github}} (github) <a href="https://github.com/{{maintainer.github}}">{{maintainer.github}}</a> {{else}} {{#if maintainer.duckco}}(duck.co) <a href="/user/{{maintainer.duckco}}"> {{maintainer.duckco}}</a>{{else}}<span></span>{{/if}}{{/if}}</span>
+            <span class="readonly"> {{#if maintainer.github}} <a href="https://github.com/{{maintainer.github}}">{{maintainer.github}}</a>{{/if}}</span>
         </div>
     {{/if}}
 

--- a/src/templates/devinfo.handlebars
+++ b/src/templates/devinfo.handlebars
@@ -132,13 +132,9 @@
     <p  class="readonly--info {{#exists staged 'maintainer'}}hide{{/exists}}" id="maintainer--readonly">
         {{#if maintainer}}
             {{#if maintainer.github}}
-                (github) <a href="https://github.com/{{maintainer.github}}"> {{maintainer.github}}</a>
+                <a href="https://github.com/{{maintainer.github}}"> {{maintainer.github}}</a>
             {{else}}
-                {{#if maintainer.duckco}}
-                    (duck.co) <a href="/user/{{maintainer.duckco}}"> {{maintainer.duckco}}</a>
-                {{else}}
-                    <span class="no-available">No maintainer yet.</span>
-                {{/if}}
+                <span class="no-available">No maintainer yet.</span>
             {{/if}}
         {{else}}
             <span class="no-available">No maintainer yet.</span>

--- a/src/templates/devinfo.handlebars
+++ b/src/templates/devinfo.handlebars
@@ -131,11 +131,11 @@
 
     <p  class="readonly--info {{#exists staged 'maintainer'}}hide{{/exists}}" id="maintainer--readonly">
         {{#if maintainer}}
-            {{#if maintainer.duckco}}
-                <a href="/user/{{maintainer.duckco}}">{{maintainer.duckco}}</a>
+            {{#if maintainer.github}}
+                (github) <a href="https://github.com/{{maintainer.github}}"> {{maintainer.github}}</a>
             {{else}}
-                {{#if maintainer.github}}
-                    <a href="https://github.com/{{maintainer.github}}">{{maintainer.github}}</a>
+                {{#if maintainer.duckco}}
+                    (duck.co) <a href="/user/{{maintainer.duckco}}"> {{maintainer.duckco}}</a>
                 {{else}}
                     <span class="no-available">No maintainer yet.</span>
                 {{/if}}

--- a/src/templates/edit_maintainer.handlebars
+++ b/src/templates/edit_maintainer.handlebars
@@ -1,6 +1,6 @@
 <div class="column-right-edits left" id="column-edits-maintainer">
     <div class="column-right-edits__child js-editable" id="maintainer" name="maintainer">
-        <input type="text" value="{{#if maintainer.duckco}}{{maintainer.duckco}}{{else}}{{maintainer.github}}{{/if}}" class="column-right-edits__child__input js-input" name="maintainer"/>
+        <input type="text" value="{{#if maintainer.github}}{{maintainer.github}}{{/if}}" class="column-right-edits__child__input js-input" name="maintainer"/>
     </div>
 </div>
 

--- a/src/templates/pre_edit_maintainer.handlebars
+++ b/src/templates/pre_edit_maintainer.handlebars
@@ -10,9 +10,7 @@
         <div class="column-center-live__child">
             <p class="column-center-live__child__p">
                 {{#if live.maintainer}}
-                    {{#if live.maintainer.duckco}}
-                        <a href="/user/{{live.maintainer.duckco}}">{{live.maintainer.duckco}}</a>
-                    {{else}}
+                    {{#if live.maintainer.github}}
                         <a href="https://github.com/{{live.maintainer.github}}">{{live.maintainer.github}}</a>
                     {{/if}}
                 {{else}}
@@ -25,9 +23,7 @@
         <div class="column-right-edits__child">
             <p class="column-right-edits__child__p">
                 {{#if edited.maintainer}}
-                    {{#if edited.maintainer.duckco}}
-                        <a href="/user/{{edited.maintainer.duckco}}">{{edited.maintainer.duckco}}</a>
-                    {{else}}
+                    {{#if edited.maintainer.github}}
                         <a href="https://github.com/{{edited.maintainer.github}}">{{edited.maintainer.github}}</a>
                     {{/if}}
                 {{/if}}


### PR DESCRIPTION
//cc @zachthompson 
Live IA Page:
![screenshot-maria duckduckgo com 5001 2016-03-07 21-55-09](https://cloud.githubusercontent.com/assets/3652195/13583067/ceec4cb8-e4af-11e5-94ed-70a12416d542.png)

Dev IA Page + duck.co account:
![screenshot-maria duckduckgo com 5001 2016-03-07 21-57-25](https://cloud.githubusercontent.com/assets/3652195/13583080/db2f4f16-e4af-11e5-8132-eeff12a0d81c.png)

Dev Pipeline detail sidebar:
![screenshot-maria duckduckgo com 5001 2016-03-07 21-54-25](https://cloud.githubusercontent.com/assets/3652195/13583083/e11b50dc-e4af-11e5-9bf3-e2797df8ab9e.png)

