### PR TITLE
Add frontend integration tests 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
   - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
   - npm install grunt --save-dev
+  - npm install load-grunt-tasks
   - npm install -g grunt-cli casperjs
 language: perl
 perl:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,9 @@ install:
   - cpanm  --quiet  --notest --skip-installed Dist::Zilla
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
   - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
-  - cpanm Plack::Loader
   - npm install grunt-cli
   - npm install
   - bower install
-  - export PATH=$PERLBREW_PATH:$PATH
 language: perl
 perl:
   - 5.16

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ addons:
     - libxml2-dev
     - libpango1.0-dev
     - imagemagick
-    - node
 before_install:
   - export HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
   - git config --global user.name "Dist Zilla Plugin TravisCI"
@@ -31,6 +30,8 @@ install:
 language: perl
 perl:
   - 5.16
+node_js:
+  - 4.2
 script:
   - dzil smoke --release --author
   - grunt test-ia

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - cpanm  --quiet  --notest --skip-installed Dist::Zilla
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
   - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
-  - npm install -g
+  - npm install
   - npm install grunt
 language: perl
 perl:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 cache:
   directories:
     - $HOME/.cpanm
-    - $HOME/perl5/perlbrew/perls/5.16/lib/site_perl
+    - $HOME/perl5
     - /var/tmp
     - $HOME/.nvm
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
     - $HOME/.cpanm
     - $HOME/perl5/perlbrew/perls/5.16/lib/site_perl
     - /var/tmp
+    - $HOME/.nvm
 addons:
   apt:
     packages:
@@ -24,7 +25,6 @@ install:
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
   - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
   - npm install -g grunt-cli casperjs
-  - bower install
 language: perl
 perl:
   - 5.16

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,4 @@ perl:
   - 5.16
 script:
   - dzil smoke --release --author
+  - grunt test-ia

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ install:
   - npm install grunt-cli
   - npm install
   - bower install
-  - export PATH=$PATH:node_modules/phantomjs/lib/phantom/bin
+  - exporport PATH=$PERLBREW_PATH:$PATH
+  - export PATH=$HOME/perl5/perlbrew/bin:$PATH
 language: perl
 perl:
   - 5.16

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
   - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
   - find /home/travis/perl5 -name plackup
+  - npm cache clean
   - npm install
 language: perl
 perl:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
   - cpanm  --quiet  --notest --skip-installed Dist::Zilla
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
   - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
+  - npm install grunt --save-dev
   - npm install -g grunt-cli casperjs
 language: perl
 perl:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,5 @@ perl:
 node_js:
   - 4.2
 script:
-  - dzil smoke --release --author
+  - prove -lr -j1 t
   - grunt test-ia

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
     - libxml2-dev
     - libpango1.0-dev
     - imagemagick
+    - node
 before_install:
   - export HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
   - git config --global user.name "Dist Zilla Plugin TravisCI"
@@ -23,6 +24,10 @@ install:
   - cpanm  --quiet  --notest --skip-installed Dist::Zilla
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
   - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
+  - npm install grunt-cli
+  - npm install
+  - bower install
+  - export PATH=$PATH:node_modules/phantomjs/lib/phantom/bin
 language: perl
 perl:
   - 5.16

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ install:
   - npm install grunt-cli
   - npm install
   - bower install
-  - exporport PATH=$PERLBREW_PATH:$PATH
-  - export PATH=$HOME/perl5/perlbrew/bin:$PATH
+  - export PATH=$PERLBREW_PATH:$PATH
 language: perl
 perl:
   - 5.16

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,7 @@ install:
   - cpanm  --quiet  --notest --skip-installed Dist::Zilla
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
   - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
-  - npm install grunt-cli
-  - npm install
+  - npm install -g grunt-cli casperjs
   - bower install
 language: perl
 perl:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
   - cpanm  --quiet  --notest --skip-installed Dist::Zilla
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
   - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
+  - cpanm Plack::Loader
   - npm install grunt-cli
   - npm install
   - bower install

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,8 @@ install:
   - cpanm  --quiet  --notest --skip-installed Dist::Zilla
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
   - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
