### PR TITLE
fix traffic graph

### DIFF
--- a/lib/DDGC/DB/ResultSet/InstantAnswer/Traffic.pm
+++ b/lib/DDGC/DB/ResultSet/InstantAnswer/Traffic.pm
@@ -4,29 +4,5 @@ package DDGC::DB::ResultSet::InstantAnswer::Traffic;
 use Moose;
 extends 'DDGC::DB::Base::ResultSet';
 use namespace::autoclean;
-
-sub get_array_by_pixel {
-    my ($self, $type) = @_;
-    my @counts = $self->get_column('count')->all;
-    my @dates = $self->get_column('date')->all;
-    my @int_counts;
-
-    # to int and sum the two types
-    for(my $i = 0; $i < scalar @counts-1; $i++) {
-        my $total = $counts[$i] + $counts[$i+1];
-        push(@int_counts, $total + 0); 
-        $i++
-    }
-
-    my @combined_dates;
-    # combine dates
-    for(my $i = 0; $i < scalar @dates-1; $i++){
-        push(@combined_dates, $dates[$i]);
-        $i++;
-    }
-
-    return {dates => \@combined_dates, counts => \@int_counts};
- }
-
 1;
 

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -765,14 +765,17 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
             my $traffic_rs = $c->d->rs('InstantAnswer::Traffic')->search(
                 {
                     answer_id => $ia->meta_id, 
-                    date => { '<' => $last_monday->date()}, 
-                    date => { '>' => $month_ago},
-                    pixel_type => [qw( iaoi iaoe )],
+                    date => { '<' => $last_monday->date(), '>' => $month_ago},
+                    pixel_type => [qw/ iaoi iaoe /]
                 },
                 {
-                    order_by => [qw( date )]
+                    select => [{'date', { sum => 'count' } }],
+                    group_by => [qw/ date /]
                 });
-            
+
+            use Data::Dumper;
+            warn Dumper $traffic_rs->as_query();
+
             my $iaoi = $traffic_rs->get_array_by_pixel();
             $ia_data{live}->{traffic} = $iaoi;
         }

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -760,26 +760,23 @@ sub ia_json :Chained('ia_base') :PathPart('json') :Args(0) {
             my $weekdays = 7;
             
             # Traffic data is updated on Mondays
-            my $last_monday = $today->subtract(days => ($today->day_of_week - $monday) %$weekdays || $weekdays);
-            my $month_ago = $last_monday->clone->subtract( days => 30 )->date();
-            my @traffic_rs = $c->d->rs('InstantAnswer::Traffic')->search({},
+            my $last_monday = $today->subtract(days => ($today->day_of_week - $monday) % $weekdays || $weekdays);
+            my $month_ago = $last_monday->clone->subtract( days => 31 )->date();
+
+            my $traffic_rs = $c->d->rs('InstantAnswer::Traffic')->search({},
                 {
-                    select => ["date", {sum => 'count', -as => 'total'} ],
+                    select => ["date", {sum => 'me.count', -as => 'total'} ],
                     where => [{
                             answer_id => $ia->meta_id, 
-                            date => { '<' => $last_monday->date(), '>' => $month_ago},
+                            date => { '<=' => $last_monday->date(), '>=' => $month_ago},
                             pixel_type => [qw/ iaoi iaoe /]
                         }],
-                    group_by => ["date", "count"],
-                    order_by => ["date"],
-                    result_class => 'DBIx::Class::ResultClass::HashRefInflator',
+                    group_by => ["me.date"],
+                    order_by => ["me.date"],
                 });
-
-            use Data::Dumper;
-            warn Dumper @traffic_rs;
-
-            # my $iaoi = $traffic_rs->get_array_by_pixel();
-            #$ia_data{live}->{traffic} = $iaoi;
+            my @dates = $traffic_rs->get_column('date')->all;
+            my @totals = $traffic_rs->get_column('total')->all;
+            $ia_data{live}->{traffic} = {dates => \@dates, counts => \@totals};
         }
     }
 

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -1783,7 +1783,7 @@
             var sum = 0;
 
             $.each(counts, function(idx) {
-                sum += counts[idx];
+                sum += parseInt(counts[idx], 10);
             });
 
             return sum;


### PR DESCRIPTION
The previous dbix query wasn't exactly getting us the right data for the pixel graphs.  It also needed an awkward `get_array_by_pixel` helper function.  So why not just do it all in the sql query, right?

I also update the date calculation to get us 30 days instead of the 28 days we're getting right now. 

Some before and after examples:
https://duck.co/ia/view/latex
Before
![selection_334](https://cloud.githubusercontent.com/assets/1882892/14687091/bac87082-0709-11e6-8db8-ed61cb1456e6.jpg)
After
![selection_333](https://cloud.githubusercontent.com/assets/1882892/14687094/c05b1bda-0709-11e6-97e3-9b29a1eb4411.jpg)

https://duck.co/ia/view/airlines
Before
![selection_332](https://cloud.githubusercontent.com/assets/1882892/14687107/d102805e-0709-11e6-9acb-5a020734cb49.jpg)

After
![selection_331](https://cloud.githubusercontent.com/assets/1882892/14687123/e12d0580-0709-11e6-8145-b7de27d4668c.jpg)


