### PR TITLE
Image upload for admins

### DIFF
--- a/lib/DDGC/Web/Controller/Admin.pm
+++ b/lib/DDGC/Web/Controller/Admin.pm
@@ -47,5 +47,28 @@ sub index :Chained('base') :PathPart('') :Args(0) {
 	$c->stash->{remaining_coupon_count} = $c->d->rs('User::Coupon')->search({ users_id => undef })->count;
 }
 
+sub upload :Chained('base') :PathPart('upload') :Args(0) {
+	my ( $self, $c ) = @_;
+	$c->add_bc('Upload an image');
+	$c->stash->{show} = $c->d->rs('Media')->find( $c->req->params->{show} );
+	my $upload = $c->req->uploads->{image};
+	if ( $upload ) {
+		my $media = $c->d->rs('Media')->create_via_file(
+			$c->user,
+			$upload->tempname,
+			{
+				upload_filename => $upload->filename,
+				content_type => $upload->type
+			}
+		);
+		$c->response->redirect(
+			$c->chained_uri(
+				qw/ Admin upload /,
+				{ show => $media->id },
+			)
+		);
+	}
+}
+
 no Moose;
 __PACKAGE__->meta->make_immutable;

--- a/t/image_upload_basics.t
+++ b/t/image_upload_basics.t
@@ -1,0 +1,105 @@
+use strict;
+use warnings;
+
+# Database setup
+BEGIN {
+    unlink 'ddgc_test.db';
+    $ENV{DDGC_DB_DSN} = 'dbi:SQLite:dbname=ddgc_test.db';
+}
+
+use Test::More;
+use t::lib::DDGC::TestUtils;
+use HTTP::Request::Common;
+use Plack::Test;
+use Plack::Builder;
+use Plack::Session::State::Cookie;
+use Plack::Session::Store::File;
+use File::Temp qw/ tempdir /;
+use JSON::MaybeXS qw/:all/;
+use URI;
+
+use FindBin;
+my $image = $FindBin::Dir . '/../root/static/images/logo.svg';
+my $non_image = $FindBin::Dir . '/../dist.ini';
+
+use DDGC;
+use DDGC::Web;
+
+my $d = DDGC->new;
+t::lib::DDGC::TestUtils::deploy( undef, $d->db );
+
+my $app = builder {
+    enable 'Session',
+        store => Plack::Session::Store::File->new(
+            dir => tempdir,
+        ),
+        state => Plack::Session::State::Cookie->new(
+            secure => 0,
+            httponly => 1,
+            expires => 21600,
+            session_key => 'ddgc_session',
+        );
+    mount '/testutils' => t::lib::DDGC::TestUtils->to_app;
+    mount '/' => DDGC::Web->new->psgi_app;
+};
+
+test_psgi $app => sub {
+    my ( $cb ) = @_;
+
+    my $create_user_and_get_cookie = sub {
+        my $opts = shift;
+
+        my $user_request = $cb->(
+            POST '/testutils/new_user',
+            {
+                username => $opts->{username},
+                ( $opts->{role} ) ? ( role => $opts->{role} ) : (),
+            }
+        );
+        ok( $user_request->is_success, 'Creating a user' );
+
+        my $session_request = $cb->(
+            POST '/testutils/user_session',
+            { username => $opts->{username} }
+        );
+        ok( $session_request->is_success, 'Getting user Cookie' );
+        my $cookie = 'ddgc_session=' . $session_request->content;
+    };
+
+    my $upload_file_request = sub {
+        my $opts = shift;
+        my $file = $opts->{file} || $image;
+        my $filename = $file =~ s/.*\///r;
+
+        $cb->(
+            POST '/admin/upload',
+            Content_Type => 'form-data',
+            Cookie       => $opts->{cookie},
+            Content      => [
+                image => [ $file, $filename ],
+            ],
+        );
+    };
+
+    my $admin_cookie = $create_user_and_get_cookie->( {
+        username => 'imageadminuser',
+        role     => 'admin',
+    } );
+
+    my $user_cookie = $create_user_and_get_cookie->( {
+        username => 'imageuser',
+    } );
+
+    my $user_request = $upload_file_request->({ cookie => $user_cookie });
+    ok( $user_request->is_redirect, 'Upload redirects' );
+    like( $user_request->decoded_content, qr/admin_required/, 'Non-admin cannot upload images' );
+
+    my $admin_request = $upload_file_request->({ cookie => $admin_cookie });
+    ok( $admin_request->is_redirect, 'Upload redirects' );
+    like( $admin_request->decoded_content, qr{/admin/upload\?show=}, 'Admin can upload images' );
+
+    $admin_request = $upload_file_request->({ cookie => $admin_cookie, file => $non_image });
+    is( $admin_request->code, 500, 'Cannot upload non-image files' );
+};
+
+done_testing;

--- a/t/image_upload_basics.t
+++ b/t/image_upload_basics.t
@@ -69,7 +69,7 @@ test_psgi $app => sub {
     my $upload_file_request = sub {
         my $opts = shift;
         my $file = $opts->{file} || $image;
-        my $filename = $file =~ s/.*\///r;
+        my $filename = $opts->{filename} || $file =~ s/.*\///r;
 
         $cb->(
             POST '/admin/upload',
@@ -100,6 +100,9 @@ test_psgi $app => sub {
 
     $admin_request = $upload_file_request->({ cookie => $admin_cookie, file => $non_image });
     is( $admin_request->code, 500, 'Cannot upload non-image files' );
+
+    $admin_request = $upload_file_request->({ cookie => $admin_cookie, file => $non_image, filename => 'image.jpg' });
+    is( $admin_request->code, 500, 'Image file content is verified' );
 };
 
 done_testing;

--- a/templates/admin/index.tx
+++ b/templates/admin/index.tx
@@ -61,6 +61,15 @@
 	<hr class="mg-top--none" />
 	<div class="row gw">
 		<div class="g third">
+			<p><a class="button  full  tall  h1  yellow" href="<: $u('Admin','upload') :>"><i class="icon-eye-open"></i></a></p>
+		</div>
+		<div class="g twothirds">
+			<h3 class="mg-top--small">Upload images</h3>
+		</div>
+	</div>
+	<hr class="mg-top--none" />
+	<div class="row gw">
+		<div class="g third">
 			<p><a class="button  full  tall  h1  darkblue" href="<: $u('Admin::Event','index') :>"><i class="icon-info-sign"></i></a></p>
 		</div>
 		<div class="g twothirds">

--- a/templates/admin/upload.tx
+++ b/templates/admin/upload.tx
@@ -1,0 +1,17 @@
+<form action='/admin/upload' method="post" enctype="multipart/form-data">
+    <p>
+        Select image: <input type="file" name="image" id="image" /><br />
+        <input type="submit" value="Upload" name="submit" />
+    </p>
+</form>
+
+: if $show {
+    <p>
+        <a href="<: $show.url :>">
+            <img src="<: $show.url :>" />
+        </a>
+        <a href="<: $show.url_thumbnail :>">
+            <img src="<: $show.url_thumbnail :>" />
+        </a>
+    </p>
+: }


### PR DESCRIPTION
Cc: @tagawa 

Review notes:
- Image upload link should be available from admin index (/admin)
- Only admins can upload
- Only image files can be uploaded
  - I renamed some random text file to have a jpg extension to verify this
  - This is only loosely related to this PR - this feature was implemented separately aeons ago.