### PR TITLE
IAIndex.js: Remove //g flag from regexp.

### DIFF
--- a/src/js/ia/IAIndex.js
+++ b/src/js/ia/IAIndex.js
@@ -292,7 +292,7 @@
 
             if (query) {
                 query = query.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
-                regex = new RegExp(query, "gi");
+                regex = new RegExp(query, "i");
                 url += "&q=" + encodeURIComponent(query.replace(/\x5c/g, "")).replace(/%20/g, "+");
             }
 


### PR DESCRIPTION
We're using a regexp with a //g flag and running it on multiple strings. Since that regexp maintains state on subsequent calls (lastIndex), we run into matching problems. The solution is to just not use the g flag.