### PR TITLE
Update IA page regex to match standard format

### DIFF
--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -83,12 +83,12 @@ sub getIssues{
 			# Match (roughly) the following formats:
 			# Instant Answer Page: Link   <- preferred standard link
 			# [Instant Answer Page](Link) <- GHFM link
-			my $name_from_link = '';
-            ($name_from_link) = $issue->{'body'} =~ qr{
-                \[(?:Instant\s?Answer|IA)\sPage\]\(https?://duck\.co/ia/view/(\w+)\)
-                | (?:Instant\s?Answer|IA)\sPage:\s https?://duck\.co/ia/view/(\w+)}ix;
+			$issue->{'body'} =~ qr{
+				\[(?:Instant\s?Answer|IA)\sPage\]\(https?://duck\.co/ia/view/(?<id>\w+)\)
+				| (?:Instant\s?Answer|IA)\sPage:\s https?://duck\.co/ia/view/(?<id>\w+)}ix;
 
-            # remove special chars from title and body
+			my $name_from_link = $+{id} // '';
+			# remove special chars from title and body
 			$issue->{'body'} =~ s/\'//g;
 			$issue->{'title'} =~ s/\'//g;
 

--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -80,8 +80,13 @@ sub getIssues{
 
             # get the IA name from the link in the first comment
 			# Update this later for whatever format we decide on
+			# Match (roughly) the following formats:
+			# Instant Answer Page: Link   <- preferred standard link
+			# [Instant Answer Page](Link) <- GHFM link
 			my $name_from_link = '';
-            ($name_from_link) = $issue->{'body'} =~ /https?:\/\/duck\.co\/ia\/view\/(\w+)/i;
+            ($name_from_link) = $issue->{'body'} =~ qr{
+                \[(?:Instant\s?Answer|IA)\sPage\]\(https?://duck\.co/ia/view/(\w+)\)
+                | (?:Instant\s?Answer|IA)\sPage:\s https?://duck\.co/ia/view/(\w+)}ix;
 
             # remove special chars from title and body
 			$issue->{'body'} =~ s/\'//g;


### PR DESCRIPTION
##### Description :

Updates the IA page regex to only match certain contexts, so we don't incorrectly infer which IA the PR/issue belongs to.

##### Reviewer notes :


##### References issues / PRs:

Fixes #1371 

##### Who should be informed of this change?

@jdorweiler 

##### Does this change have significant privacy, security, performance or deployment implications?

I really hope not.

##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android