### PR TITLE
InstantAnswer.pm - fix create_ia (called from the new IA wizard page)

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -1183,16 +1183,17 @@ sub create_ia :Chained('base') :PathPart('create') :Args() {
         my $other_queries = $data->{other_queries}? from_json($data->{other_queries}) : [];
         my $author;
         my $maintainer;
-
-        if (my $gh_id = $c->user->github_id) {
-            $author = {
-                url => 'https://github.com/' . $c->user->username,
-                name => $c->user->username,
-                type => "github"
+        my $gh_id = $c->user->github_id;
+        
+        if ($gh_id && (my $gh_user =  $c->d->rs('GitHub::User')->find({github_id => $gh_id}))) {
+            $maintainer = { 
+                github => $gh_user->login
             };
-
-            my $maintainer = { 
-                github => $c->d->rs('GitHub::User')->find({github_id => $gh_id})->login
+            
+            $author = {
+                url => 'https://github.com/' . $gh_user->login,
+                name => $gh_user->login,
+                type => "github"
             };
 
         } else {
@@ -1268,6 +1269,7 @@ sub create_ia_from_pr :Chained('base') :PathPart('create_from_pr') :Args() {
     my $repo;
     my $pr_number;
     my $gh;
+    my $gh_id = $c->user->github_id;
     
     if ($user) {
         if(($repo, $pr_number) = $url =~ /https?:\/\/github.com\/duckduckgo\/zeroclickinfo-(.+)\/pull\/(.+)$/){
@@ -1281,15 +1283,15 @@ sub create_ia_from_pr :Chained('base') :PathPart('create_from_pr') :Args() {
             my $author;
             my $maintainer;
 
-            if (my $gh_id = $c->user->github_id) {
-                $author = {
-                    url => 'https://github.com/' . $c->user->username,
-                    name => $c->user->username,
-                    type => "github"
+            if ($gh_id && (my $gh_user =  $c->d->rs('GitHub::User')->find({github_id => $gh_id}))) {
+                $maintainer = { 
+                    github => $gh_user->login
                 };
-
-                my $maintainer = { 
-                    github => $c->d->rs('GitHub::User')->find({github_id => $gh_id})->login
+                
+                $author = {
+                    url => 'https://github.com/' . $gh_user->login,
+                    name => $gh_user->login,
+                    type => "github"
                 };
 
             } else {


### PR DESCRIPTION
##### Description :
Creating a new IA (both from scratch and from a PR link) is broken on the live site.
Problem was a typo (a second "my" which made it look like the variable was different from the one defined previously for the maintainer).
While I was at it I also fixed a bug with contributor names when the author type is "github" (previously used the duck.co username, now it uses the github login)

##### Reviewer notes :
If you want to test this manually, log in as a user with a github account connected and try creating an IA from ia/new_ia.
Expected: the page is created and you're set as maintainer and added as contributor, both using your github account.

##### References issues / PRs:
Nope

##### Who should be informed of this change?
@tagawa, who spotted the bug!

##### Does this change have significant privacy, security, performance or deployment implications?
I need to deploy this as hotfix now and then it'll be included in the next regular deployment as well.

##### Checklist :
- [x] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration) 
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [x] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android

