### PR TITLE
IA Pages - fix editing maintainer when live value is null

### DIFF
--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1061,7 +1061,7 @@
                                 equal_vals = equal_vals? equal_vals : (temp_val === live_value);
                                 is_json = true;
                             } else {
-                                temp_live = (field === "maintainer")? live_value.github : live_value;
+                                temp_live = ((field === "maintainer") && live_value)? live_value.github : live_value;
                                 equal_vals = (value === temp_live)? true : false;
                             }
 


### PR DESCRIPTION
It works now (screenshot of the commit page JSON endpoint):
![screenshot-maria duckduckgo com 5001 2016-03-14 21-52-04](https://cloud.githubusercontent.com/assets/3652195/13759565/1ffdd980-ea2f-11e5-9351-1e4d0cf04107.png)
