### PR TITLE
Dev Pipeline - fix dates in comments

### DIFF
--- a/src/js/ia/Helpers.js
+++ b/src/js/ia/Helpers.js
@@ -26,6 +26,8 @@
 
     // Return elapsed time expressed as days from now (e.g. 5 days, 1 day, today)
     Handlebars.registerHelper("timeago", function(date, full, from_beta) {
+        // Dates coming from the beta server are formatted differently than the ones coming from GitHub
+        // So we parse them accordingly
         var format = from_beta? "ddd MMM D HH:mm:ss YYYY" : "YYYY-MM-DD";
         var timestring = full? " days ago" : "d";
         if (date) {

--- a/src/templates/dev_pipeline_detail.handlebars
+++ b/src/templates/dev_pipeline_detail.handlebars
@@ -205,7 +205,7 @@
                     {{text}}
                 </a>
             </p>
-            <div>by <a href="https://github.com/{{user}}">{{user}}</a> {{timeago date 1}}</div>
+            <div>by <a href="https://github.com/{{user}}">{{user}}</a> {{timeago date}}</div>
         {{/each}}
     </div>
 {{/if}}


### PR DESCRIPTION
On production the dates in the detail sidebar all show a negative number.
Turns out the timeago helper got passed an unneeded argument, since these dates come from GitHub and not from the beta server.
![screenshot-maria duckduckgo com 5001 2016-04-14 14-48-09](https://cloud.githubusercontent.com/assets/3652195/14528490/f504ee7e-024f-11e6-9fef-0f5a4b11425c.png)
