### PR TITLE
InstantAnswer.pm - call format_id() inside create_ia_from_pr()

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -1357,6 +1357,8 @@ sub create_ia_from_pr :Chained('base') :PathPart('create_from_pr') :Args() {
                     
                     # Capitalize each word in the name string
                     $name =~ s/([\w']+)/\u\L$1/g;
+
+                    $id = format_id($id);
                     
                     my $new_ia = $c->d->rs('InstantAnswer')->update_or_create({
                         id => $id,

--- a/t/instant_answer_basics.t
+++ b/t/instant_answer_basics.t
@@ -227,7 +227,7 @@ test_psgi $app => sub {
     # Use this when you need to see session data
     # $cb->( GET '/testutils/debug_session' );
 
-    # Create an IA from a PR - the link in there uses uppercase
+    # Create an IA from a PR
     my $new_ia_pr_req = $cb->(
         POST '/ia/create_from_pr',
         Cookie          => $cookie,
@@ -238,11 +238,10 @@ test_psgi $app => sub {
     );
     ok( $new_ia_pr_req->is_success, 'Creating IA from PR' );
 
-    # Find IA - the meta_id should be all lowercase
-    my $lc_ia = $d->rs('InstantAnswer')->find('upper_case_ia_test');
+    # Find IA
+    my $lc_ia = $d->rs('InstantAnswer')->find('game_of_life_cheat_sheet');
     ok( $lc_ia, 'Query returns something - the meta_id was correctly formatted' );
     isa_ok( $lc_ia, 'DDGC::DB::Result::InstantAnswer' );
-
 
 };
 

--- a/t/instant_answer_basics.t
+++ b/t/instant_answer_basics.t
@@ -227,7 +227,7 @@ test_psgi $app => sub {
     # Use this when you need to see session data
     # $cb->( GET '/testutils/debug_session' );
 
-    # Create an IA from a PR
+    # Create an IA from a PR - contains mixed case ID
     my $new_ia_pr_req = $cb->(
         POST '/ia/create_from_pr',
         Cookie          => $cookie,
@@ -238,8 +238,8 @@ test_psgi $app => sub {
     );
     ok( $new_ia_pr_req->is_success, 'Creating IA from PR' );
 
-    # Find IA
-    my $lc_ia = $d->rs('InstantAnswer')->find('game_of_life_cheat_sheet');
+    # Find IA - the meta_id should be lowercase
+    my $lc_ia = $d->rs('InstantAnswer')->find('upper_case_ia_test');
     ok( $lc_ia, 'Query returns something - the meta_id was correctly formatted' );
     isa_ok( $lc_ia, 'DDGC::DB::Result::InstantAnswer' );
 

--- a/t/instant_answer_basics.t
+++ b/t/instant_answer_basics.t
@@ -229,7 +229,7 @@ test_psgi $app => sub {
 
     # Create an IA from a PR - the link in there uses uppercase
     my $new_ia_pr_req = $cb->(
-        POST '/ia/create_ia_from_pr',
+        POST '/ia/create_from_pr',
         Cookie          => $cookie,
         Content         => [
             pr           => 'https://github.com/duckduckgo/zeroclickinfo-goodies/pull/3172',

--- a/t/instant_answer_basics.t
+++ b/t/instant_answer_basics.t
@@ -227,6 +227,23 @@ test_psgi $app => sub {
     # Use this when you need to see session data
     # $cb->( GET '/testutils/debug_session' );
 
+    # Create an IA from a PR - the link in there uses uppercase
+    my $new_ia_pr_req = $cb->(
+        POST '/ia/create_ia_from_pr',
+        Cookie          => $cookie,
+        Content         => [
+            pr           => 'https://github.com/duckduckgo/zeroclickinfo-goodies/pull/3172',
+            action_token  => $get_action_token->( $cookie ),
+         ],
+    );
+    ok( $new_ia_pr_req->is_success, 'Creating IA from PR' );
+
+    # Find IA - the meta_id should be all lowercase
+    my $lc_ia = $d->rs('InstantAnswer')->find('upper_case_ia_test');
+    ok( $lc_ia, 'Query returns something - the meta_id was correctly formatted' );
+    isa_ok( $lc_ia, 'DDGC::DB::Result::InstantAnswer' );
+
+
 };
 
 # Some basic backend template checks


### PR DESCRIPTION
##### Description :
IDs (and meta_ids) should always be case insensitive, but the format_id() function wasn't called in (here)[https://github.com/duckduckgo/community-platform/blob/master/lib/DDGC/Web/Controller/InstantAnswer.pm#L1259], which allowed people to use uppercase in their IDs when creating an IA Page from a PR.
Just added a call to that function in there, it was an easy fix.

##### Reviewer notes :
When creating an IA Page from the new IA wizard (ia/new_ia), both when filling in the fields and when skipping the wizard by using a PR link, the resulting meta_id for should always be all lowercase.

[This](https://github.com/duckduckgo/zeroclickinfo-goodies/pull/3134) was the PR used to create the IA Page with the uppercase ID, but it's fixed now.

##### References issues / PRs:

#

##### Who should be informed of this change?
@moollaza @tagawa 

##### Does this change have significant privacy, security, performance or deployment implications?


##### Checklist :
- [x] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [x] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android

