### PR TITLE
Commit Page - don't linkify maintainer and devs

### DIFF
--- a/src/templates/commit_page.handlebars
+++ b/src/templates/commit_page.handlebars
@@ -193,14 +193,14 @@
                 <td name="maintainer"  id="maintainer_original">
                     {{#if original.maintainer}}
                         {{#if original.maintainer.github}}
-                            <a href="http://duckduckhack.com/u/{{slug original.maintainer.github}}">{{original.maintainer.github}}</a>
+                            {{original.maintainer.github}}
                         {{/if}}
                     {{/if}}
                 </td>
                 <td name="maintainer">
                     {{#if maintainer}}
                         {{#if maintainer.github}}
-                            <a href="http://duckduckhack.com/u/{{slug maintainer.github}}">{{maintainer.github}}</a>
+                            {{maintainer.github}}
                         {{/if}}
                     {{/if}}
                 </td>
@@ -227,18 +227,14 @@
                 <td name="developer"  id="developer_original">
                     {{#each original.developer}}
                         <li data-type="{{type}}">
-                            <a href="{{#eq type 'github'}}https://duckduckhack.com/u/{{slug name}}{{else}}{{url}}{{/eq}}">
                                 {{name}}
-                            </a>
                         </li>
                     {{/each}}
                 </td>
                 <td name="developer">
                     {{#each developer}}
                         <li data-type="{{type}}">
-                            <a href="{{#eq type 'github'}}https://duckduckhack.com/u/{{slug name}}{{else}}{{url}}{{/eq}}">
                                 {{name}}
-                            </a>
                         </li>
                     {{/each}}
                 </td>


### PR DESCRIPTION
##### Description :
Don't linkify maintainer and devs so it's easier to select the change to commit.
![screenshot-maria duckduckgo com 5001 2016-07-11 13-38-53](https://cloud.githubusercontent.com/assets/3652195/16729525/487ad43a-476d-11e6-8640-6ebc347df305.png)


##### Reviewer notes :
Try changing the devs and maintainer values and go to the commit page. Expected: text only, no links.

##### References issues / PRs:

#

##### Who should be informed of this change?


##### Does this change have significant privacy, security, performance or deployment implications?


##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [x] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android

