### PR TITLE
remove topics and add programming mission topics

### DIFF
--- a/sql/1.183/update_topics.sql
+++ b/sql/1.183/update_topics.sql
@@ -1,0 +1,12 @@
+BEGIN;
+TRUNCATE TABLE instant_answer_topics;
+TRUNCATE TABLE topics CASCADE;
+INSERT INTO topics (name) VALUES ('python');
+INSERT INTO topics (name) VALUES ('swift');
+INSERT INTO topics (name) VALUES ('javascript');
+INSERT INTO topics (name) VALUES ('css');
+INSERT INTO topics (name) VALUES ('perl');
+
+# do stuff add stack_overflow to all topics
+
+COMMIT;

--- a/sql/1.183/update_topics.sql
+++ b/sql/1.183/update_topics.sql
@@ -6,7 +6,9 @@ INSERT INTO topics (name) VALUES ('swift');
 INSERT INTO topics (name) VALUES ('javascript');
 INSERT INTO topics (name) VALUES ('css');
 INSERT INTO topics (name) VALUES ('perl');
-
-# do stuff add stack_overflow to all topics
-
+insert into instant_answer_topics (instant_answer_id, topics_id) select 'stack_overflow', id from topics where name='python';
+insert into instant_answer_topics (instant_answer_id, topics_id) select 'stack_overflow', id from topics where name='swift';
+insert into instant_answer_topics (instant_answer_id, topics_id) select 'stack_overflow', id from topics where name='javascript';
+insert into instant_answer_topics (instant_answer_id, topics_id) select 'stack_overflow', id from topics where name='css';
+insert into instant_answer_topics (instant_answer_id, topics_id) select 'stack_overflow', id from topics where name='perl';
 COMMIT;


### PR DESCRIPTION
Remove all the old topics and update with new programming mission search spaces. We're going to use topics to tag IAs as being part of the programming mission. 
I'm also adding the topics to stack_overflow since the topics update template only allows 3 topics. We might have to fix that later to allow more. 