### PR TITLE
Porting DDH::UserPage to community-platform

### DIFF
--- a/bin/dev_server.psgi
+++ b/bin/dev_server.psgi
@@ -6,8 +6,10 @@ use warnings;
 use FindBin;
 use Plack::Builder;
 use Plack::App::Directory;
+use Plack::App::File;
 
 builder {
     mount '/' => Plack::App::Directory->new( root => $FindBin::Dir . "/../build/" )->to_app;
+    mount "/static" => Plack::App::File->new(root => $FindBin::Dir . '/../root/static')->to_app;
 };
 

--- a/bin/dev_server.psgi
+++ b/bin/dev_server.psgi
@@ -1,0 +1,13 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use FindBin;
+use Plack::Builder;
+use Plack::App::Directory;
+
+builder {
+    mount '/' => Plack::App::Directory->new( root => $FindBin::Dir . "/../build/" )->to_app;
+};
+

--- a/bin/dev_server.psgi
+++ b/bin/dev_server.psgi
@@ -4,12 +4,14 @@ use strict;
 use warnings;
 
 use FindBin;
+use lib $FindBin::Dir . "/../lib";
+
 use Plack::Builder;
-use Plack::App::Directory;
+use Plack::App::Directory::WithIndex;
 use Plack::App::File;
 
 builder {
-    mount '/' => Plack::App::Directory->new( root => $FindBin::Dir . "/../build/" )->to_app;
+    mount '/' => Plack::App::Directory::WithIndex->new( root => $FindBin::Dir . "/../build" )->to_app;
     mount "/static" => Plack::App::File->new(root => $FindBin::Dir . '/../root/static')->to_app;
 };
 

--- a/bin/dev_server.sh
+++ b/bin/dev_server.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" 1>/dev/null && pwd )
+PORT=5002
+
+while getopts "p:" o; do
+    case "${o}" in
+        p)
+            p=${OPTARG}
+            ;;
+    esac
+done
+
+if [ ! -z $p ] ; then
+    PORT=$p
+fi
+
+plackup -p $PORT -s Starman $SCRIPTDIR/dev_server.psgi

--- a/bin/generate.pl
+++ b/bin/generate.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use FindBin;
+
+use FindBin;
+use lib $FindBin::Dir . "/../lib";
+
+use DDH::UserPage::Gather;
+use DDH::UserPage::Generate;
+
+DDH::UserPage::Generate->new(
+    contributors => DDH::UserPage::Gather->new->contributors,
+    view_dir     => "$FindBin::Dir/../views",
+    build_dir    => "$FindBin::Dir/../build",
+)->generate;
+