-  - npm install grunt --save-dev
-  - npm install load-grunt-tasks
-  - npm install -g grunt-cli casperjs
+  - npm install -g
+  - npm install grunt
 language: perl
 perl:
   - 5.16

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
   - cpanm  --quiet  --notest --skip-installed Dist::Zilla
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
   - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
+  - find /home/travis/perl5 -name plackup
   - npm install
 language: perl
 perl:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ install:
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
   - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org/
   - npm install
-  - npm install grunt
 language: perl
 perl:
   - 5.16

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,6 +18,11 @@ module.exports = function(grunt) {
     var moment = 'bower_components/moment/min/moment.min.js';
     var charts = 'bower_components/Chart.js/Chart.min.js';
 
+    // Tasks running when testing.
+    var test_tasks = [
+        'exec:tests'
+    ];
+
     // Tasks that run when releasing.
     var release_tasks = [
 	'gitrm:old_releases',
@@ -272,7 +277,8 @@ module.exports = function(grunt) {
             revert_release: "./script/revert_pkg_version.pl release",
             deleteBuildFiles: "mkdir -p build && rm -r build",
             bower: "bower install",
-	    commit_static: "git add root/static/* package.json && git commit -m 'Release IA pages version: <%= pkg.version %>'",
+	        commit_static: "git add root/static/* package.json && git commit -m 'Release IA pages version: <%= pkg.version %>'",
+            tests: 'casperjs test src/t/ia/. --hostname=' + (grunt.option('hostname') || 'ddgc-staging')
         },
 
 	// Build again if any of the JS / SCSS files changed.
@@ -321,6 +327,7 @@ module.exports = function(grunt) {
 
     });
 
+    grunt.registerTask('test-ia', 'Integration tests for IA Pages.', test_tasks);
     grunt.registerTask('release', 'Same as build but creates versioned JS and CSS files.', release_tasks);
     grunt.registerTask('build', 'Compiles templates, builds JS and CSS files.', build_tasks);
     grunt.registerTask('build_release', 'Compiles templates, builds JS and CSS files for release.', build_tasks_release);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -278,7 +278,7 @@ module.exports = function(grunt) {
             deleteBuildFiles: "mkdir -p build && rm -r build",
             bower: "bower install",
 	        commit_static: "git add root/static/* package.json && git commit -m 'Release IA pages version: <%= pkg.version %>'",
-            tests: "src/t/run.sh"
+            tests: "src/t/run.bash"
         },
 
 	// Build again if any of the JS / SCSS files changed.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -278,7 +278,7 @@ module.exports = function(grunt) {
             deleteBuildFiles: "mkdir -p build && rm -r build",
             bower: "bower install",
 	        commit_static: "git add root/static/* package.json && git commit -m 'Release IA pages version: <%= pkg.version %>'",
-            tests: 'casperjs test src/t/ia/. --hostname=' + (grunt.option('hostname') || 'ddgc-staging')
+            tests: "src/t/run.sh"
         },
 
 	// Build again if any of the JS / SCSS files changed.

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,8 @@
     "duckduckgo-colors": "duckduckgo/duckduckgo-colors#v0.0.1",
     "duckduckgo-styles": "duckduckgo/duckduckgo-styles#1.0.14",
     "moment": "~2.10.6",
-    "compass-sass-mixins": "*"
+    "compass-sass-mixins": "*",
+    "casperjs": "casperjs#1.1.0"
   },
   "homepage": "https://github.com/duckduckgo/community-platform",
   "description": "Frontend files for duck.co",

--- a/cpanfile
+++ b/cpanfile
@@ -132,3 +132,5 @@ requires 'Cache::FastMmap', '1.40';
 requires 'HTML::FormatText::WithLinks', '0.15';
 requires 'Cache::LRU', '0.04';
 requires 'Number::Format', '1.73';
+requires 'Starman', '0.4009';
+

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "grunt-sass": "^1.1.0",
     "grunt-version": "~0.2.2",
     "load-grunt-tasks": "^3.3.0",
-    "phantomjs-prebuilt": "1.9.8",
+    "phantomjs": "1.9.8",
     "bower": "1.7.7",
     "casperjs": "1.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "grunt-remove-logging": "^0.2.0",
     "grunt-sass": "^1.1.0",
     "grunt-version": "~0.2.2",
