### PR TITLE
John/userpage banner

### DIFF
--- a/lib/DDGC/DB/Result/User.pm
+++ b/lib/DDGC/DB/Result/User.pm
@@ -11,6 +11,8 @@ use Path::Class;
 use IPC::Run qw/ run timeout /;
 use LWP::Simple qw/ is_success getstore /;
 use File::Temp qw/ tempfile /;
+use File::Spec::Functions;
+use URI;
 use Carp;
 use Prosody::Mod::Data::Access;
 use Digest::MD5 qw( md5_hex );
@@ -272,6 +274,29 @@ sub store_github_credentials {
 			gh_data => $gh_data,
 		})
 	}
+}
+
+sub verified_userpage {
+	my ( $self ) = @_;
+	return if !$self->github_id;
+	return if !$self->github_user;
+	my $d = catdir( '/home/ddgc/ddgc/ddh-userpages', lc( $self->github_user ) );
+	return if ( ! -d $d );
+	return URI->new(
+		sprintf( 'https://duckduckhack.com/u/%s#tutorial', lc( $self->github_user ) )
+	)->canonical;
+}
+
+sub has_not_seen_userpage_banner {
+	my ( $self ) = @_;
+	my $result = $self->schema->resultset('User::CampaignNotice')->find( {
+		users_id => $self->id,
+		campaign_id => 128,
+		campaign_source => 'campaign',
+		cache_for => 600,
+	} );
+
+	return ($result) ? 0 : 1;
 }
 
 sub add_default_notifications {

--- a/lib/DDGC/Web/Controller/Root.pm
+++ b/lib/DDGC/Web/Controller/Root.pm
@@ -42,24 +42,16 @@ sub base :Chained('/') :PathPart('') :CaptureArgs(0) {
 			return $c->detach;
 		}
 
-		if (!$c->session->{campaign_notification_checked}) {
-			$c->session->{campaign_notification_checked} = 1;
-			my $campaign = $c->user->get_first_available_campaign;
-			if ($campaign) {
-				if (!$c->user->seen_campaign_notice($campaign, 'campaign')) {
-					$c->session->{campaign_notification} = $campaign;
-				}
-			}
-		}
-
-		if ($c->session->{campaign_notification}) {
-			my $campaign_config = $c->d->config->campaigns->{$c->session->{campaign_notification}};
-			if ($campaign_config->{notification_active}) {
-				$c->stash->{campaign_info}->{campaign_id} = $campaign_config->{id};
-				$c->stash->{campaign_info}->{campaign_name} = $c->session->{campaign_notification};
-				$c->stash->{campaign_info}->{link} = $campaign_config->{url};
-				$c->stash->{campaign_info}->{notification} = $campaign_config->{notification};
-			}
+		if (
+			( my $url = $c->user->verified_userpage ) &&
+			$c->user->has_not_seen_userpage_banner
+		) {
+			$c->stash->{campaign_info}->{campaign_id} = 128;
+			$c->stash->{campaign_info}->{campaign_name} = 'Your DuckDuckHack Profile';
+			$c->stash->{campaign_info}->{link} = $url;
+			$c->stash->{campaign_info}->{notification} = sprintf(
+				"Preview your upcoming <a href='%s'>DuckDuckHack Profile</a>!", $url
+			);
 		}
 	}
 

--- a/templates/notice_campaign.tx
+++ b/templates/notice_campaign.tx
@@ -6,7 +6,7 @@
 			</div>
 			<div class="faux__body">
 				<: if ( $campaign_info.notification ) { :>
-					<: $campaign_info.notification :>
+					<: $campaign_info.notification | raw :>
 				<: } else { :>
 					We have some exciting news coming soon! Would you like to be in the loop?
 				<: } :>

--- a/templates/notice_campaign.tx
+++ b/templates/notice_campaign.tx
@@ -11,8 +11,8 @@
 					We have some exciting news coming soon! Would you like to be in the loop?
 				<: } :>
 				<div class="notice__buttons">
-					<a href="<: $campaign_info.link :>" class="button blue">Sure!</a>
-					<a href="<: $u(['My','campaign_nothanks']) :>" class="button red campaign_nothanks">No, thanks</a>
+					<!-- a href="<: $campaign_info.link :>" class="button blue">Sure!</a -->
+					<!-- a href="<: $u(['My','campaign_nothanks']) :>" class="button red campaign_nothanks">No, thanks</a -->
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
##### Description :

Adds a notification of the availability of a DuckDuckHack Profile for Github authed users.

##### Reviewer notes :

- You will need Github oauth set up.
- Generate user pages from synced IA data (if you have not already)
- Log into your dev instance as a user with a DDH Profile via Github.
- You should see a banner notification linking to your profile, with the anchor '#tutorial', on all community platform pages, apart from /blog

##### References issues / PRs:

N/A

##### Who should be informed of this change?

@jagtalon @russellholt @zekiel 

##### Does this change have significant privacy, security, performance or deployment implications?


##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [x] Chrome
    - [x] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
