### PR TITLE
Gather.pm - count_prs and count_issues should only include open ones

### DIFF
--- a/lib/DDH/UserPage/Gather.pm
+++ b/lib/DDH/UserPage/Gather.pm
@@ -211,13 +211,13 @@ sub transform {
         }
 
         # Issues count for this IA
-        if ( my $issues = $self->ddgc->rs('InstantAnswer::Issues')->search({ instant_answer_id => $ia_id, is_pr => 0 })->count ) {
+        if ( my $issues = $self->ddgc->rs('InstantAnswer::Issues')->search({ instant_answer_id => $ia_id, is_pr => 0, status => 'open' })->count ) {
 
             $ia->{$ia_id}->{issues_count} = $issues;
         }
 
         # PRs count for this IA
-        if ( my $pulls = $self->ddgc->rs('InstantAnswer::Issues')->search({ instant_answer_id => $ia_id, is_pr => 1 })->count ) {
+        if ( my $pulls = $self->ddgc->rs('InstantAnswer::Issues')->search({ instant_answer_id => $ia_id, is_pr => 1, status => 'open' })->count ) {
         
             $ia->{$ia_id}->{prs_count} = $pulls;
         }


### PR DESCRIPTION
//cc @jagtalon 

Currently, they include closed/merged issues and prs as well, but we only want to know how many are open.