### PR TITLE
Change livereload port - 5000 used by too much other stuff

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,7 +10,7 @@ module.exports = function(grunt) {
     var reload = {
 	livereload: {
 	    host: os.hostname(),
-	    port: 5000
+	    port: 5555
 	}
     };
 

--- a/lib/DDGC/Config.pm
+++ b/lib/DDGC/Config.pm
@@ -62,7 +62,7 @@ sub has_conf {
 has_conf nid => DDGC_NID => 1;
 has_conf pid => DDGC_PID => $$;
 
-has_conf livereload_js_uri => DDGC_LIVERELOAD_JS_URI => sprintf( 'http://%s:5000/livereload.js', hostname() );
+has_conf livereload_js_uri => DDGC_LIVERELOAD_JS_URI => sprintf( 'http://%s:5555/livereload.js', hostname() );
 has_conf appdir_path => DDGC_APPDIR => sub {
 	( -f "$FindBin::Bin/../package.json" ) && return "$FindBin::Bin/../";
 	return "/home/ddgc/live/";


### PR DESCRIPTION
##### Description :

Change livereload port to 5555 (an arbitrary free port) - 5000 used by too much other stuff
##### Reviewer notes :

Does livereload still work?
##### References issues / PRs:
##### Who should be informed of this change?

@MariagraziaAlastra 
##### Does this change have significant privacy, security, performance or deployment implications?

No
##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
  - [ ] IE
  - [ ] Chrome
  - [x] Firefox
  - [ ] Safari
  - [ ] Opera 
- Mobile verification
  - [ ] iOS
  - [ ] Android
