### PR TITLE
ghIssues.pl - fix adding new developers when developer value is null

### DIFF
--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -75,7 +75,7 @@ sub getIssues{
 		
         # add all the data we care about to an array
 		for my $issue (@issues){
-#            $progress->update($line) unless $d->is_live;
+            $progress->update($line) unless $d->is_live;
             $line++;
 
             # get the IA name from the link in the first comment

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -51,7 +51,7 @@ my $gh = Net::GitHub->new(access_token => $token);
 
 my $today = localtime;
 # get last 6 hours of issues
-my $since = $today - (6 * ONE_HOUR);
+my $since = $today - (100 * ONE_HOUR);
 
 # get the GH issues
 sub getIssues{
@@ -243,7 +243,7 @@ sub getIssues{
 
                 #return 1 if !$is_new_ia;
                 $d->rs('InstantAnswer')->update_or_create({%new_data});
-
+                warn $new_data{id};
 
             };
 
@@ -585,7 +585,7 @@ sub update_pr_template {
 sub add_developer {
     my ($dev_json, $author, $ia_hash) = @_;
     # don't add duplicates
-    return $dev_json if $dev_json =~ /$author/ig;
+    return $dev_json if $dev_json && $dev_json =~ /$author/ig;
 
     my $user = $d->rs('User')->find_by_github_login($author);
     my $data;
@@ -601,10 +601,10 @@ sub add_developer {
                 $ia->add_to_users($user) unless ($ia->users->find($user->id) || $user->admin);
             }
 
-            return $dev_json if $dev_json =~ /duck.co\/user\/$ddgc_name/g;
+            return $dev_json if $dev_json && $dev_json =~ /duck.co\/user\/$ddgc_name/g;
         }
 
-        $data = $dev_json? from_json($dev_json) : [];
+        $data = from_json($dev_json) if $dev_json;
 
         my $new_dev = {
             name => $author,

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -210,7 +210,7 @@ sub getIssues{
                     }
                 } 
 
-                if($ia->{developer} && $data->{state} eq 'merged'){
+                if($data->{state} eq 'merged'){
                     $ia->{developer} = add_developer($ia->{developer}, $data->{author}, $ia);
                 }
 
@@ -604,7 +604,7 @@ sub add_developer {
             return $dev_json if $dev_json =~ /duck.co\/user\/$ddgc_name/g;
         }
 
-        $data = from_json($dev_json);
+        $data = $dev_json? from_json($dev_json) : [];
 
         my $new_dev = {
             name => $author,

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -51,7 +51,7 @@ my $gh = Net::GitHub->new(access_token => $token);
 
 my $today = localtime;
 # get last 6 hours of issues
-my $since = $today - (100 * ONE_HOUR);
+my $since = $today - (6 * ONE_HOUR);
 
 # get the GH issues
 sub getIssues{
@@ -75,7 +75,7 @@ sub getIssues{
 		
         # add all the data we care about to an array
 		for my $issue (@issues){
-            $progress->update($line) unless $d->is_live;
+#            $progress->update($line) unless $d->is_live;
             $line++;
 
             # get the IA name from the link in the first comment
@@ -243,7 +243,8 @@ sub getIssues{
 
                 #return 1 if !$is_new_ia;
                 $d->rs('InstantAnswer')->update_or_create({%new_data});
-                warn $new_data{id};
+                
+                #print "ia/view/$new_data{id}\n";
 
             };
 

--- a/sql/1.164/add_devs.pl
+++ b/sql/1.164/add_devs.pl
@@ -1,0 +1,47 @@
+#!/usr/bin/env perl
+
+use strict;
+use FindBin;
+use lib $FindBin::Dir . "/../../lib";
+use DDGC;
+use Data::Dumper;
+use JSON;
+
+my $d = DDGC->new;
+
+my @gh_prs = $d->rs('GitHub::Issue')->search({
+                    'me.isa_pull_request' => 1
+                },
+                {
+                    columns => [ qw/ number / ],
+                    result_class => 'DBIx::Class::ResultClass::HashRefInflator'
+                });
+
+for my $pr (@gh_prs) {
+    if (my $ia_issue = $d->rs('InstantAnswer::Issues')->search({ issue_id => $pr->{number} })->one_row ) {
+
+        if ( ( my $ia = $d->rs('InstantAnswer')->find({ meta_id => $ia_issue->{instant_answer_id} }) ) && ( $ia_issue->{status} eq 'merged' ) ) {
+
+            warn "IA Page: " . $ia->meta_id;
+            
+            unless ($ia->{developer} && ( $ia->{developer} =~ /$ia_issue->{author}/g ) ) {
+               
+                my $data = $ia->{developer} ? from_json($ia->{developer}) : [];
+                
+                warn "JSON dev column before update: " . $ia->{developer};
+
+                my $new_dev = {
+                    name => $ia_issue->{author},
+                    type => 'github',
+                    url => 'https://github.com/' . $ia_issue->{author}
+                };
+
+                push(@{ $data }, $new_dev);
+                $data = to_json($data);
+
+                warn "JSON dev column updated: " . $data;
+                $ia->update({ developer => $data });
+            }
+        }
+    }
+}


### PR DESCRIPTION
Checking for a non null / non empty value for the developer was likely preventing new devs from being added unless the field was filled with developers already.

Thanks!