### PR TITLE
IA Pages - add 'Maintain this IA' button

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -949,6 +949,7 @@ sub save_edit :Chained('base') :PathPart('save') :Args(0) {
     my $is_admin = 0;
     my $saved = 0;
     my $field = $c->req->params->{field};
+            my $value = $c->req->params->{value};
     my $msg = "";
 
     # if the update fails because of invalid values
@@ -970,11 +971,11 @@ sub save_edit :Chained('base') :PathPart('save') :Args(0) {
        $permissions = $ia->users->find($c->user->id);
        $is_admin = $c->user->admin;
 
-        if ($permissions || $is_admin) {
+        # Allow any logged in user to self-assign an IA for maintainership
+        if ($permissions || $is_admin || (($field eq 'maintainer') && ($value eq $c->user->username) && (!$ia_data->{maintainer}->{github}))) {
             $result->{is_admin} = $is_admin;
             $c->stash->{x}->{result} = $result;
 
-            my $value = $c->req->params->{value};
             my $autocommit = $c->req->params->{autocommit};
             my $rs_user = $c->d->rs('User');
             my $complat_user = $rs_user->find({username => $value}) || $rs_user->find_by_github_login($value);

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -1034,14 +1034,15 @@ sub save_edit :Chained('base') :PathPart('save') :Args(0) {
                 return $c->forward($c->view('JSON')) unless ($complat_user_admin || $value eq '');
             } elsif ($field eq "maintainer") {
                 my $result = format_maintainer($c, $value, $ia, 0);
-                
+               use Data::Dumper;
+               print Dumper $result;
                 if (!$result->{maintainer}) {
                     $msg = $result->{msg};
                     $c->stash->{x}->{result}->{msg} = $msg;
                     return $c->forward($c->view('JSON'));
                 }
 
-                $value = $result->{maintainer};
+                $value = to_json $result->{maintainer};
             } elsif ($field eq "id") {
                 return $c->forward($c->view('JSON')) unless $is_admin;
                 $field = "meta_id";
@@ -1435,7 +1436,7 @@ sub format_maintainer {
     }
 
     %result = (
-        maintainer => %maintainer ? to_json \%maintainer : 0,
+        maintainer => \%maintainer,
         msg => $msg,
     );
 

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -1401,7 +1401,7 @@ sub format_maintainer {
     my %maintainer;
     if ($complat_user && (my $gh_id = $complat_user->github_id)) {
         %maintainer = ( github => $c->d->rs('GitHub::User')->find({github_id => $gh_id})->login );
-    } elsif (check_github($value)) {
+    } elsif ((!$complat_user) && check_github($value)) {
         # this github account isn't tied to any duck.co account
         # we still allow it to be listed as maintainer
         # but can't give edit permissions

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -949,7 +949,7 @@ sub save_edit :Chained('base') :PathPart('save') :Args(0) {
     my $is_admin = 0;
     my $saved = 0;
     my $field = $c->req->params->{field};
-            my $value = $c->req->params->{value};
+    my $value = $c->req->params->{value};
     my $msg = "";
 
     # if the update fails because of invalid values
@@ -1033,20 +1033,20 @@ sub save_edit :Chained('base') :PathPart('save') :Args(0) {
             if ($field =~ /designer|producer/){
                 return $c->forward($c->view('JSON')) unless ($complat_user_admin || $value eq '');
             } elsif ($field eq "maintainer") {
-                my $result;
+                my $maintainer;
                 if ($value) {
-                    $result = format_maintainer($c, $value, $ia, 0);
-                    if ((!$result->{maintainer}) || ($result->{maintainer} && (!$result->{maintainer}->{github}))) {
-                        $msg = $result->{msg};
+                    $maintainer = format_maintainer($c, $value, $ia, 0);
+                    if ((!$maintainer->{maintainer}) || ($maintainer->{maintainer} && (!$maintainer->{maintainer}->{github}))) {
+                        $msg = $maintainer->{msg};
                         $c->stash->{x}->{result}->{msg} = $msg;
                         return $c->forward($c->view('JSON'));
                     }
                 } else {
-                  my $maintainer = {github => ''};
-                  $result = {maintainer => $maintainer};
+                  my $gh_empty = {github => ''};
+                  $maintainer = {maintainer => $gh_empty};
                 }
 
-                $value = to_json $result->{maintainer};
+                $value = to_json $maintainer->{maintainer};
             } elsif ($field eq "id") {
                 return $c->forward($c->view('JSON')) unless $is_admin;
                 $field = "meta_id";

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -748,6 +748,7 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
     $ia_data{live}->{prs} = \@all_prs;
     
     if ($c->user) {
+        $ia_data{live}->{gh_exists} = $c->user->github_id? 1 : 0;
         $permissions = $c->stash->{ia}->users->find($c->user->id);
         $is_admin = $c->user->admin;
 
@@ -972,7 +973,9 @@ sub save_edit :Chained('base') :PathPart('save') :Args(0) {
        $is_admin = $c->user->admin;
 
         # Allow any logged in user to self-assign an IA for maintainership
-        if ($permissions || $is_admin || (($field eq 'maintainer') && ($value eq $c->user->username) && (!$ia_data->{maintainer}->{github}))) {
+        if ($permissions || $is_admin || (($field eq 'maintainer') 
+            && ($value eq $c->user->username) && ((!defined $ia_data->{maintainer}{github}) || (!length $ia_data->{maintainer}{github})))) {
+            
             $result->{is_admin} = $is_admin;
             $c->stash->{x}->{result} = $result;
 

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -26,7 +26,7 @@
 
             var page = this;
             var json_url = "/ia/view/" + DDH_iaid + "/json";
-            var this_username = $.trim($(".header-account-info .user-name a.js-popout-link").text());
+            this.username = $.trim($(".header-account-info .user-name a.js-popout-link").text());
             
             if (DDH_iaid) {
                 //console.log("for ia id '%s'", DDH_iaid);
@@ -153,12 +153,6 @@
 
                     page.updateAll(readonly_templates, ia_data, false);
 
-                    // Only logged in contributors can assign themselves IAs to maintain
-                    if (!this_username) {
-                        $("#maintain-button").remove();
-                    } else {
-                        $("#maintainer--readonly .no-available").remove();
-                    }
 
                     $('body').on("click", "#show-all-issues", function(evt) {
                         $(this).hide();
@@ -885,14 +879,14 @@
 
                     $("body").on('click', ".assign-button.js-autocommit", function(evt) {
                         var $input = $(".team-input");
-                        $input.val(this_username);
+                        $input.val(page.username);
                         $("#producer-input").removeClass("focused");
                          $("#contributors-popup .save-button-popup").removeClass("is-disabled");
-                        usercheck("duck.co", this_username, null, $("#producer-input"));
+                        usercheck("duck.co", page.username, null, $("#producer-input"));
                     });
 
                     $("body").on('click', '#maintain-button', function(evt) {
-                        autocommit('maintainer', this_username, DDH_iaid);
+                        autocommit('maintainer', page.username, DDH_iaid);
                     });
 
                     $("body").on('click', '.js-pre-editable.button', function(evt) {
@@ -1809,7 +1803,7 @@
                         $(".ia-single--left").append(templates.screens);
                     }
                 }
-
+                
                 if ((ia_data.live.dev_milestone === "live") && ia_data.live.hasOwnProperty("traffic") && ia_data.live.traffic.dates.length) {
                     var traffic = $("#ia_traffic").get(0).getContext("2d");
                     //var weekend_labels = this.getWeekends(ia_data.live.traffic.dates);
@@ -1862,6 +1856,14 @@
                     this.appendTopics($(".topic-group.js-autocommit"));
                     this.appendBlockgroup($(".available_blockgroups.js-autocommit"));
                 }
+                
+                // Only logged in contributors can assign themselves IAs to maintain
+                if (!this.username) {
+                    $("#maintain-button").remove();
+                } else {
+                    $("#maintainer--readonly .no-available").remove();
+                }
+
             } else {
                 $("#ia-single-top").attr("id", "ia-single-top--edit");
                 $("#ia-single-top-name, #ia-single-top-details, .ia-single--left, .ia-single--right, .edit-container, #ia-breadcrumbs").hide();

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -153,6 +153,11 @@
 
                     page.updateAll(readonly_templates, ia_data, false);
 
+                    // Only logged in contributors can assign themselves IAs to maintain
+                    if (!this_username) {
+                        $("#maintain-button").remove();
+                    }
+
                     $('body').on("click", "#show-all-issues", function(evt) {
                         $(this).hide();
                         $(".ia-issues ul li").show();
@@ -884,6 +889,10 @@
                         usercheck("duck.co", this_username, null, $("#producer-input"));
                     });
 
+                    $("body").on('click', '#maintain-button', function(evt) {
+                        autocommit('maintainer', this_username, DDH_iaid);
+                    });
+
                     $("body").on('click', '.js-pre-editable.button', function(evt) {
                         var field = $(this).attr('name');
                         var $row = $(this).parent();
@@ -1590,7 +1599,7 @@
                                 } else {
                                     ia_data.edited[field] = data.result[field];
                                 }
-
+                                
                                 pre_templates[field] = Handlebars.templates['pre_edit_' + field](ia_data);
 
                                 $obj.replaceWith(pre_templates[field]);

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1859,9 +1859,14 @@
                 
                 // Only logged in contributors can assign themselves IAs to maintain
                 if (!this.username) {
+                    $(".error-gh-exists").removeClass("hide");
                     $("#maintain-button").remove();
                 } else {
                     $("#maintainer--readonly .no-available").remove();
+                    if (!ia_data.live.gh_exists) {
+                        $(".error-gh-exists").removeClass("hide");
+                        $("#maintain-button").remove();
+                    }
                 }
 
             } else {

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -156,6 +156,8 @@
                     // Only logged in contributors can assign themselves IAs to maintain
                     if (!this_username) {
                         $("#maintain-button").remove();
+                    } else {
+                        $("#maintainer--readonly .no-available").remove();
                     }
 
                     $('body').on("click", "#show-all-issues", function(evt) {

--- a/src/scss/ia/_dev.scss
+++ b/src/scss/ia/_dev.scss
@@ -1,3 +1,5 @@
+#maintain-button { margin-left: 0; }
+
 .ia-single {
 
     #add_developer {

--- a/src/scss/ia/_dev.scss
+++ b/src/scss/ia/_dev.scss
@@ -1,4 +1,4 @@
-#maintain-button { margin-left: 0; }
+#maintain-button, .ia-single .ia-single--right .error-gh-exists { margin-left: 0; }
 
 .ia-single {
 

--- a/src/templates/devinfo.handlebars
+++ b/src/templates/devinfo.handlebars
@@ -137,11 +137,15 @@
                 <span class="no-available">No maintainer yet.</span>
                 <span class="error-notification hide"></span>
                 <div class="button btn--primary" id="maintain-button">Maintain this IA</div>
+                <div class="error-gh-exists hide"> <a href="/my/github_oauth">Login with GitHub </a></div>
+                <div class="error-gh-exists hide">to maintain this IA</div>
             {{/if}}
         {{else}}
             <span class="no-available">No maintainer yet.</span>
             <span class="error-notification hide"></span>
             <div class="button btn--primary" id="maintain-button">Maintain this IA</div>
+            <div class="error-gh-exists hide"> <a href="/my/github_oauth">Login with GitHub </a></div>
+            <div class="error-gh-exists hide">to maintain this IA</div>
         {{/if}}
     </p>
 

--- a/src/templates/devinfo.handlebars
+++ b/src/templates/devinfo.handlebars
@@ -135,15 +135,18 @@
                 <a href="https://github.com/{{maintainer.github}}"> {{maintainer.github}}</a>
             {{else}}
                 <span class="no-available">No maintainer yet.</span>
+                <span class="error-notification hide"></span>
                 <div class="button btn--primary" id="maintain-button">Maintain this IA</div>
             {{/if}}
         {{else}}
             <span class="no-available">No maintainer yet.</span>
+            <span class="error-notification hide"></span>
             <div class="button btn--primary" id="maintain-button">Maintain this IA</div>
         {{/if}}
     </p>
 
     {{#if permissions.admin}}
+        <span class="error-notification hide"></span>
         <input class="{{#n_exists staged 'maintainer'}}hide{{/n_exists}} frm__input maintainer js-autocommit hidden-toshow" id="maintainer-input"
             value="{{~#exists staged 'maintainer'~}}
                 {{staged.maintainer}}

--- a/src/templates/devinfo.handlebars
+++ b/src/templates/devinfo.handlebars
@@ -135,9 +135,11 @@
                 <a href="https://github.com/{{maintainer.github}}"> {{maintainer.github}}</a>
             {{else}}
                 <span class="no-available">No maintainer yet.</span>
+                <div class="button btn--primary" id="maintain-button">Maintain this IA</div>
             {{/if}}
         {{else}}
             <span class="no-available">No maintainer yet.</span>
+            <div class="button btn--primary" id="maintain-button">Maintain this IA</div>
         {{/if}}
     </p>
 


### PR DESCRIPTION
Live IA without maintainer (I previously removed it):
![screenshot-maria duckduckgo com 5001 2016-03-21 21-25-54](https://cloud.githubusercontent.com/assets/3652195/13933105/d323e12c-efab-11e5-8fd8-ab4ba4497341.png)

After clicking on the button:
![screenshot-maria duckduckgo com 5001 2016-03-21 21-28-34](https://cloud.githubusercontent.com/assets/3652195/13933131/f375b9e6-efab-11e5-95e4-7822d615e886.png)

TODO: open up editing to all logged in users, not just ones with edit permissions
