### PR TITLE
Profile links on /blog

### DIFF
--- a/lib/DDGC/DB/Result/User.pm
+++ b/lib/DDGC/DB/Result/User.pm
@@ -4,14 +4,16 @@ package DDGC::DB::Result::User;
 use Moose;
 use MooseX::NonMoose;
 extends 'DDGC::DB::Base::Result';
-with 'DDGC::Schema::Role::Result::User::Subscription';
+with qw/
+    DDGC::Schema::Role::Result::User::Subscription
+    DDGC::Schema::Role::Result::User::Profile
+/;
 use DBIx::Class::Candy;
 use DDGC::User::Page;
 use Path::Class;
 use IPC::Run qw/ run timeout /;
 use LWP::Simple qw/ is_success getstore /;
 use File::Temp qw/ tempfile /;
-use File::Spec::Functions;
 use URI;
 use Carp;
 use Prosody::Mod::Data::Access;
@@ -274,17 +276,6 @@ sub store_github_credentials {
 			gh_data => $gh_data,
 		})
 	}
-}
-
-sub verified_userpage {
-	my ( $self ) = @_;
-	return if !$self->github_id;
-	return if !$self->github_user;
-	my $d = catdir( '/home/ddgc/ddgc/ddh-userpages', lc( $self->github_user ) );
-	return if ( ! -d $d );
-	return URI->new(
-		sprintf( 'https://duckduckhack.com/u/%s#tutorial', lc( $self->github_user ) )
-	)->canonical;
 }
 
 sub has_not_seen_userpage_banner {

--- a/lib/DDGC/Schema/Result/User.pm
+++ b/lib/DDGC/Schema/Result/User.pm
@@ -113,6 +113,21 @@ unique_column github_id => {
 has_many 'roles', 'DDGC::Schema::Result::User::Role', 'users_id';
 has_many 'subscriptions', 'DDGC::Schema::Result::User::Subscription', 'users_id';
 
+sub github_user {
+    my ( $self ) = @_;
+    my $github_stats_user = $self->result_source->schema->storage->dbh_do(
+        sub {
+            return if (!$self->github_id);
+            $_[1]->selectrow_array(
+                'SELECT login FROM github_user WHERE github_id = ?',
+                {}, $self->github_id
+            );
+        }
+    );
+    return $github_stats_user if $github_stats_user;
+    return $self->github_user_plaintext;
+}
+
 sub normalise_role {
     my ( $role ) = @_;
     return 'forum_manager' if ( lc( $role ) eq 'idea_manager' );

--- a/lib/DDGC/Schema/Result/User.pm
+++ b/lib/DDGC/Schema/Result/User.pm
@@ -100,6 +100,11 @@ column updated => {
     set_on_update => 1,
 };
 
+column github_user_plaintext => {
+    data_type => 'text',
+    is_nullable => 1
+};
+
 unique_column github_id => {
     data_type => 'bigint',
     is_nullable => 1

--- a/lib/DDGC/Schema/Result/User.pm
+++ b/lib/DDGC/Schema/Result/User.pm
@@ -4,7 +4,10 @@ package DDGC::Schema::Result::User;
 
 use Moo;
 extends 'DDGC::Schema::Result';
-with 'DDGC::Schema::Role::Result::User::Subscription';
+with qw/
+    DDGC::Schema::Role::Result::User::Subscription
+    DDGC::Schema::Role::Result::User::Profile
+/;
 
 use DBIx::Class::Candy;
 use Scalar::Util qw/ looks_like_number /;

--- a/lib/DDGC/Schema/Role/Result/User/Profile.pm
+++ b/lib/DDGC/Schema/Role/Result/User/Profile.pm
@@ -1,0 +1,19 @@
+package DDGC::Schema::Role::Result::User::Profile;
+use strict;
+use warnings;
+
+use Moo::Role;
+use File::Spec::Functions;
+
+sub verified_userpage {
+    my ( $self ) = @_;
+    return if !$self->github_id;
+    return if !$self->github_user;
+    my $d = catdir( '/home/ddgc/ddgc/ddh-userpages', lc( $self->github_user ) );
+    return if ( ! -d $d );
+    return URI->new(
+        sprintf( 'https://duckduckhack.com/u/%s#tutorial', lc( $self->github_user ) )
+    )->canonical;
+}
+
+1;

--- a/templates/header_accountinfo.tx
+++ b/templates/header_accountinfo.tx
@@ -10,9 +10,10 @@
 	<div class="modal__box">
 	  <div class="modal__body">
 	    <div><a href="<: $u('My','account') :>">Settings</a></div>
-            <: if $c.user.verified_userpage { :>
+            : my $up = $c.user.verified_userpage;
+            : if $up {
               <div><a href="<: $c.user.verified_userpage :>">Profile</a></div>
-            <: } :>
+            : }
 	    <div><a href="<: $u('My','logout', { action_token => $action_token }) :>">Logout</a></div>
 	  </div>
 	</div>

--- a/views/includes/header/accountinfo.tx
+++ b/views/includes/header/accountinfo.tx
@@ -10,6 +10,10 @@
         <div class="modal__box">
           <div class="modal__body">
             <div><a href="/my/account">Settings</a></div>
+            : my $up = $vars.user.verified_userpage;
+            : if $up {
+              <div><a href="<: $up :>">Profile</a></div>
+            : }
             <div><a href="<: uri_for('/my/logout', { action_token => $session.action_token }) :>">Logout</a></div>
           </div>
         </div>

--- a/views/includes/header/nav.tx
+++ b/views/includes/header/nav.tx
@@ -1,8 +1,8 @@
 <div class="header-nav">
     <ul>
-        <li class="nav-develop"><a href="https://duck.co/ia/dev">Instant Answers</a></li>
+        <li class="nav-develop"><a href="/ia/dev">Instant Answers</a></li>
         <li class="nav-docs"><a href="http://docs.duckduckhack.com/">Docs</a></li>
-        <li class="nav-help"><a href="https://duck.co/help">Help</a></li>
-        <li class="nav-blog"><a href="https://duck.co/blog">Blog</a></li>
+        <li class="nav-help"><a href="/help">Help</a></li>
+        <li class="nav-blog"><a href="/blog">Blog</a></li>
     </ul>
 </div>

--- a/views/includes/modal_login.tx
+++ b/views/includes/modal_login.tx
@@ -34,6 +34,8 @@
             </span>
         </fieldset>
 
+        or <a href="/my/github_oauth" name="register">Login with Github</a>
+
         <div class="account-links clear">
             <p class="half  palm-half">
                 <a href="/my/forgotpw">Forgot your password?</a>


### PR DESCRIPTION
##### Description :

Adds profile link to blog template where a DDH profile is present for the logged in user
##### Reviewer notes :
- You will need Github oauth set up.
- Generate user pages from synced IA data (if you have not already)
- Log into your dev instance as a user with a DDH Profile via Github.
- Clicking your username in the top right of /blog/\* should show a 'Profile' link if the logged in user has a userpage
- This should link to the correct profile on duckduckhack.com
##### References issues / PRs:
#1394 - Add DuckDuckHack Profile in the Dropdown
##### Who should be informed of this change?

 @jagtalon @MariagraziaAlastra 
##### Does this change have significant privacy, security, performance or deployment implications?

No
##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
  - [ ] IE
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [ ] Opera 
- Mobile verification
  - [ ] iOS
  - [ ] Android
