### PR TITLE
Fix blog title on post pages

### DIFF
--- a/lib/DDGC/Schema/Result/Comment.pm
+++ b/lib/DDGC/Schema/Result/Comment.pm
@@ -72,6 +72,10 @@ column context_id => {
     is_nullable => 0,
 };
 
+column ghosted => {
+    data_type => 'int',
+};
+
 belongs_to 'user',     'DDGC::Schema::Result::User',    'users_id';
 has_many   'children', 'DDGC::Schema::Result::Comment', 'parent_id';
 belongs_to 'parent',   'DDGC::Schema::Result::Comment', 'parent_id';

--- a/lib/DDGC/Web/App/Blog.pm
+++ b/lib/DDGC/Web/App/Blog.pm
@@ -81,12 +81,12 @@ get '/post/:id/:uri' => sub {
     my $post = rset('User::Blog')->single_post_ref( $params->{id} );
     if ( $post->{post} ) {
         if ( $post->{post}->{uri} ne $params->{uri} ) {
-            redirect '/post/' . $post->{id} . '/' . $post->{uri};
+            redirect '/post/' . $post->{post}->{id} . '/' . $post->{post}->{uri};
         }
-
+        use DDP; p $post;
         template 'blog/index', {
             %{ $post },
-            title => join ' : ', ( title, $post->{title} ),
+            title => join ' : ', ( title, $post->{post}->{title} ),
         };
     }
     else {

--- a/lib/DDGC/Web/App/Blog.pm
+++ b/lib/DDGC/Web/App/Blog.pm
@@ -74,7 +74,6 @@ get '/topic/:topic' => sub {
 
 get '/post/:id/:uri' => sub {
     my $params = params('route');
-    my $post;
     # Since we have a login prompt on this page, set last_url
     # TODO: Make this happen for everything (in login handler?)
     session last_url => request->env->{REQUEST_URI};

--- a/t/blog.t
+++ b/t/blog.t
@@ -16,10 +16,12 @@ use File::Temp qw/ tempdir /;
 use JSON::MaybeXS qw/:all/;
 use HTML::TreeBuilder::LibXML;
 
+use DDGC;
 use DDGC::Web::App::Blog;
 use DDGC::Web::Service::Blog;
 
-
+my $d = DDGC->new;
+t::lib::DDGC::TestUtils::deploy( { drop => 1 }, $d->db );
 
 my $app = builder {
     enable 'Session',

--- a/t/blog.t
+++ b/t/blog.t
@@ -60,6 +60,8 @@ test_psgi $app => sub {
         teaser      => 'This is a blog post karble warble snarble',
         content     => 'This is a blog post',
         topics      => [qw/blogs posts this/],
+        live        => 1,
+        company_blog => 1,
     });
 
     my $new_post_request = $cb->(

--- a/t/blog.t
+++ b/t/blog.t
@@ -76,6 +76,8 @@ test_psgi $app => sub {
         Content         => $blog_post,
     );
     ok( $new_post_request->is_success, "Admin user can create blog post" );
+
+    use DDP ; p $new_post_request;
 };
 
 done_testing;


### PR DESCRIPTION
##### Description :

This change restores the post title to the `<title>` tag of blog posts. It also demonstrates a method for verifying an element of a HTML page using [HTML::TreeBuilder::LibXML](https://metacpan.org/pod/HTML::TreeBuilder::LibXML). It also attempts to demonstrate usage of the proposed pull request template.

##### Reviewer notes :

The title of the blog post should be shown in the tab / browser window title when viewing a single blog post.

Run tests with:

`$ prove -Ilib t/blog.t`

##### References issues / PRs:

#1325 - Blog posts missing title
#1334 - Basic PR template to help guide verification process 

##### Who should be informed of this change?

@nilnilnil is probably getting bored of these

##### Does this change have significant privacy, security, performance or deployment implications?

No.

##### Checklist :
- [x] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration) - **N/A**
- Browser verification
    - [x] IE
    - [x] Chrome
    - [x] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android