### PR TITLE
Basic IA controller tests

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -1161,10 +1161,7 @@ sub create_ia :Chained('base') :PathPart('create') :Args() {
     my $is_admin;
     my $result = '';
     my $data = $c->req->params->{data}? from_json($c->req->params->{data}) : "";
-    use Data::Dumper;
-    print Dumper $c->req->params;
     my $meta_id = format_id($data->{id});
-    warn $meta_id;
     my $ia = $c->d->rs('InstantAnswer')->find({id => $meta_id}) || $c->d->rs('InstantAnswer')->find({meta_id => $meta_id});
     my $name;
     my $exists;

--- a/t/instant_answer_basics.t
+++ b/t/instant_answer_basics.t
@@ -119,7 +119,7 @@ test_psgi $app => sub {
 
     # Check all_milestones JSON (should have everything)
     my $ia_repo = $get_repo_json->({ repo => 'longtail', all_milestones => 1 });
-    is( ref $ia_repo->{test_ia}, 'HASH', 'Test IA approved - is in all milestone repo JSON' );
+    is( ref $ia_repo->{test_ia}, 'HASH', 'Test IA is in all milestone repo JSON' );
 
     # "Approve" IA
     my $ia_approve_result = $set_ia_value->({ cookie => $cookie, public => 1 });

--- a/t/instant_answer_basics.t
+++ b/t/instant_answer_basics.t
@@ -118,18 +118,9 @@ test_psgi $app => sub {
     ok( $ia, 'Query returns something' );
     is( ref $ia, 'DDGC::DB::Result::InstantAnswer' ,'IA is a Result::InstantAnswer' );
 
-    # "Approve" IA
-    my $ia_approve_request = $cb->(
-        POST '/ia/save',
-        Cookie  => $cookie,
-        Content => [
-            id           => 'test_ia',
-            field        => 'public',
-            value        => 1,
-            action_token => $action_token,
-        ],
-    );
-    ok( $ia_approve_request->is_success, 'IA "Approve" request succeeds' );
+    # Check all_milestones JSON (should have everything)
+    my $ia_repo = $get_repo_json->({ repo => 'longtail', all_milestones => 1 });
+    is( ref $ia_repo->{test_ia}, 'HASH', 'Test IA approved - is in all milestone repo JSON' );
 
     is( $ia->public, 0, 'IA cannot be approved by non-admin' );
 

--- a/t/instant_answer_basics.t
+++ b/t/instant_answer_basics.t
@@ -129,6 +129,18 @@ test_psgi $app => sub {
     $ia->discard_changes;
     is( $ia->public, 1, 'IA Result is now public' );
 
+    # Check repo JSON - test_ia should be absent due to its milestone
+    $ia_repo = $get_repo_json->({ repo => 'longtail' });
+    ok( !$ia_repo->{test_ia}, 'Test IA not in published milestone' );
+
+    # Set IA milestone
+    my $ia_milestone_result = $set_ia_value->({ cookie => $cookie, dev_milestone => 'testing' });
+    is( $ia_milestone_result->{saved}, 1, 'Set test_ia milestone to testing' );
+
+    # Check repo JSON - test_ia should now be present
+    $ia_repo = $get_repo_json->({ repo => 'longtail' });
+    is( ref $ia_repo->{test_ia}, 'HASH', 'Test IA is now in published milestone' );
+
     # Use this when you need to see session data
     # $cb->( GET '/testutils/debug_session' );
 

--- a/t/instant_answer_basics.t
+++ b/t/instant_answer_basics.t
@@ -1,0 +1,108 @@
+use strict;
+use warnings;
+
+# Database setup
+BEGIN {
+    $ENV{DDGC_DB_DSN} = 'dbi:SQLite:dbname=ddgc_test.db';
+}
+
+use Test::More;
+use t::lib::DDGC::TestUtils;
+use HTTP::Request::Common;
+use Plack::Test;
+use Plack::Builder;
+use Plack::Session::State::Cookie;
+use Plack::Session::Store::File;
+use File::Temp qw/ tempdir /;
+use JSON::MaybeXS qw/:all/;
+
+use DDGC;
+use DDGC::Web;
+
+my $d = DDGC->new;
+t::lib::DDGC::TestUtils::deploy( undef, $d->db );
+
+# Application setup and creation
+my $app = builder {
+    enable 'Session',
+        store => Plack::Session::Store::File->new(
+            dir => tempdir,
+        ),
+        state => Plack::Session::State::Cookie->new(
+            secure => 0,
+            httponly => 1,
+            expires => 21600,
+            session_key => 'ddgc_session',
+        );
+    mount '/testutils' => t::lib::DDGC::TestUtils->to_app;
+    mount '/' => DDGC::Web->new->psgi_app;
+};
+
+# Tests - assert things here
+test_psgi $app => sub {
+    my ( $cb ) = @_;
+
+    # Create user
+    my $user_request = $cb->(
+        POST '/testutils/new_user',
+        { username => 'ia_user' }
+    );
+    ok( $user_request->is_success, 'Creating an IA user' );
+
+    # Get session
+    my $session_request = $cb->(
+        POST '/testutils/user_session',
+        { username => 'ia_user' }
+    );
+    ok( $session_request->is_success, 'Getting IA user Cookie' );
+    my $cookie = 'ddgc_session=' . $session_request->content;
+
+    # Retrieve CSRF Token
+    my $action_token = $cb->( GET '/testutils/action_token' )->decoded_content;
+    ok( $action_token && !ref $action_token, 'Have a CSRF token scalar' );
+
+    # Create an IA
+    my $new_ia_req = $cb->(
+        POST '/ia/create',
+        Cookie          => $cookie,
+        Content         => [ data => encode_json( {
+            id            => 'test_ia',
+            name          => 'Test IA',
+            description   => 'This is a test IA',
+            example_query => 'testing IAs',
+            repo          => 'longtail',
+            action_token  => $action_token,
+        } ) ],
+    );
+    ok( $new_ia_req->is_success, 'Creating IA' );
+
+    # Find IA
+    my $ia = $d->rs('InstantAnswer')->find('test_ia');
+    ok( $ia, 'Query returns something' );
+    is( ref $ia, 'DDGC::DB::Result::InstantAnswer' ,'IA is a Result' );
+
+    # "Approve" IA
+    my $ia_approve_request = $cb->(
+        POST '/ia/save',
+        Cookie  => $cookie,
+        Content => [
+            id           => 'test_ia',
+            field        => 'public',
+            value        => 1,
+            action_token => $action_token,
+        ],
+    );
+    ok( $ia_approve_request->is_success, 'IA "Approve" request succeeds' );
+
+    # IA should be in repo JSON
+    my $ia_repo_json_request = $cb->( GET '/ia/repo/all/json?all_milestones=1' );
+    ok( $ia_repo_json_request->is_success, 'Can retrieve longtail JSON' );
+    my $ia_repo = decode_json( $ia_repo_json_request->decoded_content );
+    is( ref $ia_repo->{test_ia}, 'HASH', 'Test IA approved - is in repo JSON' );
+
+    # Use this when you need to see session data
+    # $cb->( GET '/testutils/debug_session' );
+
+};
+
+done_testing;

--- a/t/instant_answer_basics.t
+++ b/t/instant_answer_basics.t
@@ -94,6 +94,8 @@ test_psgi $app => sub {
     );
     ok( $ia_approve_request->is_success, 'IA "Approve" request succeeds' );
 
+    is( $ia->public, 0, 'IA cannot be approved by non-admin' );
+
     # IA should be in repo JSON
     my $ia_repo_json_request = $cb->( GET '/ia/repo/all/json?all_milestones=1' );
     ok( $ia_repo_json_request->is_success, 'Can retrieve longtail JSON' );

--- a/t/instant_answer_basics.t
+++ b/t/instant_answer_basics.t
@@ -7,6 +7,7 @@ BEGIN {
 }
 
 use Test::More;
+use Test::WWW::Mechanize::PSGI;
 use t::lib::DDGC::TestUtils;
 use HTTP::Request::Common;
 use Plack::Test;
@@ -145,5 +146,20 @@ test_psgi $app => sub {
     # $cb->( GET '/testutils/debug_session' );
 
 };
+
+# Some basic backend template checks
+my $mech = Test::WWW::Mechanize::PSGI->new( app => $app );
+
+my $ia = $d->rs('InstantAnswer')->find('test_ia');
+
+$ia->update({ dev_milestone => 'live', perl_module => 'DDG::Longtail::TestIA' });
+$ia->add_to_topics( { name => 'interesting_topic' } );
+
+$mech->get_ok('/ia');
+$mech->content_contains('test_ia');
+
+$mech->get_ok('/ia/view/test_ia');
+$mech->title_is('Test Ia'); # Title case filter
+
 
 done_testing;

--- a/t/instant_answer_basics.t
+++ b/t/instant_answer_basics.t
@@ -115,7 +115,7 @@ test_psgi $app => sub {
     # Find IA
     my $ia = $d->rs('InstantAnswer')->find('test_ia');
     ok( $ia, 'Query returns something' );
-    is( ref $ia, 'DDGC::DB::Result::InstantAnswer' ,'IA is a Result::InstantAnswer' );
+    isa_ok( $ia, 'DDGC::DB::Result::InstantAnswer' );
 
     # Check all_milestones JSON (should have everything)
     my $ia_repo = $get_repo_json->({ repo => 'longtail', all_milestones => 1 });

--- a/t/instant_answer_basics.t
+++ b/t/instant_answer_basics.t
@@ -79,7 +79,7 @@ test_psgi $app => sub {
     # Find IA
     my $ia = $d->rs('InstantAnswer')->find('test_ia');
     ok( $ia, 'Query returns something' );
-    is( ref $ia, 'DDGC::DB::Result::InstantAnswer' ,'IA is a Result' );
+    is( ref $ia, 'DDGC::DB::Result::InstantAnswer' ,'IA is a Result::InstantAnswer' );
 
     # "Approve" IA
     my $ia_approve_request = $cb->(

--- a/t/lib/DDGC/TestUtils.pm
+++ b/t/lib/DDGC/TestUtils.pm
@@ -17,9 +17,11 @@ sub deploy {
                     add_drop_table => $opts->{drop} || 0
                 });
             }
-            DDGC::Schema->connect($ENV{DDGC_DB_DSN})->deploy({
-                add_drop_table => $opts->{drop} || 0
-            });
+            else {
+                DDGC::Schema->connect($ENV{DDGC_DB_DSN})->deploy({
+                    add_drop_table => $opts->{drop} || 0
+                });
+            }
         }
     }
     catch {

--- a/t/lib/DDGC/TestUtils.pm
+++ b/t/lib/DDGC/TestUtils.pm
@@ -99,4 +99,8 @@ get '/debug_session' => sub {
     return 1;
 };
 
+get '/action_token' => sub {
+    return session('action_token');
+};
+
 1;

--- a/t/lib/DDGC/TestUtils.pm
+++ b/t/lib/DDGC/TestUtils.pm
@@ -10,6 +10,8 @@ sub deploy {
     my $success = 1;
     try {
         if ($ENV{DDGC_DB_DSN} =~ /^dbi:SQLite/) {
+            my $fn = $ENV{DDGC_DB_DSN} =~ s/.*dbname=(.*)/$1/r;
+            unlink $fn if $fn;
             if ( $schema ) {
                 $schema->deploy({
                     add_drop_table => $opts->{drop} || 0


### PR DESCRIPTION
Cc: @MariagraziaAlastra @russellholt 

Here is a very basic IA flow (create a new IA, verify it exists in database) which should demonstrate:

- DB schema rollout
- Plack test app creation (with testutils session integration)
- How to create and get a session for a user of a given class.
- How to test things with CSRF mitigation.
- The most basic of [Test::More](https://metacpan.org/pod/Test::More) assertions (read this doc).

Thanks to @MariagraziaAlastra for help navigating the instant_answer controller.