### PR TITLE
Dev IA Pages - fix assigning edit permissions to the maintainer

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -1044,7 +1044,7 @@ sub save_edit :Chained('base') :PathPart('save') :Args(0) {
             if ($field =~ /designer|producer/){
                 return $c->forward($c->view('JSON')) unless ($complat_user_admin || $value eq '');
             } elsif ($field eq "maintainer") {
-                return $c->forward($c->view('JSON')) unless $value = format_maintainer($c, $value, $ia, 0);
+                return $c->forward($c->view('JSON')) unless $value = format_maintainer($c, $value, $ia, $autocommit);
             } elsif ($field eq "id") {
                 return $c->forward($c->view('JSON')) unless $is_admin;
                 $field = "meta_id";


### PR DESCRIPTION
##### Description :
Fixes a bug with giving edit permissions to the maintainer when the IA is not yet live.
The culprit is we required the edit to be committed, and didn't take into account autocommitting, when assigning permissions, so it worked only for live IAs.

##### Reviewer notes :
I wrote a back-end test for this in instant_answers_basics.t but you can also test it manually by logging in as admin, changing the maintainer of a live IA and an IA in development to another non-admin user in your instance (it needs to have a GitHub account connected though), log out, log in again as the non-admin user, load again the pages and see if you have edit permissions for them.

##### References issues / PRs:

#

##### Who should be informed of this change?
@moollaza 

##### Does this change have significant privacy, security, performance or deployment implications?
I'd like to stage the changes and then deploy to prod either today or tomorrow after this is merged.

##### Checklist :
- [x] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [x] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
