### PR TITLE
InstantAnswer.pm - sort traffic data by date

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -767,7 +767,10 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
                     answer_id => $ia->meta_id, 
                     date => { '<' => $last_monday->date()}, 
                     date => { '>' => $month_ago},
-                    pixel_type => [qw( iaoi iaoe )]
+                    pixel_type => [qw( iaoi iaoe )],
+                },
+                {
+                    order_by => [qw( date )]
                 });
             
             my $iaoi = $traffic_rs->get_array_by_pixel();


### PR DESCRIPTION
On the frontend, when looping over the data, we add zeroes whenever we see date gaps to fill.
It seems like we don't always get the data sorted by date though, so we need to user order_by when querying the DB to make sure we don't add zeroes where there's no need for them.
