### PR TITLE
Fix ddgc_populate_ia_dev

### DIFF
--- a/script/ddgc_populate_ia_dev.pl
+++ b/script/ddgc_populate_ia_dev.pl
@@ -25,6 +25,7 @@ for my $ia_id (keys $data) {
     my $topics = delete $data->{$ia_id}->{topic};
     my $developer = delete $data->{$ia_id}->{developer};
     my $attribution = delete $data->{$ia_id}->{attribution};
+    my $maintainer = delete $data->{$ia_id}->{maintainer};
     my $src_options = delete $data->{$ia_id}->{src_options};
 
     my $ia = $d->rs('InstantAnswer')->update_or_create({
@@ -38,6 +39,9 @@ for my $ia_id (keys $data) {
             : (),
         ( $developer )
             ? ( developer => encode_json( $developer ) )
+            : (),
+        ( $maintainer )
+            ? ( maintainer => encode_json( $maintainer ) )
             : (),
     });
 


### PR DESCRIPTION
Pulling maintainer hash from data before insert.

Still barfs a load of "uninitialized value in concatenation" errors from this [stringification override](https://github.com/duckduckgo/community-platform/blob/9d0f94d5ace1219b87ae784ef00bc603a9859395/lib/DDGC/DB/Base/Result.pm#L278-L281) but I'm not too worried about that for now.