### PR TITLE
Supporting backend elements to dismiss ddh profile notification

### DIFF
--- a/lib/DDGC/DB/Result/User.pm
+++ b/lib/DDGC/DB/Result/User.pm
@@ -299,6 +299,15 @@ sub has_not_seen_userpage_banner {
 	return ($result) ? 0 : 1;
 }
 
+sub set_seen_userpage_banner {
+	my ( $self ) = @_;
+	$self->schema->resultset('User::CampaignNotice')->find_or_create( {
+		users_id => $self->id,
+		campaign_id => 128,
+		campaign_source => 'campaign',
+	}	);
+}
+
 sub add_default_notifications {
 	my ( $self ) = @_;
 	return if $self->search_related('user_notifications')->count;

--- a/lib/DDGC/Web/Controller/My.pm
+++ b/lib/DDGC/Web/Controller/My.pm
@@ -61,6 +61,15 @@ sub campaign_nothanks :Chained('base') :Args(0) {
 	return $c->detach;
 }
 
+sub dismiss_ddh_profile :Chained('base') :Args(0) {
+	my ( $self, $c ) = @_;
+	$c->stash->{x} = ( $c->user->set_seen_userpage_banner ) ? { ok => 1 } : { ok => 0 };
+	$c->session->{campaign_notification} = undef;
+	$c->stash->{campaign_info} = undef;
+	$c->forward( $c->view('JSON') );
+	return $c->detach;
+}
+
 sub _post_login_setup {
 	my ( $self, $c ) = @_;
 	my $user = $c->user;

--- a/templates/notice_campaign.tx
+++ b/templates/notice_campaign.tx
@@ -19,7 +19,7 @@
 				</div>
 			</div>
 		</div>
-		<!-- <a href="<: $u(['My','campaign_nothanks']) :>"><span class="ddgsi ddgsi-close-bold"></span></a>-->
+		<a href="<: $u(['My','dismiss_ddh_profile']) :>" class="campaign_nothanks"><span class="ddgsi ddgsi-close-bold"></span></a>
 	</div>
 <: } :>
 


### PR DESCRIPTION
##### Description :

When you click the 'x' in the DDH Profile notification, this will dismiss it and prevent it showing again.

##### Reviewer notes :

- You will need Github oauth set up.
- Generate user pages from synced IA data (if you have not already)
- Log into your dev instance as a user with a DDH Profile via Github.
- You should see a banner notification linking to your profile, with the anchor '#tutorial', on all community platform pages, apart from /blog
- Clicking the 'x' on the right side of this banner should dismiss it.
- Refreshing, loading another page, logging out / in again should not show the banner

##### References issues / PRs:

#1385 

##### Who should be informed of this change?

@jagtalon 

##### Does this change have significant privacy, security, performance or deployment implications?

No

##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [x] Chrome
    - [x] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android

