### PR TITLE
Test::Perl::Critic - security and bugs theme

### DIFF
--- a/t/perlcritic.t
+++ b/t/perlcritic.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use File::Spec;
+use Test::More;
+use English qw(-no_match_vars);
+
+if ( not $ENV{TEST_AUTHOR} ) {
+    my $msg = 'Author test.  Set $ENV{TEST_AUTHOR} to a true value to run.';
+    plan( skip_all => $msg );
+}
+
+eval { require Test::Perl::Critic; };
+
+if ( $EVAL_ERROR ) {
+   my $msg = 'Test::Perl::Critic required to criticise code';
+   plan( skip_all => $msg );
+}
+
+my $rcfile = File::Spec->catfile( 't', 'perlcriticrc' );
+Test::Perl::Critic->import( -profile => $rcfile );
+all_critic_ok();
+

--- a/t/perlcriticrc
+++ b/t/perlcriticrc
@@ -1,0 +1,1 @@
+theme = security && bugs


### PR DESCRIPTION
Cc: @nilnilnil @russellholt 

We fail at PBP in this project, so the scope here is limited to checking for common security issues and bugs.

...though this adds almost 2 minutes to test runtime in development

```
$ time TEST_AUTHOR=1 prove -Ilib
t/perlcritic.t

t/perlcritic.t .. ok     
All tests successful.
Files=1, Tests=249, 100 wallclock secs ( 0.10 usr  0.01 sys + 147.82 cusr  0.34 csys = 148.27 CPU)
Result: PASS

real    1m40.447s
user    2m27.989s
sys     0m0.356s
```

These are the applied policies:

```
$ perlcritic --list | grep -E 'security|bugs'
5 BuiltinFunctions::ProhibitSleepViaSelect [bugs core pbp]
5 BuiltinFunctions::ProhibitStringyEval [bugs certrule core pbp]
4 BuiltinFunctions::RequireBlockGrep [bugs core pbp]
4 BuiltinFunctions::RequireBlockMap [bugs core pbp]
5 BuiltinFunctions::RequireGlobFunction [bugs core pbp]
5 ClassHierarchies::ProhibitOneArgBless [bugs core pbp]
4 CodeLayout::RequireConsistentNewlines [bugs core]
4 ControlStructures::ProhibitLabelsWithSpecialBlockNames [bugs core]
5 ControlStructures::ProhibitMutatingListFunctions [bugs certrule core pbp]
4 ControlStructures::ProhibitUnreachableCode [bugs certrec core]
3 ErrorHandling::RequireCheckingReturnValueOfEval [bugs core]
5 InputOutput::ProhibitBarewordFileHandles [bugs certrec core pbp]
5 InputOutput::ProhibitInteractiveTest [bugs certrule core pbp]
4 InputOutput::ProhibitOneArgSelect [bugs certrule core pbp]
4 InputOutput::ProhibitReadlineInForLoop [bugs core pbp]
5 InputOutput::ProhibitTwoArgOpen [bugs certrule core pbp security]
5 InputOutput::RequireEncodingWithUTF8Layer [bugs core security]
4 Modules::ProhibitAutomaticExportation [bugs core]
3 Modules::ProhibitConditionalUseStatements [bugs core]
5 Modules::ProhibitEvilModules [bugs certrule core]
4 Modules::ProhibitMultiplePackages [bugs core]
4 Modules::RequireEndWithOne [bugs certrule core pbp]
4 Modules::RequireExplicitPackage [bugs core]
5 Modules::RequireFilenameMatchesPackage [bugs core]
4 Subroutines::ProhibitBuiltinHomonyms [bugs certrule core pbp]
5 Subroutines::ProhibitExplicitReturnUndef [bugs certrec core pbp]
5 Subroutines::ProhibitNestedSubs [bugs core]
5 Subroutines::ProhibitReturnSort [bugs certrule core]
5 Subroutines::ProhibitSubroutinePrototypes [bugs certrec core pbp]
4 Subroutines::RequireFinalReturn [bugs certrec core pbp]
5 TestingAndDebugging::ProhibitNoStrict [bugs certrec core pbp]
4 TestingAndDebugging::ProhibitNoWarnings [bugs certrec core pbp]
4 TestingAndDebugging::ProhibitProlongedStrictureOverride [bugs certrec core pbp]
5 TestingAndDebugging::RequireUseStrict [bugs certrec certrule core pbp]
4 TestingAndDebugging::RequireUseWarnings [bugs certrule core pbp]
4 ValuesAndExpressions::ProhibitCommaSeparatedStatements [bugs certrule core pbp]
4 ValuesAndExpressions::ProhibitConstantPragma [bugs core pbp]
5 ValuesAndExpressions::ProhibitLeadingZeros [bugs certrec core pbp]
3 ValuesAndExpressions::ProhibitMismatchedOperators [bugs certrule core]
4 ValuesAndExpressions::ProhibitMixedBooleanOperators [bugs certrec core pbp]
4 Variables::ProhibitAugmentedAssignmentInDeclaration [bugs core]
5 Variables::ProhibitConditionalDeclarations [bugs core]
3 Variables::ProhibitReusedNames [bugs core]
3 Variables::RequireInitializationForLocalVars [bugs certrec core pbp]
5 Variables::RequireLexicalLoopIterators [bugs certrec core pbp]
4 Variables::RequireLocalizedPunctuationVars [bugs certrec core pbp]
```
