### PR TITLE
Add script for random traffic data generation

### DIFF
--- a/script/ddgc_generate_traffic.pl
+++ b/script/ddgc_generate_traffic.pl
@@ -15,7 +15,16 @@ use List::Util qw(any pairs);
 use DateTime;
 
 use Moo;
-use MooX::Options;
+use MooX::Options
+    description => 'generate random traffic data',
+    authors     => 'Ben Moon <guiltydolphin@gmail.com>',
+    synopsis    => '
+
+    To generate a week of traffic for the calculator, with each
+    day having a maximum count of 10:
+
+    ddgc_generate_traffic.pl --id=calculator --days=7 --max=10
+';
 
 my $default_days = 31;
 

--- a/script/ddgc_generate_traffic.pl
+++ b/script/ddgc_generate_traffic.pl
@@ -71,3 +71,5 @@ foreach my $id (@ids) {
         map { my ($date, $count) = @$_; [$id, 'iaoi', $date, $count] } pairs zip (@days, @counts),
     ]);
 }
+
+1;

--- a/script/ddgc_generate_traffic.pl
+++ b/script/ddgc_generate_traffic.pl
@@ -26,6 +26,10 @@ use MooX::Options
     ddgc_generate_traffic.pl --id=calculator --days=7 --max=10
 ';
 