-    "load-grunt-tasks": "^3.3.0"
+    "load-grunt-tasks": "^3.3.0",
+    "phantomjs": "1.9.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "grunt-sass": "^1.1.0",
     "grunt-version": "~0.2.2",
     "load-grunt-tasks": "^3.3.0",
-    "phantomjs": "1.9.8"
+    "phantomjs": "1.9.8",
+    "bower": "1.7.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "grunt-sass": "^1.1.0",
     "grunt-version": "~0.2.2",
     "load-grunt-tasks": "^3.3.0",
-    "phantomjs": "1.9.8",
+    "phantomjs-prebuilt": "1.9.8",
     "bower": "1.7.7",
     "casperjs": "1.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "grunt-version": "~0.2.2",
     "load-grunt-tasks": "^3.3.0",
     "phantomjs": "1.9.8",
-    "bower": "1.7.7"
+    "bower": "1.7.7",
+    "casperjs": "1.1.0"
   }
 }

--- a/script/ddgc_deploy_test_db.pl
+++ b/script/ddgc_deploy_test_db.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{DDGC_DB_DSN} = 'dbi:SQLite:dbname=ddgc_test.db';
+}
+
+if ( -f 'ddgc_test.db' ) {
+    printf "Test db exists, exiting...\n";
+    exit 1;
+}
+
+use FindBin;
+use lib $FindBin::Dir . "/../lib";
+
+use DDGC;
+use DDGC::DB;
+DDGC::DB->connect( DDGC->new )->deploy;
+

--- a/src/t/config.json
+++ b/src/t/config.json
@@ -1,0 +1,18 @@
+{
+    ia_types: [
+        'goodies',
+        'spice',
+        'longtail',
+        'fathead'
+    ],
+
+    dev_admin: {
+        username: 'TestOne',
+        password: 'asd'
+   },
+
+   dev_user: {
+        username: 'TestTwo',
+        password: 'asd'
+   }
+}

