### PR TITLE
Missing files from ghIssues

### DIFF
--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -33,10 +33,10 @@ my @results;
 
 # the repos we care about
 my @repos = (
-     'zeroclickinfo-spice',
-#    'zeroclickinfo-goodies',
-#    'zeroclickinfo-longtail',
-#    'zeroclickinfo-fathead'
+    'zeroclickinfo-spice',
+    'zeroclickinfo-goodies',
+    'zeroclickinfo-longtail',
+    'zeroclickinfo-fathead'
 );
 
 my $token;


### PR DESCRIPTION
This fixes a bug in the merge_files function.  The way it works right now is actually overwriting the links to the files with whatever files were altered in the last PR.  This is fine for a new IA PR or a PR that alters all the files but in cases where a PR changes only a few files, we loose the others.   

I've updated it do do the following:
1. get the current file list from the database
2. add any new files from the PR
3. remove any files removed by the PR
4. update the database with the new list. 

To test:
1. run `./find_files.pl`.  This takes a good 5 minuets or so to run but should get you upto date file data
2. `psql -U ddgc -f files.sql`.  Update your files in the DB
3. Change this line to get the last 100 hours of issues
	https://github.com/duckduckgo/community-platform/blob/f2b0b5731cb07af8004a11fe190a78ba34d3d52e/script/ghIssues.pl#L54
4. It's not a bad idea to comment out the other repos (besides goodies) to speed this up. 
https://github.com/duckduckgo/community-platform/blob/f2b0b5731cb07af8004a11fe190a78ba34d3d52e/script/ghIssues.pl#L36
5. `./ghIssues <your api key>`


Compare the [conversions IA page](https://duck.co/ia/view/conversions) locally and on production.  The last PR only changed one of the files which is why the current file list in production only contains one file. 
![selection_314](https://cloud.githubusercontent.com/assets/1882892/14332195/5b3b147e-fc16-11e5-9fed-ba552444e57b.jpg)

Your local versions should have all the correct files. 
![selection_315](https://cloud.githubusercontent.com/assets/1882892/14332350/1a665af2-fc17-11e5-8ed8-653d7cc9f8a5.jpg)