### PR TITLE
Small script wrapping Devel::Cover

### DIFF
--- a/script/ddgc_devel_cover.sh
+++ b/script/ddgc_devel_cover.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+cover -delete
+PERL5OPT="$PERL5OPT -MDevel::Cover" prove -Ilib
+cover
+


### PR DESCRIPTION
This is a tiny but hopefully useful script you can use to get test coverage metrics. The final result is a set of html in cover_db/

You can use something like [App::HTTPThis](https://metacpan.org/pod/App::HTTPThis) to quickly serve your current directory.

You'll also need to install [Devel::Cover](https://metacpan.org/pod/Devel::Cover)