### PR TITLE
Commit Page - send developer account URL to the backend

### DIFF
--- a/src/js/ia/IAPageCommit.js
+++ b/src/js/ia/IAPageCommit.js
@@ -56,7 +56,7 @@
                                                 var temp_dev = {};
                                                 temp_dev.name = $.trim($(this).text());
                                                 temp_dev.type = $.trim($(this).attr("data-type"));
-                                                temp_dev.url = $.trim($(this).find("a").attr("href"));
+                                                temp_dev.url = $.trim($(this).attr("data-url"));
 
                                                 temp_value.push(temp_dev);
                                             } else {

--- a/src/templates/commit_page.handlebars
+++ b/src/templates/commit_page.handlebars
@@ -226,14 +226,14 @@
 
                 <td name="developer"  id="developer_original">
                     {{#each original.developer}}
-                        <li data-type="{{type}}">
+                        <li data-url="{{url}}" data-type="{{type}}">
                                 {{name}}
                         </li>
                     {{/each}}
                 </td>
                 <td name="developer">
                     {{#each developer}}
-                        <li data-type="{{type}}">
+                        <li data-url="{{url}}" data-type="{{type}}">
                                 {{name}}
                         </li>
                     {{/each}}


### PR DESCRIPTION
##### Description :
Fixes an issue with DDH profile URLs not showing on the IA Pages for contributors, when they're added manually.

There was a missing parameter, the URL, not being sent to the backend on commit - the issue affects the live IA Pages.

##### Reviewer notes :


##### References issues / PRs:

#

##### Who should be informed of this change?
@jbarrett 

##### Does this change have significant privacy, security, performance or deployment implications?
I need to deploy this asap as hotfix

##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [x] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android

