### PR TITLE
Banner - send req on show

### DIFF
--- a/lib/DDGC/Web/Controller/Root.pm
+++ b/lib/DDGC/Web/Controller/Root.pm
@@ -64,7 +64,7 @@ sub base :Chained('/') :PathPart('') :CaptureArgs(0) {
 			$c->stash->{campaign_info}->{campaign_name} = 'Your DuckDuckHack Profile';
 			$c->stash->{campaign_info}->{link} = $url;
 			$c->stash->{campaign_info}->{notification} = sprintf(
-				"Preview your upcoming <a href='%s'>DuckDuckHack Profile</a>!", $url
+				"Preview your upcoming <a href='%s' onClick='sendReq()'>DuckDuckHack Profile</a>!", $url
 			);
 		}
 	}

--- a/lib/DDGC/Web/Controller/Root.pm
+++ b/lib/DDGC/Web/Controller/Root.pm
@@ -7,6 +7,7 @@ use DateTime;
 use DateTime::Duration;
 use DateTime::Format::Mail;
 use URI;
+use POSIX;
 
 use namespace::autoclean;
 
@@ -46,6 +47,19 @@ sub base :Chained('/') :PathPart('') :CaptureArgs(0) {
 			( my $url = $c->user->verified_userpage ) &&
 			$c->user->has_not_seen_userpage_banner
 		) {
+            my $random = ceil(rand(1e7));
+            my $base_req_url = 'https://duckduckgo.com/t/uplaunch_'; 
+            my $role = 'regular';
+            if ($c->user->admin) {
+                $role = 'staff';
+            } elsif ($c->user->is('community_leader')) {
+                $role = 'comleader';
+            }
+
+            $role .= '_' . $c->user->github_user;
+            $c->stash->{campaign_info}->{user_info} = $role;
+            $c->stash->{campaign_info}->{show_req} = $base_req_url . 'shown_' . $role . '?' . $random;
+            $c->stash->{campaign_info}->{base_req} = $base_req_url;
 			$c->stash->{campaign_info}->{campaign_id} = 128;
 			$c->stash->{campaign_info}->{campaign_name} = 'Your DuckDuckHack Profile';
 			$c->stash->{campaign_info}->{link} = $url;

--- a/templates/notice_campaign.tx
+++ b/templates/notice_campaign.tx
@@ -4,6 +4,9 @@
 			<div class="faux__image">
 				<img src="/static/img/logo_ddg_community_thm.png" />
 			</div>
+			<div class="hide">
+				<img src="<: $campaign_info.show_req :>" />
+			</div>
 			<div class="faux__body">
 				<: if ( $campaign_info.notification ) { :>
 					<: $campaign_info.notification | raw :>

--- a/templates/notice_campaign.tx
+++ b/templates/notice_campaign.tx
@@ -1,11 +1,17 @@
 <: if $c.user && $campaign_info { :>
+    <script>
+        function sendReq() {
+            var img = new Image();
+            img.src = '<: $campaign_info.base_req :>' + 'clicked_' + '<: $campaign_info.user_info :>' + '?' + Math.ceil(Math.random() * 1e7);
+        };
+    </script>
 	<div id='campaign_info' class="notice info notice--campaign">
 		<div class="faux  notice__content">
 			<div class="faux__image">
 				<img src="/static/img/logo_ddg_community_thm.png" />
 			</div>
 			<div class="hide">
-				<img src="<: $campaign_info.show_req :>" />
+				<img id="imgReq" src="<: $campaign_info.show_req :>" />
 			</div>
 			<div class="faux__body">
 				<: if ( $campaign_info.notification ) { :>


### PR DESCRIPTION
##### Description :
Sends requests to duckduckgo.com when the banner is shown and when it's clicked.

##### Reviewer notes :
You just need to watch the network tab in the developer tools to see the request,
provided you logged in using an account with a GitHub user linked.

##### References issues / PRs:

#1378 

##### Who should be informed of this change?
@jbarrett @jagtalon @russellholt 

##### Does this change have significant privacy, security, performance or deployment implications?


##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [x] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android

