### PR TITLE
UserPage.js: Add PRs that were created by the user

### DIFF
--- a/root/static/js/userpages/UserPage.js
+++ b/root/static/js/userpages/UserPage.js
@@ -235,6 +235,11 @@ app.controller('UserPageController', function($scope, $http, fn) {
       $scope.count.other += _.filter(response.pulls_assigned, function(ia) {
 	  return !$scope.mapIssues[ia.id];
       }).length || 0;
+
+      $scope.count.other += _.filter(response.pulls_created, function(ia) {
+	  return !$scope.mapIssues[ia.id];
+      }).length || 0;
+
     $scope.count.developed_only_ias = _.size($scope.ias_developed_only);
     $scope.count.open_issues = _.size(response.issues_assigned);
     $scope.count.closed_issues = _.size(response.issues) - $scope.count.open_issues;
@@ -247,12 +252,22 @@ app.controller('UserPageController', function($scope, $http, fn) {
     $scope.count.ias = _.size($scope.ias)
       $scope.count.filtered = 0;
 
-      $scope.all_the_issues = _.toArray(response.issues_assigned).concat(_.toArray(response.pulls_assigned));
+      $scope.all_the_issues = _.toArray(response.issues_assigned).concat(_.toArray(response.pulls_assigned)).concat(_.toArray(response.pulls_created));
       $scope.all_the_issues = _.sortBy($scope.all_the_issues, function(issue) {
 	  return moment().diff(moment(issue.updated_at), 'days');
       });
 
-      _.each(_.filter($scope.maintained.concat($scope.ias_developed_only), function(ia) {
+
+      var seen = {};
+      var temp = [];
+      _.each($scope.maintained.concat($scope.ias_developed_only), function(ia) {
+	  if(!seen[ia.id]) {
+	      seen[ia.id] = true;
+	      temp.push(ia);
+	  }
+      });
+
+      _.each(_.filter(temp, function(ia) {
 	  return ia.issues.length > 0;
       }), function(ia) {
 	  $scope.count.filtered += ia.issues.length;

--- a/root/static/js/userpages/UserPage.js
+++ b/root/static/js/userpages/UserPage.js
@@ -315,7 +315,7 @@ app.controller('UserPageController', function($scope, $http, fn) {
       $scope.count.all_prs = 0;
       $scope.count.all_issues = 0;
 
-      _.each($scope.maintained.concat($scope.ias_developed_only), function(ia) {
+      _.each(temp, function(ia) {
 	  _.each(ia.issues, function(issue) {
 	      if(issue.isa_pull_request === 1) {
 		  $scope.count.all_prs++;


### PR DESCRIPTION
They weren't being shown on the page before.

![screen shot 2016-05-27 at 8 51 25 am](https://cloud.githubusercontent.com/assets/81969/15608501/3e5d073c-23e8-11e6-8a91-52d6ebd9b0a7.png)

`#2754` is now being shown. Here was the original bug report:

<img width="1269" alt="screen shot 2016-05-26 at 11 40 17 am" src="https://cloud.githubusercontent.com/assets/81969/15608521/5ff8b422-23e8-11e6-9954-8f2d0520cd5e.png">
