### PR TITLE
update ia page regex

### DIFF
--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -84,8 +84,8 @@ sub getIssues{
 			# Instant Answer Page: Link   <- preferred standard link
 			# [Instant Answer Page](Link) <- GHFM link
 			$issue->{'body'} =~ qr{
-				\[(?:Instant\s?Answer|IA)\sPage\]\(https?://duck\.co/ia/view/(?<id>\w+)\)
-				| (?:Instant\s?Answer|IA)\sPage:\s https?://duck\.co/ia/view/(?<id>\w+)}ix;
+				\[(?:Instant\s?Answer|IA)\sPage\]\(https?://duck\.co/ia/view/(?<id>\w+[^\s])\)
+				| (?:Instant\s?Answer|IA)\sPage:?\s+ https?://duck\.co/ia/view/(?<id>\w+[^\s])}ix;
 
 			my $name_from_link = $+{id} // '';
 			# remove special chars from title and body


### PR DESCRIPTION
Updated the regex that finds IA page links in the first post of issues and pull requests. I updated it to be a little more forgiving by allowing extra spaces before the url and pulling off trailing spaces after the url.

cc/ @GuiltyDolphin 