### PR TITLE
Use ngBind to replace the <title>

### DIFF
--- a/root/static/pages/ddh_up_index.html
+++ b/root/static/pages/ddh_up_index.html
@@ -77,7 +77,7 @@
 <link rel="stylesheet" href="/ddh-static/fonts/userpages/octicons/octicons.css" charset="utf-8">
 <link rel="stylesheet" href="/ddh-static/css/userpages/UserPage.css">
 
-<title>{{response.gh_data.login}} | DuckDuckHack</title>
+<title ng-bind="response.gh_data.login + ' | ' + 'DuckDuckHack'">DuckDuckHack</title>
 
 <!-- Header -->
 <header>


### PR DESCRIPTION
Since JS needs to execute and fetch the data, the markup in the `<title>` tag is recorded in the history. To get around it, I used the ngBind directive to replace the text inside the tag once the data is available instead of using the template markup.