--- a/lib/DDH/UserPage/Gather.pm
+++ b/lib/DDH/UserPage/Gather.pm
@@ -43,6 +43,7 @@ sub transform {
 
     for my $ia_id ( keys $ia ) {
         my @contributors;
+        my @topics;
         $ia->{ia_id} = $ia_id;
 
         if ( $ia->{$ia_id}->{developer} ) {
@@ -76,6 +77,14 @@ sub transform {
             $contributor =~ s{/$}{};
             my $milestone = $ia->{$ia_id}->{dev_milestone} || 'planning';
             push @{ $transform->{$contributor}->{ $milestone } }, $ia->{$ia_id};
+            if ( $ia->{$ia_id}->{topic} && ( $ia->{$ia_id}->{dev_milestone} eq 'live' ) ) {
+                for my $topic ( @{ $ia->{$ia_id}->{topic} } ) {
+
+                    my $topic_count = $transform->{contributor}->{topics}->{$topic};
+                    $topic_count = $topic_count? $topic_count + 1 : 1;
+                    $transform->{$contributor}->{topics}->{$topic} = $topic_count;
+                }
+            }
         }
     }
 

--- a/lib/DDH/UserPage/Gather.pm
+++ b/lib/DDH/UserPage/Gather.pm
@@ -1,0 +1,91 @@
+package DDH::UserPage::Gather;
+
+use strict;
+use warnings;
+
+use Moo;
+
+use HTTP::Tiny;
+use Try::Tiny;
+use JSON::MaybeXS;
+use List::MoreUtils qw/ uniq /;
+use Carp;
+
+has repo_url => (
+    is => 'ro',
+    default => 'https://duck.co/ia/repo/all/json?all_milestones=1',
+);
+
+has http => ( is => 'lazy' );
+sub _build_http {
+    HTTP::Tiny->new;
+}
+
+has json => ( is => 'lazy' );
+sub _build_json {
+    JSON::MaybeXS->new(utf8 => 1);
+}
+
+sub ia_repo {
+    my ( $self ) = @_;
+    my $response = $self->http->get( $self->repo_url );
+
+    if ( !$response->{success} ) {
+        croak "$response->{status} $response->{reason}";
+    }
+
+    $self->json->decode( $response->{content} );
+}
+
+sub transform {
+    my ( $self, $ia ) = @_;
+    my $transform = {};
+
+    for my $ia_id ( keys $ia ) {
+        my @contributors;
+        $ia->{ia_id} = $ia_id;
+
+        if ( $ia->{$ia_id}->{developer} ) {
+
+            for my $developer ( @{ $ia->{$ia_id}->{developer} } ) {
+
+                if ( $developer->{type} &&
+                     $developer->{type} eq 'github' ) {
+
+                    ( my $login = $developer->{url} ) =~
+                        s{https://github.com/(.*)/?}{$1};
+
+                    push @contributors, lc $login;
+                }
+            }
+
+        }
+
+        if ( $ia->{$ia_id}->{attribution} ) {
+
+            for my $attribution ( keys $ia->{$ia_id}->{attribution} ) {
+                push @contributors, map { lc $_->{loc} }
+                  grep { $_->{type} && $_->{type} eq 'github' }
+                      @{ $ia->{$ia_id}->{attribution}->{ $attribution } };
+            }
+
+        }
+
+        for my $contributor ( uniq @contributors ) {
+            # Some of our github logins contain '/' at the end?
+            $contributor =~ s{/$}{};
+            my $milestone = $ia->{$ia_id}->{dev_milestone} || 'planning';
+            push @{ $transform->{$contributor}->{ $milestone } }, $ia->{$ia_id};
+        }
+    }
+
+    return $transform;
+}
+
+sub contributors {
+    my ( $self ) = @_;
+    $self->transform( $self->ia_repo );
+}
+
+1;
+

--- a/lib/DDH/UserPage/Gather/Github.pm
+++ b/lib/DDH/UserPage/Gather/Github.pm
@@ -1,0 +1,11 @@
+package DDH::UserPage::Gather::Github;
+
+use strict;
+use warnings;
+
+use Moo;
+
+
+
+1;
+

--- a/lib/DDH/UserPage/Generate.pm
+++ b/lib/DDH/UserPage/Generate.pm
@@ -82,13 +82,15 @@ sub generate {
             next;
         }
         my $build_dir = $self->contributor_dir( $contributor );
+        my $contributor_data = $self->contributors->{ $contributor };
 
         my $content = $self->xslate->render(
             'userpage/index.tx',
             {
-                data => $self->json->encode(
-                    $self->contributors->{ $contributor }
-                )
+                json_data => $self->json->encode(
+                    $contributor_data
+                ),
+                data => $contributor_data
             }
         );
 

--- a/lib/DDH/UserPage/Generate.pm
+++ b/lib/DDH/UserPage/Generate.pm
@@ -1,0 +1,80 @@
+package DDH::UserPage::Generate;
+
+use strict;
+use warnings;
+
+use Moo;
+use Text::Xslate;
+use File::Path qw/ make_path /;
+use JSON::MaybeXS;
+use Cwd qw/ abs_path /;
+use Carp;
+
+has view_dir => (
+    is       => 'ro',
+    required => 1,
+    coerce   => sub { abs_path( $_[0] ) },
+);
+
+has build_dir => (
+    is       => 'ro',
+    required => 1,
+    coerce   => sub {
+        my $p = abs_path( $_[0] );
+        make_path( $p );
+        return $p;
+    },
+);
+
+has contributors => (
+    is       => 'ro',
+    required => 1,
+);
+
+has xslate => ( is => 'lazy' );
+sub _build_xslate {
+    Text::Xslate->new( {
+        path => [ $_[0]->view_dir ],
+    } );
+}
+
+has json => ( is => 'lazy' );
+sub _build_json {
+    JSON::MaybeXS->new( utf8 => 1, pretty => 1 );
+}
+
+sub contributor_dir {
+    my ( $self, $contributor ) = @_;
+    my $p = abs_path(
+        sprintf( '%s/%s', $self->build_dir, $contributor )
+    );
+    make_path( $p );
+    return $p;
+}
+
+sub generate {
+    my ( $self ) = @_;
+
+    open my $fh, '>:encoding(UTF-8)', $self->build_dir . "/index.json" or die();
+    print $fh $self->json->encode( $self->contributors );
+
+    for my $contributor ( keys $self->contributors ) {
+        if ( $contributor=~ /^https?:/ ) {
+            warn "$contributor appears to be a URL - skipping";
+            next;
+        }
+        my $build_dir = $self->contributor_dir( $contributor );
+
+        open my $fh, '>:encoding(UTF-8)', "$build_dir/index.html" or die();
+        print $fh $self->xslate->render(
+            'userpage/index.tx',
+            { data => $self->json->encode(
+                $self->contributors->{ $contributor }
+            ) }
+        );
+        close $fh;
+    }
+}
+
+1;
+

--- a/lib/DDH/UserPage/Generate.pm
+++ b/lib/DDH/UserPage/Generate.pm
@@ -9,6 +9,7 @@ use File::Path qw/ make_path /;
 use JSON::MaybeXS;
 use Cwd qw/ abs_path /;
 use Carp;
+use DDGC;
 
 has view_dir => (
     is       => 'ro',
@@ -41,6 +42,16 @@ sub _build_xslate {
 has json => ( is => 'lazy' );
 sub _build_json {
     JSON::MaybeXS->new( utf8 => 1, pretty => 1 );
+}
+
+has ddgc => ( is => 'lazy' );
+sub _build_ddgc {
+    DDGC->new;
+}
+
+has db => ( is => 'lazy' );
+sub _build_db {
+    $_[0]->ddgc->db;
 }
 
 sub contributor_dir {

--- a/lib/Plack/App/Directory/WithIndex.pm
+++ b/lib/Plack/App/Directory/WithIndex.pm
@@ -1,0 +1,30 @@
+package Plack::App::Directory::WithIndex;
+use parent qw(Plack::App::Directory);
+use strict;
+use warnings;
+
+use Plack::Util::Accessor qw( index );
+
+sub serve_path {
+    my($self, $env, $dir, $fullpath) = @_;
+
+    my $idx_files = ( $self->index )
+        ? ( ( ref $self->index eq 'ARRAY' )
+            ? $self->index
+            : [ $self->index ] )
+        : [ qw( index.html index.htm ) ];
+
+    if ( -d $dir ) {
+        for my $file ( @{ $idx_files } ) {
+            my $idx_path = sprintf( '%s/%s', $dir, $file );
+            if ( -f $idx_path ) {
+                $dir = $idx_path;
+            }
+        }
+    }
+
+    return $self->SUPER::serve_path($env, $dir, $fullpath);
+}
+
+1;
+

--- a/lib/Plack/App/Directory/WithIndex.pm
+++ b/lib/Plack/App/Directory/WithIndex.pm
@@ -19,6 +19,7 @@ sub serve_path {
             my $idx_path = sprintf( '%s/%s', $dir, $file );
             if ( -f $idx_path ) {
                 $dir = $idx_path;
+                last;
             }
         }
     }

--- a/root/static/css/index.css
+++ b/root/static/css/index.css
@@ -3,8 +3,7 @@ ul { list-style: none; }
 #userpage-wrap { padding: 0 5 em; }
 
 #userpage-keywords-title {
-    margin-top: 1.3em;
-    margin-bottom: 1.5em;
+    margin-bottom: 0.8em;
     font-size: 1.1em;
     color: #aaa;
 }

--- a/root/static/css/index.css
+++ b/root/static/css/index.css
@@ -1,0 +1,15 @@
+ul { list-style: none; }
+
+#userpage-wrap { padding: 0 5 em; }
+
+#userpage-keywords-title {
+    margin-top: 1.3em;
+    margin-bottom: 1.5em;
+    font-size: 1.1em;
+    color: #aaa;
+}
+
+.userpage-wrap__child {
+    min-height: 30em;
+    padding: 2em;
+}

--- a/views/includes/header/index.tx
+++ b/views/includes/header/index.tx
@@ -15,10 +15,12 @@
 		<: } :>
         : include "includes/header/nav.tx"
 
-        : if $vars.user {
-            : include "includes/header/accountinfo.tx"
-        : } else {
-            : include "includes/header/login.tx"
+        : if !$hide_login {
+            : if $vars.user {
+                : include "includes/header/accountinfo.tx"
+            : } else {
+                : include "includes/header/login.tx"
+            : }
         : }
 
     </div>
@@ -28,12 +30,14 @@
 <div class="site-header mobile">
   <div class="content-wrap">
     <div class="flex-container">
+      : if !$hide_login {
       <div class="notification-bubble">
 	<: my $notification_count = $vars.user.unread_notifications || $undone_notifications_count || $vars.user.undone_notifications_count || 0; :>
 	  <a href="/my/notifications">
 	    <i class="ddgsi ddgsi-comment notification <: if $notification_count { :>has-notification<: } :>"></i>
 	  </a>
       </div>
+      : }
 
       <div class="header-logo">
 	<div class="header-logo__logo"><a href="/"><img src="/static/images/logo.svg" /></a></div>

--- a/views/userpage/index.tx
+++ b/views/userpage/index.tx
@@ -1,3 +1,45 @@
-<pre>
-    : $data | raw
-</pre>
+<!doctype html>
+<head>
+    <link rel="stylesheet" href="/static/css/index.css">
+</head>
+<body>
+    <div id="userpage-wrap">
+        <div class="left userpage-wrap__child" id="userpage-keywords">
+            <div id="userpage-keywords-title">Keywords</div>
+            
+            <ul id="userpage-keywords-list">
+                : if $data.topics {
+                    : for $data.topics.keys() -> $topic {
+                        <li class="userpage-keywords-list__item">
+                            <div class="left topic_name">
+                                : $topic
+                            </div>
+                            <div class="right topic_count">
+                                : $data.topics[$topic]
+                            </div>
+                            <span class="clear"></span>
+                        </li>
+                    : }
+                : }
+            </ul>
+        </div>
+
+        <div class="left userpage-wrap__child" id="userpage-main">
+            <h2 id="userpage-main-title">Contributed Instant Answers</h2>
+
+            <ul id="userpage-main-ias">
+                : if $data.live {
+                    : for $data.live -> $ia {
+                        <li class="userpage-main-ias__item">
+                            <a href="https://duck.co/ia/view/<:$ia.id:>">
+                                : $ia.name
+                            </a>
+                        </li>
+                    : }
+                : }
+            </ul>
+        </div>
+        <span class="clear"></span>
+    </div>
+</body>
+</html>

--- a/views/userpage/index.tx
+++ b/views/userpage/index.tx
@@ -1,0 +1,3 @@
+<pre>
+    : $data | raw
+</pre>


### PR DESCRIPTION
This is almost the same as the original project - `bin/generate.pl` creates pages. `bin/dev_server.pl` is a static file server.

Differences:

- Gather has a db handle via a `DDGC`instance (so we can probably lose the HTTP operations).
- dev_server mounts static files (CSS etc)
- userpage/index is rendered within a duck.co style frame with nav bar and no account info.

![](http://jbrt.org/ddg/frame.png)

Cc: @abeyang @jagtalon 