+#######################################################################
+#                               Options                               #
+#######################################################################
+
 my $default_days = 31;
 
 option days => (
@@ -66,6 +70,10 @@ option clear => (
     doc     => 'delete all traffic data and exit',
 );
 
+######################
+#  Fetching Options  #
+######################
+
 my $opt = DDGC::Cmd::GenerateTraffic->new_with_options;
 
 my $num_days = $opt->{days};
@@ -79,6 +87,10 @@ my @ids = @{$opt->id};
 
 my @bounds = @{$opt->max};
 die 'cannot have a negative maximum!' if any { $_ < 0 } @bounds;
+
+#######################################################################
+#                         Traffic Generation                          #
+#######################################################################
 
 # Generate a set of counts, bounded in sections (small, large etc)
 sub get_random_counts {

--- a/script/ddgc_generate_traffic.pl
+++ b/script/ddgc_generate_traffic.pl
@@ -42,16 +42,12 @@ my @ids = $d->rs('InstantAnswer')
     ->get_column('meta_id')
     ->all;
 
-sub generate_bounded_counts {
-    my $max = shift;
-    map { int(rand($max)) } (0..$num_days);
-}
-
 my @bounds = (10, 100, 1_000, 10_000);
 
 # Generate a set of counts, bounded in sections (small, large etc)
 sub get_random_counts {
-    generate_bounded_counts($bounds[int(rand($#bounds))])
+    my $max = $bounds[int(rand($#bounds))];
+    map { int(rand($max)) } (0..$num_days);
 }
 
 foreach my $id (@ids) {

--- a/script/ddgc_generate_traffic.pl
+++ b/script/ddgc_generate_traffic.pl
@@ -9,8 +9,6 @@ use FindBin;
 use lib $FindBin::Dir . "/../lib";
 
 use DDGC;
-use Carp;
-use Data::Printer;
 use List::MoreUtils qw(zip);
 use List::Util qw(pairs);
 use DateTime;

--- a/script/ddgc_generate_traffic.pl
+++ b/script/ddgc_generate_traffic.pl
@@ -42,17 +42,18 @@ my @ids = $d->rs('InstantAnswer')
     ->get_column('meta_id')
     ->all;
 
-my @bounds = (10, 100, 1_000, 10_000);
+my @bounds = (0, 10, 100, 1_000, 10_000);
 
 # Generate a set of counts, bounded in sections (small, large etc)
 sub get_random_counts {
     my $max = $bounds[int(rand($#bounds))];
+    return () if $max == 0;
     map { int(rand($max)) } (0..$num_days);
 }
 
 foreach my $id (@ids) {
-    my @counts = get_random_counts();
     $d->rs('InstantAnswer::Traffic')->search({answer_id => $id})->delete();
+    my @counts = get_random_counts() or next;
     $d->rs('InstantAnswer::Traffic')->populate([
         [qw( answer_id pixel_type date count )],
         map { my ($date, $count) = @$_; [$id, 'iaoi', $date, $count] } pairs zip (@days, @counts),

--- a/script/ddgc_generate_traffic.pl
+++ b/script/ddgc_generate_traffic.pl
@@ -43,19 +43,19 @@ my @ids = $d->rs('InstantAnswer')
     ->all;
 
 sub generate_bounded_counts {
-    my ($min, $max) = @_;
-    map { int(rand($max+$min)) + $min } (0..$num_days);
+    my $max = shift;
+    map { int(rand($max)) } (0..$num_days);
 }
 
 my %bounds = (
-    small => [0, 3_000],
-    large => [1_000, 100_000],
+    small => 3_000,
+    large => 100_000,
 );
 
 # Generate a set of counts, bounded in sections (small, large etc)
 sub get_random_counts {
     generate_bounded_counts(int(rand())
-        ? @{$bounds{small}} : @{$bounds{large}}
+        ? $bounds{small} : $bounds{large}
     );
 }
 

--- a/script/ddgc_generate_traffic.pl
+++ b/script/ddgc_generate_traffic.pl
@@ -17,7 +17,10 @@ use DateTime;
 
 my $d = DDGC->new;
 
-my @ids = $d->rs('InstantAnswer')->get_column('meta_id')->all;
+my @ids = $d->rs('InstantAnswer')
+    ->search({dev_milestone => 'live'})
+    ->get_column('meta_id')
+    ->all;
 
 my $today = DateTime->now();
 my $last_month = $today->clone()->subtract(days => 31);

--- a/script/ddgc_generate_traffic.pl
+++ b/script/ddgc_generate_traffic.pl
@@ -1,0 +1,40 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+$ENV{DDGC_IA_AUTOUPDATES} = 0;
+
+use FindBin;
+use lib $FindBin::Dir . "/../lib";
+
+use DDGC;
+use Carp;
+use Data::Printer;
+use List::MoreUtils qw(zip);
+use List::Util qw(pairs);
+use DateTime;
+
+my $d = DDGC->new;
+
+my @ids = $d->rs('InstantAnswer')->get_column('meta_id')->all;
+
+my $today = DateTime->now();
+my $last_month = $today->clone()->subtract(days => 31);
+
+my @days = map { $last_month->clone->add(days => $_)->strftime('%F') } (1..31);
+my @counts = (1..31);
+my $days = \@days;
+my $counts = \@counts;
+
+foreach my $id (@ids) {
+    foreach (pairs zip @days, @counts) {
+        my ($day, $count) = @$_;
+        $d->rs('InstantAnswer::Traffic')->update_or_create({
+            answer_id  => $id,
+            date       => $day,
+            count      => $count,
+            pixel_type => 'iaoi',
+        });
+    }
+}

--- a/script/ddgc_generate_traffic.pl
+++ b/script/ddgc_generate_traffic.pl
@@ -51,8 +51,9 @@ sub get_random_counts {
     map { int(rand($max)) } (0..$num_days);
 }
 
+$d->rs('InstantAnswer::Traffic')->delete();
+
 foreach my $id (@ids) {
-    $d->rs('InstantAnswer::Traffic')->search({answer_id => $id})->delete();
     my @counts = get_random_counts() or next;
     $d->rs('InstantAnswer::Traffic')->populate([
         [qw( answer_id pixel_type date count )],

--- a/script/ddgc_generate_traffic.pl
+++ b/script/ddgc_generate_traffic.pl
@@ -51,6 +51,12 @@ option max => (
         " a maximum of 0 implies there wasn't enough traffic data",
 );
 
+option clear => (
+    is      => 'ro',
+    default => 0,
+    doc     => 'delete all traffic data and exit',
+);
+
 my $opt = DDGC::Cmd::GenerateTraffic->new_with_options;
 
 my $num_days = $opt->{days};
@@ -73,6 +79,7 @@ sub get_random_counts {
 }
 
 $d->rs('InstantAnswer::Traffic')->delete();
+exit if $opt->{clear};
 
 foreach my $id (@ids) {
     my @counts = get_random_counts() or next;

--- a/script/ddgc_generate_traffic.pl
+++ b/script/ddgc_generate_traffic.pl
@@ -47,16 +47,11 @@ sub generate_bounded_counts {
     map { int(rand($max)) } (0..$num_days);
 }
 
-my %bounds = (
-    small => 3_000,
-    large => 100_000,
-);
+my @bounds = (10, 100, 1_000, 10_000);
 
 # Generate a set of counts, bounded in sections (small, large etc)
 sub get_random_counts {
-    generate_bounded_counts(int(rand())
-        ? $bounds{small} : $bounds{large}
-    );
+    generate_bounded_counts($bounds[int(rand($#bounds))])
 }
 
 foreach my $id (@ids) {

--- a/script/ddgc_generate_traffic.pl
+++ b/script/ddgc_generate_traffic.pl
@@ -26,6 +26,22 @@ option days => (
     default => $default_days,
 );
 
+my $d = DDGC->new;
+
+option id => (
+    is        => 'ro',
+    format    => 's@',
+    autosplit => ',',
+    doc       => 'IDs of Instant Answers to generate traffic for',
+    default   => sub {
+        my @ids = $d->rs('InstantAnswer')
+                    ->search({dev_milestone => 'live'})
+                    ->get_column('meta_id')
+                    ->all;
+        return \@ids;
+    },
+);
+
 my $opt = DDGC::Cmd::GenerateTraffic->new_with_options;
 
 my $num_days = $opt->{days};
@@ -35,12 +51,7 @@ my $start_date = DateTime->now->subtract(days => $num_days);
 
 my @days = map { $start_date->clone->add(days => $_)->strftime('%F') } (0..$num_days);
 
-my $d = DDGC->new;
-
-my @ids = $d->rs('InstantAnswer')
-    ->search({dev_milestone => 'live'})
-    ->get_column('meta_id')
-    ->all;
+my @ids = @{$opt->id};
 
 my @bounds = (0, 10, 100, 1_000, 10_000);
 

--- a/script/ddgc_generate_traffic.pl
+++ b/script/ddgc_generate_traffic.pl
@@ -26,18 +26,29 @@ my $today = DateTime->now();
 my $last_month = $today->clone()->subtract(days => 31);
 
 my @days = map { $last_month->clone->add(days => $_)->strftime('%F') } (1..31);
-my @counts = (1..31);
 my $days = \@days;
-my $counts = \@counts;
+
+sub generate_bounded_counts {
+    my ($min, $max) = @_;
+    map { int(rand($max+$min)) + $min } (1..31);
+}
+
+my %bounds = (
+    small => [0, 3_000],
+    large => [1_000, 100_000],
+);
+
+# Returns a month's worth of counts
+sub get_random_counts {
+    generate_bounded_counts(int(rand())
+        ? @{$bounds{small}} : @{$bounds{large}}
+    );
+}
 
 foreach my $id (@ids) {
-    foreach (pairs zip @days, @counts) {
-        my ($day, $count) = @$_;
-        $d->rs('InstantAnswer::Traffic')->update_or_create({
-            answer_id  => $id,
-            date       => $day,
-            count      => $count,
-            pixel_type => 'iaoi',
-        });
-    }
+    my @counts = get_random_counts();
+    $d->rs('InstantAnswer::Traffic')->populate([
+        [qw( answer_id pixel_type date count )],
+        map { my ($date, $count) = @$_; [$id, 'iaoi', $date, $count] } pairs zip (@days, @counts),
+    ]);
 }

--- a/script/ddgc_generate_traffic.pl
+++ b/script/ddgc_generate_traffic.pl
@@ -52,6 +52,7 @@ sub get_random_counts {
 
 foreach my $id (@ids) {
     my @counts = get_random_counts();
+    $d->rs('InstantAnswer::Traffic')->search({answer_id => $id})->delete();
     $d->rs('InstantAnswer::Traffic')->populate([
         [qw( answer_id pixel_type date count )],
         map { my ($date, $count) = @$_; [$id, 'iaoi', $date, $count] } pairs zip (@days, @counts),


### PR DESCRIPTION
`script/ddgc_generate_traffic.pl` generates random traffic data for local testing.

Fixes #1303 

![screenshot-2016-05-16-22 05 04_784_466](https://cloud.githubusercontent.com/assets/8598426/15304120/7620c5c4-1bb3-11e6-9e2f-8a41d9aef01d.png)

#### TO-DO

- [x] More realistic data (not 3 million queries!)
- [x] Truncate tables on update (@jdorweiler)

/cc @jdorweiler @MariagraziaAlastra @jbarrett 