### PR TITLE
IA Pages - limit length for the description text

### DIFF
--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1008,7 +1008,10 @@
                                 } else {
                                     $input = $obj.find("input.js-input,#description textarea");
                                     value = $input.length? $.trim($input.val().replace(/"/g, "")) : '';
-                                    value = value? value.substr(0, 1000) : '';
+                                    
+                                    if (value.length > 1000) {
+                                        value = truncateDesc(value); 
+                                    }
                                 }
                             }
 
@@ -1093,6 +1096,15 @@
                         var both_empty = (value_empty && live_empty)? true : false;
 
                         return both_empty;
+                    }
+
+                    // Truncate desc to max 1000 chars and try to break on the last period
+                    function truncateDesc(value) {
+                        value = value.substr(0, 1000);
+                        var last_period = value.lastIndexOf(".") + 1;
+                        value = last_period? value.substring(0, last_period) : value;
+                        
+                        return value;
                     }
 
                     // Check if username exists for the given account type (either github or duck.co)
@@ -1228,8 +1240,11 @@
                                         value = null;
                                     }
                                 } else if (editable_type === "input" || editable_type === "textarea") {
-                                    value =  $.trim($editable.val().replace(/"/g, ""));
-                                    value = ($editable.attr("type") === "number")? parseInt(value) : value.substr(0, 1000);
+                                    value =  ($editable.attr("type") === "number")? parseInt($editable.val()) :$.trim($editable.val().replace(/"/g, ""));
+
+                                    if ((field === "description") && (value.length > 1000)) {
+                                        value = truncateDesc(value);
+                                    }
 
                                     if ($editable.hasClass("comma-separated")) {
                                         value = value.length? JSON.stringify(value.split(/\s*,\s*/)) : "[]";

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1228,8 +1228,8 @@
                                         value = null;
                                     }
                                 } else if (editable_type === "input" || editable_type === "textarea") {
-                                    value = ($editable.attr("type") === "number")? parseInt($editable.val()) : $.trim($editable.val().replace(/"/g, ""));
-                                    value = value? value.substr(0, 1000) : '';
+                                    value =  $.trim($editable.val().replace(/"/g, ""));
+                                    value = ($editable.attr("type") === "number")? parseInt(value) : value.substr(0, 1000);
 
                                     if ($editable.hasClass("comma-separated")) {
                                         value = value.length? JSON.stringify(value.split(/\s*,\s*/)) : "[]";

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1008,6 +1008,7 @@
                                 } else {
                                     $input = $obj.find("input.js-input,#description textarea");
                                     value = $input.length? $.trim($input.val().replace(/"/g, "")) : '';
+                                    value = value? value.substr(0, 1000) : '';
                                 }
                             }
 
@@ -1228,6 +1229,7 @@
                                     }
                                 } else if (editable_type === "input" || editable_type === "textarea") {
                                     value = ($editable.attr("type") === "number")? parseInt($editable.val()) : $.trim($editable.val().replace(/"/g, ""));
+                                    value = value? value.substr(0, 1000) : '';
 
                                     if ($editable.hasClass("comma-separated")) {
                                         value = value.length? JSON.stringify(value.split(/\s*,\s*/)) : "[]";

--- a/src/js/ia/IAPageNew.js
+++ b/src/js/ia/IAPageNew.js
@@ -142,7 +142,7 @@
                     var temp_id = $temp_el.attr("id");
                     var temp_field = temp_id.replace(/\-[^\-]+$/, "");
                     var temp_type = temp_id.replace(/^.+\-/, "");
-                    var temp_val = (temp_type === "radio")? $.trim($temp_el.find('input[type="radio"]:checked').val()) : $.trim($temp_el.val().replace(/"/g, ""));
+                    var temp_val = (temp_type === "radio")? $.trim($temp_el.find('input[type="radio"]:checked').val()) : $.trim($temp_el.val().replace(/"/g, "").substr(0, 1000));
 
                     if (temp_field) {
                         temp_field = temp_field.replace(/^.+\-/, "");

--- a/src/js/ia/IAPageNew.js
+++ b/src/js/ia/IAPageNew.js
@@ -142,7 +142,17 @@
                     var temp_id = $temp_el.attr("id");
                     var temp_field = temp_id.replace(/\-[^\-]+$/, "");
                     var temp_type = temp_id.replace(/^.+\-/, "");
-                    var temp_val = (temp_type === "radio")? $.trim($temp_el.find('input[type="radio"]:checked').val()) : $.trim($temp_el.val().replace(/"/g, "").substr(0, 1000));
+                    var temp_val; 
+                    if (temp_type === "radio") {
+                        temp_val = $.trim($temp_el.find('input[type="radio"]:checked').val());
+                    } else {
+                        temp_val = $.trim($temp_el.val().replace(/"/g, ""));
+                        if ((temp_field === "description") && (temp_val.length > 1000)) {
+                            temp_val = temp_val.substr(0, 1000);
+                            var last_period = temp_val.lastIndexOf(".") + 1;
+                            temp_val = last_period? temp_val.substring(0, last_period) : temp_val;
+                        }
+                    }
 
                     if (temp_field) {
                         temp_field = temp_field.replace(/^.+\-/, "");


### PR DESCRIPTION
Truncate to the last period, if that's available; otherwise, truncate at 1000 chars length.

In order to test this, I copypasted the text from the [lorem ipsum IA](https://duckduckgo.com/?q=10+paragraphs+of+lorem+ipsum&ia=answer&iax=1) in the description field. 
Newly created IA Page:
![screenshot-maria duckduckgo com 5001 2016-03-18 20-35-02](https://cloud.githubusercontent.com/assets/3652195/13890105/13767d70-ed4a-11e5-93da-c4ad11cbc514.png)

Live Page in edit mode:
![screenshot-maria duckduckgo com 5001 2016-03-18 20-36-45](https://cloud.githubusercontent.com/assets/3652195/13890107/15c90322-ed4a-11e5-99db-038a0ee79548.png)