--- a/src/t/config.json
+++ b/src/t/config.json
@@ -1,18 +1,18 @@
 {
-    ia_types: [
-        'goodies',
-        'spice',
-        'longtail',
-        'fathead'
+    "ia_types": [
+        "goodies",
+        "spice",
+        "longtail",
+        "fathead"
     ],
 
-    dev_admin: {
-        username: 'TestOne',
-        password: 'asd'
+    "dev_admin": {
+        "username": "TestOne",
+        "password": "asd"
    },
 
-   dev_user: {
-        username: 'TestTwo',
-        password: 'asd'
+   "dev_user": {
+        "username": "TestTwo",
+        "password": "asd"
    }
 }

--- a/src/t/ia/index.js
+++ b/src/t/ia/index.js
@@ -9,10 +9,11 @@ var config = require("../config.json"),
 
 
 casper.test.begin("IA Index", function suite(test) {
-    casper.start("http://" + hostname + ".duckduckgo.com:5001/ia", function(response) {
+    casper.start("http://" + hostname + ":5001/ia", function(response) {
         // we don't really support mobile yet
         casper.viewport(1336, 768).then(function() {
             this.reload(function() {
+                test.comment("hostname: " + hostname);
 
                 test.comment("Check existence of basic elements in the page")
                 test.assertExists(NAVBAR);

--- a/src/t/ia/index.js
+++ b/src/t/ia/index.js
@@ -13,7 +13,6 @@ casper.test.begin("IA Index", function suite(test) {
         // we don't really support mobile yet
         casper.viewport(1336, 768).then(function() {
             this.reload(function() {
-                test.comment("hostname: " + hostname);
 
                 test.comment("Check existence of basic elements in the page")
                 test.assertExists(NAVBAR);

--- a/src/t/ia/index.js
+++ b/src/t/ia/index.js
@@ -1,21 +1,38 @@
+var config = require("../config.json"),
+    hostname = casper.cli.get('hostname');
+
+    NAVBAR = ".developer-nav",
+    IA_LIST = "#ia_index",
+    FILTERS = "#filters",
+    REPO_FILTER = "#ia_repo-",
+    REPO_IA = ".ia-item > .ia_repo-";
+
+
 casper.test.begin("IA Index", function suite(test) {
-    casper.start("http://maria.duckduckgo.com:5001/ia", function(response) {
+    casper.start("http://" + hostname + ".duckduckgo.com:5001/ia", function(response) {
         // we don't really support mobile yet
         casper.viewport(1336, 768).then(function() {
             this.reload(function() {
 
                 test.comment("Check existence of basic elements in the page")
-                test.assertExists(".developer-nav");
-                test.assertExists("#ia_index");
-                test.assertExists("#filters");
+                test.assertExists(NAVBAR);
+                test.assertExists(IA_LIST);
+                test.assertExists(FILTERS);
 
+                for (var i = 0; i < config.ia_types.length; i++) {
+                    var current_type = config.ia_types[i];
+                    test.comment("Test filtering by type - " + current_type);
+                    this.click(REPO_FILTER + current_type);
 
-                test.comment("Test filtering by type - Goodies");
-                this.click("#ia_repo-goodies");
+                    test.assertVisible(REPO_IA + current_type, current_type + " type visible after filtering");
 
-                test.assertVisible(".ia-item > .ia_repo-goodies", "Goodies are visible after filtering");
-                test.assertNotVisible(".ia-item > .ia_repo-spice", "Spices are hidden after filtering");
-
+                    for (var j = 0; j < config.ia_types.length; j++) {
+                        if (j !== i) {
+                            var unselected_type = config.ia_types[j];
+                            test.assertNotVisible(REPO_IA + unselected_type, unselected_type + " type hidden after filtering");
+                        }
+                    }
+                }
           });
        });
     });

--- a/src/t/ia/index.js
+++ b/src/t/ia/index.js
@@ -10,6 +10,7 @@ var config = require("../config.json"),
 
 casper.test.begin("IA Index", function suite(test) {
     casper.start("http://" + hostname + "/ia", function(response) {
+        test.assertEquals(200, response.status);
         // we don't really support mobile yet
         casper.viewport(1336, 768).then(function() {
             this.reload(function() {

--- a/src/t/ia/index.js
+++ b/src/t/ia/index.js
@@ -8,7 +8,7 @@ page.open('https://maria.duckduckgo.com:5001/ia', function(status) {
 
 
 casper.test.begin('IA Index', function suite(test) {
-    casper.start("http://duck.co/ia", function(response) {
+    casper.start("https://www.github.com", function(response) {
         casper.viewport(1336, 768).then(function() {
             this.reload(function() {
 

--- a/src/t/ia/index.js
+++ b/src/t/ia/index.js
@@ -1,17 +1,18 @@
-var page = require('webpage').create();
+/*var page = require('webpage').create();
 
 page.open('https://maria.duckduckgo.com:5001/ia', function(status) {
     console.log(page.content);
     phantom.exit();
 });
+*/
 
 
-
-/*
 casper.test.begin('IA Index', function suite(test) {
-    casper.start("http://duck.co/ia", function() {
+    casper.start("http://duck.co/ia", function(response) {
         casper.viewport(1336, 768).then(function() {
             this.reload(function() {
+
+            require('utils').dump(response);
    
             casper.echo(this.fetchText('h2'));
 
@@ -42,8 +43,6 @@ casper.test.begin('IA Index', function suite(test) {
     });
 });
 
-i
 
 
 
-*/

--- a/src/t/ia/index.js
+++ b/src/t/ia/index.js
@@ -1,44 +1,19 @@
-/*var page = require('webpage').create();
-
-page.open('https://maria.duckduckgo.com:5001/ia', function(status) {
-    console.log(page.content);
-    phantom.exit();
-});
-*/
-
-
-casper.test.begin('IA Index', function suite(test) {
-    casper.start("https://www.github.com", function(response) {
+casper.test.begin("IA Index", function suite(test) {
+    casper.start("http://maria.duckduckgo.com:5001/ia", function(response) {
+        // we don't really support mobile yet
         casper.viewport(1336, 768).then(function() {
             this.reload(function() {
 
-            require('utils').dump(response);
-   
-            casper.echo(this.fetchText('h2'));
+                // check basic elements exist
+                test.assertExists(".developer-nav");
+                test.assertExists("#ia_index");
+                test.assertExists("#filters");
 
-            casper.echo(this.getPageContent());
-
-            casper.echo(this.userAgent());
-
-         });
-         });
-            
-    });
-        
-    casper.on('page.resource.received', function(requestData, request) {
-        casper.echo(JSON.stringify(requestData));
-    });
-
-    casper.then(function() {
-        this.echo(this.getHTML());
-    });
-    
-    casper.then(function() {
-            test.pass('Test');
+          });
+       });
     });
 
     casper.run(function() {
-        suite();
         test.done()
     });
 });

--- a/src/t/ia/index.js
+++ b/src/t/ia/index.js
@@ -14,6 +14,8 @@ casper.test.begin("IA Index", function suite(test) {
         casper.viewport(1336, 768).then(function() {
             this.reload(function() {
 
+                test.comment(hostname);
+
                 test.comment("Check existence of basic elements in the page")
                 test.assertExists(NAVBAR);
                 test.assertExists(IA_LIST);

--- a/src/t/ia/index.js
+++ b/src/t/ia/index.js
@@ -9,7 +9,7 @@ var config = require("../config.json"),
 
 
 casper.test.begin("IA Index", function suite(test) {
-    casper.start("http://" + hostname + ":5001/ia", function(response) {
+    casper.start("http://" + hostname + "/ia", function(response) {
         // we don't really support mobile yet
         casper.viewport(1336, 768).then(function() {
             this.reload(function() {

--- a/src/t/ia/index.js
+++ b/src/t/ia/index.js
@@ -1,0 +1,49 @@
+var page = require('webpage').create();
+
+page.open('https://maria.duckduckgo.com:5001/ia', function(status) {
+    console.log(page.content);
+    phantom.exit();
+});
+
+
+
+/*
+casper.test.begin('IA Index', function suite(test) {
+    casper.start("http://duck.co/ia", function() {
+        casper.viewport(1336, 768).then(function() {
+            this.reload(function() {
+   
+            casper.echo(this.fetchText('h2'));
+
+            casper.echo(this.getPageContent());
+
+            casper.echo(this.userAgent());
+
+         });
+         });
+            
+    });
+        
+    casper.on('page.resource.received', function(requestData, request) {
+        casper.echo(JSON.stringify(requestData));
+    });
+
+    casper.then(function() {
+        this.echo(this.getHTML());
+    });
+    
+    casper.then(function() {
+            test.pass('Test');
+    });
+
+    casper.run(function() {
+        suite();
+        test.done()
+    });
+});
+
+i
+
+
+
+*/

--- a/src/t/ia/index.js
+++ b/src/t/ia/index.js
@@ -4,10 +4,17 @@ casper.test.begin("IA Index", function suite(test) {
         casper.viewport(1336, 768).then(function() {
             this.reload(function() {
 
-                // check basic elements exist
+                test.comment("Check existence of basic elements in the page")
                 test.assertExists(".developer-nav");
                 test.assertExists("#ia_index");
                 test.assertExists("#filters");
+
+
+                test.comment("Test filtering by type - Goodies");
+                this.click("#ia_repo-goodies");
+
+                test.assertVisible(".ia-item > .ia_repo-goodies", "Goodies are visible after filtering");
+                test.assertNotVisible(".ia-item > .ia_repo-spice", "Spices are hidden after filtering");
 
           });
        });

--- a/src/t/run.bash
+++ b/src/t/run.bash
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export PIDFILE="/tmp/ddgc-$(date --iso-8601=seconds).pid"
 grunt
-DDGC_DB_DSN="dbi:SQLite:dbname=ddgc_test.db" plackup --host 127.0.0.1 -p 3000 -s Starman -D script/ddgc_dev_server.psgi --workers=5
+DDGC_DB_DSN="dbi:SQLite:dbname=ddgc_test.db" plackup --host 127.0.0.1 -p 3000 -s Starman -D --pid $PIDFILE script/ddgc_dev_server.psgi
 casperjs test src/t/ia/. --hostname=127.0.0.1:3000
+kill $(cat $PIDFILE)

--- a/src/t/run.bash
+++ b/src/t/run.bash
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+script/ddgc_deploy_test_db.pl
 export PIDFILE="/tmp/ddgc-$(date --iso-8601=seconds).pid"
 grunt
 DDGC_DB_DSN="dbi:SQLite:dbname=ddgc_test.db" plackup --host 127.0.0.1 -p 3000 -s Starman -D --pid $PIDFILE script/ddgc_dev_server.psgi

--- a/src/t/run.bash
+++ b/src/t/run.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 grunt
-plackup --host 127.0.0.1 -p 3000 -s Starman -D script/ddgc_dev_server.psgi
+DDGC_DB_DSN="dbi:SQLite:dbname=ddgc_test.db" plackup --host 127.0.0.1 -p 3000 -s Starman -D script/ddgc_dev_server.psgi --workers=5
 casperjs test src/t/ia/. --hostname=127.0.0.1:3000

--- a/src/t/run.bash
+++ b/src/t/run.bash
@@ -2,6 +2,4 @@
 
 grunt
 plackup --host 127.0.0.1 -p 3000 -s Starman -D script/ddgc_dev_server.psgi
-sleep 3
-curl http://127.0.0.1:3000/
 casperjs test src/t/ia/. --hostname=127.0.0.1:3000

--- a/src/t/run.bash
+++ b/src/t/run.bash
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 script/ddgc_deploy_test_db.pl
+cat src/t/sql/ia.sql | sqlite3 ddgc_test.db
 export PIDFILE="/tmp/ddgc-$(date --iso-8601=seconds).pid"
 grunt
 DDGC_DB_DSN="dbi:SQLite:dbname=ddgc_test.db" plackup --host 127.0.0.1 -p 3000 -s Starman -D --pid $PIDFILE script/ddgc_dev_server.psgi

--- a/src/t/run.bash
+++ b/src/t/run.bash
@@ -2,4 +2,4 @@
 
 grunt
 plackup -p 3000 -s Starman -D script/ddgc_dev_server.psgi
-casperjs test src/t/ia/. --hostname=localhost:3000
+casperjs test src/t/ia/. --hostname=127.0.0.1:3000

--- a/src/t/run.bash
+++ b/src/t/run.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 grunt
-plackup -p 3000 -s Starman -D script/ddgc_dev_server.psgi
+plackup --host 127.0.0.1 -p 3000 -s Starman -D script/ddgc_dev_server.psgi
 casperjs test src/t/ia/. --hostname=127.0.0.1:3000

--- a/src/t/run.bash
+++ b/src/t/run.bash
@@ -2,4 +2,6 @@
 
 grunt
 plackup --host 127.0.0.1 -p 3000 -s Starman -D script/ddgc_dev_server.psgi
+sleep 3
+curl http://127.0.0.1:3000/
 casperjs test src/t/ia/. --hostname=127.0.0.1:3000

--- a/src/t/run.bash
+++ b/src/t/run.bash
@@ -1,4 +1,4 @@
 #!/bin/bash
-source /etc/profile.d/perlbrew.sh
-plackup -p 3000 -s Starman -D /home/ddgc/community-platform/script/ddgc_dev_server.psgi
+
+plackup -p 3000 -s Starman -D script/ddgc_dev_server.psgi
 casperjs test src/t/ia/. --hostname=localhost:3000

--- a/src/t/run.bash
+++ b/src/t/run.bash
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+grunt
 plackup -p 3000 -s Starman -D script/ddgc_dev_server.psgi
 casperjs test src/t/ia/. --hostname=localhost:3000

--- a/src/t/run.bash
+++ b/src/t/run.bash
@@ -1,0 +1,4 @@
+#!/bin/bash
+source /etc/profile.d/perlbrew.sh
+plackup -p 3000 -s Starman -D /home/ddgc/community-platform/script/ddgc_dev_server.psgi
+casperjs test src/t/ia/. --hostname=localhost:3000

--- a/src/t/run.sh
+++ b/src/t/run.sh
@@ -1,11 +1,4 @@
 #!/bin/sh
 
-if [ $(hostname) ]
-then
-    HOSTNAME=$(hostname)
-else 
-    HOSTNAME='ddgc-staging'
-fi
-
 plackup -p 3000 -s Starman -D script/ddgc_dev_server.psgi
-casperjs test src/t/ia/. --hostname="$HOSTNAME"
+casperjs test src/t/ia/. --hostname=localhost:3000

--- a/src/t/run.sh
+++ b/src/t/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+casperjs test src/t/ia/. --hostname=$(hostname)

--- a/src/t/run.sh
+++ b/src/t/run.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-plackup -p 3000 -s Starman -D script/ddgc_dev_server.psgi
-casperjs test src/t/ia/. --hostname=localhost:3000

--- a/src/t/run.sh
+++ b/src/t/run.sh
@@ -1,3 +1,10 @@
 #!/bin/sh
 
-casperjs test src/t/ia/. --hostname=$(hostname)
+if [ $(hostname) ]
+then
+    HOSTNAME=$(hostname)
+else 
+    HOSTNAME='ddgc-staging'
+fi
+
+casperjs test src/t/ia/. --hostname="$HOSTNAME"

--- a/src/t/run.sh
+++ b/src/t/run.sh
@@ -7,4 +7,5 @@ else
     HOSTNAME='ddgc-staging'
 fi
 
+plackup -p 3000 -s Starman -D script/ddgc_dev_server.psgi
 casperjs test src/t/ia/. --hostname="$HOSTNAME"

--- a/src/t/sql/ia.sql
+++ b/src/t/sql/ia.sql
@@ -1,3 +1,4 @@
+DELETE FROM instant_answer;
 INSERT INTO instant_answer ( id, meta_id, name,
                              description, example_query, repo,
                              dev_milestone, public, perl_module,

--- a/src/t/sql/ia.sql
+++ b/src/t/sql/ia.sql
@@ -1,0 +1,33 @@
+INSERT INTO instant_answer ( id, meta_id, name,
+                             description, example_query, repo,
+                             dev_milestone, public, perl_module,
+                             updated )
+                    VALUES ( 'testing_goodie', 'testing_goodie', 'Testing Goodie',
+                             'This is the test Goodie IA', 'testing goodie', 'goodies',
+                             'live', 1, 'DDG::Goodie::TestingGoodie',
+                              date() );
+INSERT INTO instant_answer ( id, meta_id, name,
+                             description, example_query, repo,
+                             dev_milestone, public, perl_module,
+                             updated )
+                    VALUES ( 'testing_spice', 'testing_spice', 'Testing Spice',
+                             'This is the test Spice IA', 'testing spice', 'spice',
+                             'live', 1, 'DDG::Spice::TestingSpice',
+                              date() );
+INSERT INTO instant_answer ( id, meta_id, name,
+                             description, example_query, repo,
+                             dev_milestone, public, perl_module,
+                             updated )
+                    VALUES ( 'testing_longtail', 'testing_longtail', 'Testing Longtail',
+                             'This is the test Longtail IA', 'testing longtail', 'longtail',
+                             'live', 1, 'DDG::Longtail::TestingLongtail',
+                              date() );
+INSERT INTO instant_answer ( id, meta_id, name,
+                             description, example_query, repo,
+                             dev_milestone, public, perl_module,
+                             updated )
+                    VALUES ( 'testing_fathead', 'testing_fathead', 'Testing Fathead',
+                             'This is the test Fathead IA', 'testing fathead', 'fathead',
+                             'live', 1, 'DDG::Fathead::TestingFathead',
+                              date() );
+


### PR DESCRIPTION
//cc @nilnilnil 
This is still very very WIP, I just started with a little demo of what we can do with casperjs.
TODO: add some modules with utility functions we can reuse, add grunt task.

**How to install casperjs on your instance:**
- `npm install` This will install phantomjs - I had to pin it to 1.9.8 because that's the latest release working seamlessly with casperjs

- `bower install` this will install casperjs, since it's available as a bower module.

- `export PATH=$PATH:node_modules/phantomjs/lib/phantom/bin`

**How to run a test:**
`casperjs test [filename] --hostname=[hostname]`

For example, in my case:  `casperjs test src/t/ia/index.js --hostname=maria`.

When we'll have the grunt task it should be even easier, though.

Thanks @jbarrett for the help!

![new-blank](https://cloud.githubusercontent.com/assets/3652195/14688007/81542152-0740-11e6-8c3f-87b36a70004a.png)
