### PR TITLE
IA Pages - find the correct IA regardless of letter casing in the URL

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -595,7 +595,7 @@ sub ia_base :Chained('base') :PathPart('view') :CaptureArgs(1) {  # /ia/view/cal
     my ( $self, $c, $answer_id ) = @_;
 
     $c->stash->{ia_page} = "IAPage";
-    $c->stash->{ia} = $c->d->rs('InstantAnswer')->find({meta_id => $answer_id});
+    $c->stash->{ia} = $c->d->rs('InstantAnswer')->find({meta_id => lc $answer_id});
     my $ia = $c->stash->{ia};
     
     unless ($ia) {

--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -595,7 +595,7 @@ sub ia_base :Chained('base') :PathPart('view') :CaptureArgs(1) {  # /ia/view/cal
     my ( $self, $c, $answer_id ) = @_;
 
     $c->stash->{ia_page} = "IAPage";
-    $c->stash->{ia} = $c->d->rs('InstantAnswer')->find({meta_id => lc $answer_id});
+    $c->stash->{ia} = $c->d->rs('InstantAnswer')->search( \[ 'LOWER(me.meta_id) = ?', ( lc($answer_id) ) ] )->one_row;
     my $ia = $c->stash->{ia};
     
     unless ($ia) {

--- a/t/instant_answer_basics.t
+++ b/t/instant_answer_basics.t
@@ -258,6 +258,8 @@ $mech->content_contains('test_ia');
 
 $mech->get_ok('/ia/view/test_ia');
 $mech->title_is('Test Ia'); # Title case filter
+$mech->get_ok('/ia/view/TEst_Ia'); # make sure we still get the IA with different letter casing
+$mech->title_is('Test Ia'); # is this the correct IA?
 
 if ( -d $userpage_out ) {
      remove_tree( $userpage_out );


### PR DESCRIPTION
##### Description :
Redirect to the correct IA Page even if the meta_id in the URL contains uppercase chars.
![new-blank](https://cloud.githubusercontent.com/assets/3652195/15823576/94cae86c-2bfb-11e6-8183-1c7c56575687.png)

##### Reviewer notes :
How to test this manually: 
- manually type a single IA Page URL containing one or more uppercase letters. Does it load the correct IA Page?
- Now type the URL for the same IA Page, but using the lowercase meta_id. Does it still load the correct IA Page?

##### References issues / PRs:

#

##### Who should be informed of this change?
@tagawa @russellholt 

##### Does this change have significant privacy, security, performance or deployment implications?


##### Checklist :
- [x] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [x] Chrome
    - [x] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android

