### PR TITLE
Subscriber management and mailer jobs

### DIFF
--- a/lib/DDGC/Base/Web/Light.pm
+++ b/lib/DDGC/Base/Web/Light.pm
@@ -1,0 +1,48 @@
+package DDGC::Base::Web::Light;
+
+# ABSTRACT: Base module for simple, unintegrated web apps
+
+# Drops: Sessions, user integration
+# Keeps: Database
+
+use Import::Into;
+
+use strict;
+use warnings;
+use utf8;
+
+use Dancer2;
+use Dancer2::Plugin::DBIC;
+use Dancer2::Plugin::RootURIFor;
+use Dancer2::Plugin::Params::HashMultiValue;
+use Dancer2::Plugin::DDGC::Config;
+use Dancer2::Plugin::DDGC::SchemaApp;
+
+{   no warnings 'redefine';
+    sub import {
+        my ($caller, $filename) = caller;
+        for (
+          qw/
+            strict
+            warnings
+            utf8
+            Dancer2
+          /
+        ) {
+            $_->import::into($caller);
+        }
+        Dancer2::Plugin::DDGC::Config->import::into( $caller, 'nosession' );
+        for (
+          qw/
+            Dancer2::Plugin::DBIC
+            Dancer2::Plugin::RootURIFor
+            Dancer2::Plugin::Params::HashMultiValue
+            Dancer2::Plugin::DDGC::SchemaApp
+          /
+        ) {
+            $_->import::into($caller);
+        }
+    }
+};
+
+1;

--- a/lib/DDGC/Schema/Result/Subscriber.pm
+++ b/lib/DDGC/Schema/Result/Subscriber.pm
@@ -45,7 +45,7 @@ sub _url {
         sprintf "/s/%s/%s/%s/%s",
         ( $type eq 'u' ? 'u' : 'v' ),
         $self->campaign,
-        $self->email_address,
+        $self->email_address =~ s/\@/%24/gr,
         ( $type eq 'u' ? $self->u_key : $self->v_key )
     );
     return $u->canonical->as_string;

--- a/lib/DDGC/Schema/Result/Subscriber.pm
+++ b/lib/DDGC/Schema/Result/Subscriber.pm
@@ -22,7 +22,7 @@ column created      => {
     set_on_create => 1,
 };
 
-has_many => logs => 'DDGC::Schema::Result::Subscriber::MailLog' => {
+has_many logs => 'DDGC::Schema::Result::Subscriber::MailLog' => {
     'foreign.email_address' => 'self.email_address',
     'foreign.campaign'      => 'self.campaign',
 };
@@ -54,12 +54,12 @@ sub _url {
 
 sub verify_url {
     my ( $self ) = @_;
-    self->_url( 'v' );
+    $self->_url( 'v' );
 }
 
 sub unsubscribe_url {
     my ( $self ) = @_;
-    self->_url( 'u' );
+    $self->_url( 'u' );
 }
 
 sub verify {

--- a/lib/DDGC/Schema/Result/Subscriber.pm
+++ b/lib/DDGC/Schema/Result/Subscriber.pm
@@ -1,0 +1,76 @@
+package DDGC::Schema::Result::Subscriber;
+
+use Moo;
+extends 'DDGC::Schema::Result';
+use DBIx::Class::Candy;
+
+use URI;
+use Digest::SHA1;
+
+table 'subscriber';
+
+primary_column email_address => { data_type => 'text' };
+primary_column campaign      => { data_type => 'text' };
+
+column verified     => { data_type => 'int', default_value => 0 };
+column unsubscribed => { data_type => 'int', default_value => 0 };
+column v_key        => { data_type => 'text' };
+column u_key        => { data_type => 'text' };
+column created      => {
+    data_type => 'timestamp with time zone',
+    set_on_create => 1,
+};
+
+has_many => logs => 'DDGC::Schema::Result::Subscriber::MailLog' => {
+    'foreign.email_address' => 'self.email_address',
+    'foreign.campaign'      => 'self.campaign',
+};
+
+around new => sub {
+    my $orig = shift;
+    my $self = shift;
+    $_[0]->{v_key} = _key();
+    $_[0]->{u_key} = _key();
+    $orig->( $self, @_ );
+};
+
+sub _key {
+    Digest::SHA1::sha1_hex( rand() . $$ . {} . time );
+}
+
+sub _url {
+    my ( $self, $type ) = @_;
+    my $u = URI->new( $self->app->config->{ddgc_config}->web_base );
+    $u->path(
+        sprintf "/s/%s/%s/%s/%s",
+        ( $type eq 'u' ? 'u' : 'v' ),
+        $self->campaign,
+        $self->email_address,
+        ( $type eq 'u' ? $self->u_key : $self->v_key )
+    );
+    return $u->canonical->as_string;
+}
+
+sub verify_url {
+    my ( $self ) = @_;
+    self->_url( 'v' );
+}
+
+sub unsubscribe_url {
+    my ( $self ) = @_;
+    self->_url( 'u' );
+}
+
+sub verify {
+    my ( $self, $key ) = @_;
+    $self->update({ verified => 1 })
+        if ( $key eq $self->v_key );
+}
+
+sub unsubscribe {
+    my ( $self, $key ) = @_;
+    $self->update({ unsubscribed => 1 })
+        if ( $key eq $self->u_key );
+}
+
+1;

--- a/lib/DDGC/Schema/Result/Subscriber.pm
+++ b/lib/DDGC/Schema/Result/Subscriber.pm
@@ -14,6 +14,7 @@ primary_column campaign      => { data_type => 'text' };
 
 column verified     => { data_type => 'int', default_value => 0 };
 column unsubscribed => { data_type => 'int', default_value => 0 };
+column flow         => { data_type => 'text', is_nullable => 1 };
 column v_key        => { data_type => 'text' };
 column u_key        => { data_type => 'text' };
 column created      => {

--- a/lib/DDGC/Schema/Result/Subscriber.pm
+++ b/lib/DDGC/Schema/Result/Subscriber.pm
@@ -46,7 +46,7 @@ sub _url {
         sprintf "/s/%s/%s/%s/%s",
         ( $type eq 'u' ? 'u' : 'v' ),
         $self->campaign,
-        $self->email_address =~ s/\@/%24/gr,
+        $self->email_address =~ s/\@/%40/gr,
         ( $type eq 'u' ? $self->u_key : $self->v_key )
     );
     return $u->canonical->as_string;

--- a/lib/DDGC/Schema/Result/Subscriber/MailLog.pm
+++ b/lib/DDGC/Schema/Result/Subscriber/MailLog.pm
@@ -1,0 +1,23 @@
+package DDGC::Schema::Result::Subscriber::MailLog;
+
+use Moo;
+extends 'DDGC::Schema::Result';
+use DBIx::Class::Candy;
+
+table 'subscriber_maillog';
+
+primary_column email_address => { data_type => 'text' };
+primary_column campaign      => { data_type => 'text' };
+primary_column email_id      => { data_type => 'char', size => 1 };
+
+column sent => {
+    data_type => 'timestamp with time zone',
+    set_on_create => 1,
+};
+
+belongs_to subscriber => 'DDGC::Schema::Result::Subscriber' => {
+    'foreign.email_address' => 'self.email_address',
+    'foreign.campaign'      => 'self.campaign',
+};
+
+1;

--- a/lib/DDGC/Schema/ResultSet/Subscriber.pm
+++ b/lib/DDGC/Schema/ResultSet/Subscriber.pm
@@ -1,0 +1,58 @@
+package DDGC::Schema::ResultSet::Subscriber;
+
+use Moo;
+extends 'DDGC::Schema::ResultSet';
+
+use DateTime;
+use DateTime::Duration;
+
+sub campaign {
+    my ( $self, $c ) = @_;
+    $self->search_rs( { campaign => $c } );
+}
+
+sub subscribed {
+    my ( $self ) = @_;
+    $self->search_rs( { unsubscribed => 0 } );
+}
+
+sub verified {
+    my ( $self ) = @_;
+    $self->search_rs( { verified => 1 } );
+}
+
+sub unverified {
+    my ( $self ) = @_;
+    $self->search_rs( { verified => 0 } );
+}
+
+sub verification_mail_unsent_for {
+    my ( $self, $campaign ) = @_;
+    $self->search_rs( {
+        email_address => { -not_in => \[
+                'SELECT email_address
+                 FROM subscriber_maillog
+                 WHERE campaign = ?
+                 AND email_id = \'verify\'',
+                $campaign
+            ],
+        }
+    } );
+}
+
+sub by_days_ago {
+    my ( $self, $days ) = @_;
+    my $today = DateTime->now->truncate( to => 'day' );
+    my $end = $self->format_datetime(
+        $today->subtract( days => $days )
+    );
+    my $start = $self->format_datetime(
+        $today->subtract( days => 1 )
+    );
+
+    $self->search_rs( {
+        created => 
+    } );
+}
+
+1;

--- a/lib/DDGC/Schema/ResultSet/Subscriber.pm
+++ b/lib/DDGC/Schema/ResultSet/Subscriber.pm
@@ -26,6 +26,20 @@ sub unverified {
     $self->search_rs( { verified => 0 } );
 }
 
+sub mail_unsent {
+    my ( $self, $campaign, $email ) = @_;
+    $self->search_rs( {
+        email_address => { -not_in => \[
+                'SELECT email_address
+                 FROM subscriber_maillog
+                 WHERE campaign = ?
+                 AND email_id = ?',
+                [ $campaign, $email ]
+            ],
+        }
+    } );
+}
+
 sub verification_mail_unsent_for {
     my ( $self, $campaign ) = @_;
     $self->search_rs( {

--- a/lib/DDGC/Schema/ResultSet/Subscriber.pm
+++ b/lib/DDGC/Schema/ResultSet/Subscriber.pm
@@ -34,7 +34,7 @@ sub mail_unsent {
                  FROM subscriber_maillog
                  WHERE campaign = ?
                  AND email_id = ?',
-                [ $campaign, $email ]
+                ( $campaign, $email )
             ],
         }
     } );
@@ -58,14 +58,14 @@ sub by_days_ago {
     my ( $self, $days ) = @_;
     my $today = DateTime->now->truncate( to => 'day' );
     my $end = $self->format_datetime(
-        $today->subtract( days => $days )
+        $today->subtract( days => ( $days - 1 ) )
     );
     my $start = $self->format_datetime(
         $today->subtract( days => 1 )
     );
 
     $self->search_rs( {
-        created => 
+        created => { -between => [ $start, $end ] }
     } );
 }
 

--- a/lib/DDGC/Schema/ResultSet/Subscriber.pm
+++ b/lib/DDGC/Schema/ResultSet/Subscriber.pm
@@ -33,7 +33,7 @@ sub verification_mail_unsent_for {
                 'SELECT email_address
                  FROM subscriber_maillog
                  WHERE campaign = ?
-                 AND email_id = \'verify\'',
+                 AND email_id = \'v\'',
                 $campaign
             ],
         }

--- a/lib/DDGC/Util/Email.pm
+++ b/lib/DDGC/Util/Email.pm
@@ -146,6 +146,8 @@ sub send {
             ],
         }
     }
+
+    return { ok => 1 };
 }
 
 sub DESTROY {

--- a/lib/DDGC/Util/Script/SubscriberMailer.pm
+++ b/lib/DDGC/Util/Script/SubscriberMailer.pm
@@ -73,7 +73,7 @@ sub email {
     } );
 
     if ( $status->{ok} ) {
-        $subscriber->update_or_create_related( 'logs', $log );
+        $subscriber->update_or_create_related( 'logs', { email_id => $log } );
     }
 }
 

--- a/lib/DDGC/Util/Script/SubscriberMailer.pm
+++ b/lib/DDGC/Util/Script/SubscriberMailer.pm
@@ -123,6 +123,8 @@ sub verify {
             );
         }
     }
+
+    return $self->smtp->transport;
 }
 
 1;

--- a/lib/DDGC/Util/Script/SubscriberMailer.pm
+++ b/lib/DDGC/Util/Script/SubscriberMailer.pm
@@ -115,7 +115,7 @@ sub verify {
 
         for my $subscriber ( @subscribers ) {
             $self->email(
-                'verify',
+                'v',
                 $subscriber,
                 $self->campaigns->{verify}->{subject},
                 $self->campaigns->{verify}->{template},

--- a/lib/DDGC/Util/Script/SubscriberMailer.pm
+++ b/lib/DDGC/Util/Script/SubscriberMailer.pm
@@ -19,37 +19,37 @@ sub _build_campaigns {
             },
             mails => {
                 1 => {
-                    days     => 2,
+                    days     => 1,
                     subject  => 'Placeholder 1',
                     template => 'email/a/1.tx',
                 },
                 2 => {
-                    days     => 5,
+                    days     => 3,
                     subject  => 'Placeholder 2',
                     template => 'email/a/2.tx',
                 },
                 3 => {
-                    days     => 10,
+                    days     => 5,
                     subject  => 'Placeholder 3',
                     template => 'email/a/3.tx',
                 },
                 4 => {
-                    days     => 17,
+                    days     => 7,
                     subject  => 'Placeholder 4',
                     template => 'email/a/4.tx',
                 },
                 5 => {
-                    days     => 25,
+                    days     => 9,
                     subject  => 'Placeholder 5',
                     template => 'email/a/5.tx',
                 },
                 6 => {
-                    days     => 35,
+                    days     => 11,
                     subject  => 'Placeholder 6',
                     template => 'email/a/6.tx',
                 },
                 7 => {
-                    days     => 40,
+                    days     => 15,
                     subject  => 'Placeholder 7',
                     template => 'email/a/7.tx',
                 },

--- a/lib/DDGC/Util/Script/SubscriberMailer.pm
+++ b/lib/DDGC/Util/Script/SubscriberMailer.pm
@@ -86,6 +86,7 @@ sub execute {
                 ->campaign( $campaign )
                 ->subscribed
                 ->verified
+                ->mail_unsent( $campaign, $mail )
                 ->by_days_ago( $mail->{days} )
                 ->all;
 

--- a/lib/DDGC/Util/Script/SubscriberMailer.pm
+++ b/lib/DDGC/Util/Script/SubscriberMailer.pm
@@ -121,8 +121,8 @@ sub verify {
             $self->email(
                 'v',
                 $subscriber,
-                $self->campaigns->{verify}->{subject},
-                $self->campaigns->{verify}->{template},
+                $self->campaigns->{ $campaign }->{verify}->{subject},
+                $self->campaigns->{ $campaign }->{verify}->{template},
                 1
             );
         }

--- a/lib/DDGC/Util/Script/SubscriberMailer.pm
+++ b/lib/DDGC/Util/Script/SubscriberMailer.pm
@@ -83,21 +83,21 @@ sub execute {
 
     for my $campaign ( keys %{ $self->campaigns } ) {
         next if !$self->campaigns->{ $campaign }->{live};
-        for my $mail ( keys %{ $self->campaigns->{ $campaign }->mails } ) {
+        for my $mail ( keys %{ $self->campaigns->{ $campaign }->{mails} } ) {
             my @subscribers = rset('Subscriber')
                 ->campaign( $campaign )
                 ->subscribed
                 ->verified
                 ->mail_unsent( $campaign, $mail )
-                ->by_days_ago( $mail->{days} )
+                ->by_days_ago( $self->campaigns->{ $campaign }->{mails}->{ $mail }->{days} )
                 ->all;
 
             for my $subscriber ( @subscribers ) {
                 $self->email(
                     $mail,
                     $subscriber,
-                    $self->campaigns->{ $campaign }->mails->{ $mail }->{subject},
-                    $self->campaigns->{ $campaign }->mails->{ $mail }->{template},
+                    $self->campaigns->{ $campaign }->{mails}->{ $mail }->{subject},
+                    $self->campaigns->{ $campaign }->{mails}->{ $mail }->{template},
                 );
             }
         }

--- a/lib/DDGC/Util/Script/SubscriberMailer.pm
+++ b/lib/DDGC/Util/Script/SubscriberMailer.pm
@@ -1,0 +1,128 @@
+use strict;
+use warnings;
+package DDGC::Util::Script::SubscriberMailer;
+
+use DateTime;
+use Moo;
+
+with 'DDGC::Util::Script::Base::Service';
+with 'DDGC::Util::Script::Base::ServiceEmail';
+
+has campaigns => ( is => 'lazy' );
+sub _build_campaigns {
+    {
+        'a' => {
+            verify => {
+                subject => 'Please verify your email address',
+                template => 'email/a/v.tx'
+            },
+            mails => {
+                1 => {
+                    days     => 2,
+                    subject  => 'Placeholder 1',
+                    template => 'email/a/1.tx',
+                },
+                2 => {
+                    days     => 5,
+                    subject  => 'Placeholder 2',
+                    template => 'email/a/2.tx',
+                },
+                3 => {
+                    days     => 10,
+                    subject  => 'Placeholder 3',
+                    template => 'email/a/3.tx',
+                },
+                4 => {
+                    days     => 17,
+                    subject  => 'Placeholder 4',
+                    template => 'email/a/4.tx',
+                },
+                5 => {
+                    days     => 25,
+                    subject  => 'Placeholder 5',
+                    template => 'email/a/5.tx',
+                },
+                6 => {
+                    days     => 35,
+                    subject  => 'Placeholder 6',
+                    template => 'email/a/6.tx',
+                },
+                7 => {
+                    days     => 40,
+                    subject  => 'Placeholder 7',
+                    template => 'email/a/7.tx',
+                },
+            }
+        }
+    },
+}
+
+sub email {
+    my ( $self, $log, $subscriber, $subject, $template, $verified ) = @_;
+
+    my $status = $self->smtp->send( {
+        to       => $subscriber->email_address,
+        verified => $verified
+                    || ( $subscriber->verified && !$subscriber->unsubscribed ),
+        from     => '"DuckDuckGo" <info@duckduckgo.com>',
+        subject  => $subject,
+        template => $template,
+        content  => {
+            subscriber => $subscriber,
+        }
+    } );
+
+    if ( $status->{ok} ) {
+        $subscriber->update_or_create_related( 'logs', $log );
+    }
+}
+
+sub execute {
+    my ( $self ) = @_;
+
+    for my $campaign ( keys %{ $self->campaigns } ) {
+        for my $mail ( keys %{ $self->campaigns->{ $campaign }->mails } ) {
+            my @subscribers = rset('Subscriber')
+                ->campaign( $campaign )
+                ->subscribed
+                ->verified
+                ->by_days_ago( $mail->{days} )
+                ->all;
+
+            for my $subscriber ( @subscribers ) {
+                $self->email(
+                    $mail,
+                    $subscriber,
+                    $self->campaigns->{ $campaign }->mails->{ $mail }->{subject},
+                    $self->campaigns->{ $campaign }->mails->{ $mail }->{template},
+                );
+            }
+        }
+    }
+
+    return $self->smtp->transport;
+}
+
+sub verify {
+    my ( $self ) = @_;
+
+    for my $campaign ( keys %{ $self->campaigns } ) {
+        my @subscribers = rset('Subscriber')
+            ->campaign( $campaign )
+            ->unverified
+            ->verification_mail_unsent_for( $campaign )
+            ->all;
+
+        for my $subscriber ( @subscribers ) {
+            $self->email(
+                'verify',
+                $subscriber,
+                $self->campaigns->{verify}->{subject},
+                $self->campaigns->{verify}->{template},
+                1
+            );
+        }
+    }
+}
+
+1;

--- a/lib/DDGC/Util/Script/SubscriberMailer.pm
+++ b/lib/DDGC/Util/Script/SubscriberMailer.pm
@@ -12,6 +12,7 @@ has campaigns => ( is => 'lazy' );
 sub _build_campaigns {
     {
         'a' => {
+            live => 1,
             verify => {
                 subject => 'Please verify your email address',
                 template => 'email/a/v.tx'
@@ -81,6 +82,7 @@ sub execute {
     my ( $self ) = @_;
 
     for my $campaign ( keys %{ $self->campaigns } ) {
+        next if !$self->campaigns->{ $campaign }->{live};
         for my $mail ( keys %{ $self->campaigns->{ $campaign }->mails } ) {
             my @subscribers = rset('Subscriber')
                 ->campaign( $campaign )
@@ -108,6 +110,7 @@ sub verify {
     my ( $self ) = @_;
 
     for my $campaign ( keys %{ $self->campaigns } ) {
+        next if !$self->campaigns->{ $campaign }->{live};
         my @subscribers = rset('Subscriber')
             ->campaign( $campaign )
             ->unverified

--- a/lib/DDGC/Web/App/Subscriber.pm
+++ b/lib/DDGC/Web/App/Subscriber.pm
@@ -1,0 +1,46 @@
+package DDGC::Web::App::Subscriber;
+
+# ABSTRACT: Subscriber management
+
+use DDGC::Base::Web::Light;
+
+get '/u/:campaign/:email/:key' => sub {
+    my $params = params('route');
+    my $s = rset('Subscriber')->find( {
+        email    => $params->{email},
+        campaign => $params->{campaign},
+    } );
+    if ( !$s || !$s->unsubscribe( $params->{ key } ) ) {
+        status 500;
+        return "NOT OK";
+    }
+    return "OK";
+};
+
+get '/v/:campaign/:email/:key' => sub {
+    my $params = params('route');
+    my $s = rset('Subscriber')->find( {
+        email    => $params->{email},
+        campaign => $params->{campaign},
+    } );
+    if ( !$s || !$s->verify( $params->{ key } ) ) {
+        status 500;
+        return "NOT OK";
+    }
+    return "OK";
+};
+
+post '/a' => sub {
+    my $params = params('body');
+    my $s = rset('Subscriber')->create( {
+        email_address => $params->{email},
+        campaign => $params->{campaign},
+    } );
+    if ( !$s ) {
+        status 500;
+        return "NOT OK";
+    }
+    return "OK";
+};
+
+1;

--- a/lib/DDGC/Web/App/Subscriber.pm
+++ b/lib/DDGC/Web/App/Subscriber.pm
@@ -7,8 +7,8 @@ use DDGC::Base::Web::Light;
 get '/u/:campaign/:email/:key' => sub {
     my $params = params('route');
     my $s = rset('Subscriber')->find( {
-        email    => $params->{email},
-        campaign => $params->{campaign},
+        email_address => $params->{email},
+        campaign      => $params->{campaign},
     } );
     if ( !$s || !$s->unsubscribe( $params->{ key } ) ) {
         status 500;
@@ -20,8 +20,8 @@ get '/u/:campaign/:email/:key' => sub {
 get '/v/:campaign/:email/:key' => sub {
     my $params = params('route');
     my $s = rset('Subscriber')->find( {
-        email    => $params->{email},
-        campaign => $params->{campaign},
+        email_address => $params->{email},
+        campaign      => $params->{campaign},
     } );
     if ( !$s || !$s->verify( $params->{ key } ) ) {
         status 500;
@@ -34,7 +34,8 @@ post '/a' => sub {
     my $params = params('body');
     my $s = rset('Subscriber')->create( {
         email_address => $params->{email},
-        campaign => $params->{campaign},
+        campaign      => $params->{campaign},
+        flow          => $params->{flow}
     } );
     if ( !$s ) {
         status 500;

--- a/lib/Dancer2/Plugin/DDGC/Config.pm
+++ b/lib/Dancer2/Plugin/DDGC/Config.pm
@@ -7,6 +7,13 @@ use Dancer2::Plugin;
 use DDGC::Config;
 use DDGC::Util::TemplateHelpers;
 
+my $nosession;
+
+sub import {
+    shift;
+    $nosession = grep { $_ eq 'nosession' } @_;
+}
+
 on_plugin_import {
     my ( $dsl ) = @_;
     my $settings = plugin_setting();
@@ -23,19 +30,21 @@ on_plugin_import {
         $dsl->set( environment => 'staging' );
     }
 
-    $dsl->set(
-        engines  => {
-            ( $dsl->config->{engines} )
-            ? %{ $dsl->config->{engines} }
-            : (),
-            session => {
-                PSGI => {
-                    cookie_name => 'ddgc_session',
+    if ( !$nosession ) {
+        $dsl->set(
+            engines  => {
+                ( $dsl->config->{engines} )
+                ? %{ $dsl->config->{engines} }
+                : (),
+                session => {
+                    PSGI => {
+                        cookie_name => 'ddgc_session',
+                    },
                 },
-            },
-        }
-    );
-    $dsl->set(session => 'PSGI');
+            }
+        );
+        $dsl->set(session => 'PSGI');
+    }
 
     my $dsn_cfgs = {
        'Pg' => {

--- a/script/ddgc_dev_server.psgi
+++ b/script/ddgc_dev_server.psgi
@@ -13,6 +13,7 @@ use Plack::Builder;
 use CHI;
 use DDGC::Web;
 use DDGC::Web::App::Blog;
+use DDGC::Web::App::Subscriber;
 use DDGC::Web::Service::Blog;
 use DDGC::Web::Service::ActivityFeed;
 use Plack::App::File;
@@ -40,6 +41,7 @@ builder {
             qw/ Environment Response Parameters Timer Session DBITrace CatalystLog /
         ];
     }
+    mount '/s' => DDGC::Web::App::Subscriber->to_app;
     mount '/blog' => DDGC::Web::App::Blog->to_app;
     mount '/blog.json' => DDGC::Web::Service::Blog->to_app;
     mount '/activityfeed.json' => DDGC::Web::Service::ActivityFeed->to_app;

--- a/script/ddgc_subscriber_mail.pl
+++ b/script/ddgc_subscriber_mail.pl
@@ -3,10 +3,10 @@
 use Moo;
 use MooX::Options;
 
+use Test::MockTime qw/ set_absolute_time /;
 use FindBin;
 use lib $FindBin::Dir . "/../lib";
 use DDGC::Util::Script::SubscriberMailer;
-use Test::MockTime qw/ set_absolute_time /;
 
 option verify => (
     is => 'ro',

--- a/script/ddgc_subscriber_mail.pl
+++ b/script/ddgc_subscriber_mail.pl
@@ -1,0 +1,38 @@
+#!/usr/bin/env perl
+
+use Moo;
+use MooX::Options;
+
+use FindBin;
+use lib $FindBin::Dir . "/../lib";
+use DDGC::Util::Script::SubscriberMailer;
+use Test::MockTime qw/ set_absolute_time /;
+
+option verify => (
+    is => 'ro',
+    doc => 'Run verify mail shot'
+);
+
+option mock_date => (
+    is => 'ro',
+    format => 's',
+    doc => 'Run mail for given day (for testing): YYYY-MM-DD',
+    coerce => sub {
+        set_absolute_time(sprintf '%sT12:00:00Z', $_[0]);
+    }
+);
+
+my $self = main->new_with_options;
+
+if ( $self->mock_date ) {
+    printf "Run with mock date [y/N]? ";
+    chomp ( my $r = <STDIN> );
+    die unless $r =~ /^y/i;
+}
+
+if ( $self->verify ) {
+    DDGC::Util::Script::SubscriberMailer->new->verify;
+}
+else {
+    DDGC::Util::Script::SubscriberMailer->new->execute;
+}

--- a/sql/1.189/subscriber.sql
+++ b/sql/1.189/subscriber.sql
@@ -4,6 +4,7 @@ CREATE TABLE subscriber (
     created timestamp with time zone NOT NULL,
     verified integer DEFAULT 0 NOT NULL,
     unsubscribed integer DEFAULT 0 NOT NULL,
+    flow text,
     v_key text NOT NULL,
     u_key text NOT NULL
 );

--- a/sql/1.189/subscriber.sql
+++ b/sql/1.189/subscriber.sql
@@ -1,0 +1,28 @@
+CREATE TABLE subscriber (
+    email_address text NOT NULL,
+    campaign text NOT NULL,
+    created timestamp with time zone NOT NULL,
+    verified integer DEFAULT 0 NOT NULL,
+    unsubscribed integer DEFAULT 0 NOT NULL,
+    v_key text NOT NULL,
+    u_key text NOT NULL
+);
+
+CREATE TABLE subscriber_maillog (
+    email_address text NOT NULL,
+    campaign text NOT NULL,
+    email_id character(1) NOT NULL,
+    sent timestamp with time zone NOT NULL
+);
+
+ALTER TABLE ONLY subscriber
+    ADD CONSTRAINT subscriber_pkey PRIMARY KEY (email_address, campaign);
+
+ALTER TABLE ONLY subscriber_maillog
+    ADD CONSTRAINT subscriber_maillog_pkey PRIMARY KEY (email_address, campaign, email_id);
+
+CREATE INDEX subscriber_maillog_idx_email_address_campaign ON subscriber_maillog USING btree (email_address, campaign);
+
+ALTER TABLE ONLY subscriber_maillog
+    ADD CONSTRAINT subscriber_maillog_fk_email_address_campaign FOREIGN KEY (email_address, campaign) REFERENCES subscriber(email_address, campaign) DEFERRABLE;
+

--- a/t/subscribers.t
+++ b/t/subscribers.t
@@ -1,0 +1,54 @@
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{DDGC_DB_DSN} = 'dbi:SQLite:dbname=ddgc_test.db';
+    $ENV{DDGC_MAIL_TEST} = 1;
+}
+
+
+use Plack::Test;
+use Plack::Builder;
+use HTTP::Request::Common;
+use Test::More;
+use Test::MockTime qw/:all/;
+use t::lib::DDGC::TestUtils;
+use DDGC::Web::App::Subscriber;
+use DDGC::Base::Web::Light;
+use DDGC::Util::Script::SubscriberMailer;
+use URI;
+
+t::lib::DDGC::TestUtils::deploy( { drop => 1 }, schema );
+my $m = DDGC::Util::Script::SubscriberMailer->new;
+
+my $app = builder {
+    mount '/s' => DDGC::Web::App::Subscriber->to_app;
+};
+
+test_psgi $app => sub {
+    my ( $cb ) = @_;
+
+    for my $email (qw/
+        test1@duckduckgo.com
+        test2@duckduckgo.com
+        test3@duckduckgo.com
+        test4@duckduckgo.com
+        test5@duckduckgo.com
+        test6duckduckgo.com
+    / ) {
+        ok( $cb->(
+            POST '/s/a',
+            [ email => $email, campaign => 'a', flow => 'flow1' ]
+        ), "Adding subscriber : $email" );
+    }
+
+    my $transport = DDGC::Util::Script::SubscriberMailer->new->verify;
+    my @deliveries = $transport->deliveries;
+    is( scalar @deliveries, 5, 'Correct number of verification emails sent' );
+
+    $transport = DDGC::Util::Script::SubscriberMailer->new->verify;
+    @deliveries = $transport->deliveries;
+    is( scalar @deliveries, 0, 'No verification emails re-sent' );
+};
+
+done_testing;

--- a/t/subscribers.t
+++ b/t/subscribers.t
@@ -45,12 +45,11 @@ test_psgi $app => sub {
     }
 
     my $transport = DDGC::Util::Script::SubscriberMailer->new->verify;
-    my @deliveries = $transport->deliveries;
-    is( scalar @deliveries, 5, 'Correct number of verification emails sent' );
+    is( $transport->delivery_count, 5, 'Correct number of verification emails sent' );
 
     $transport = DDGC::Util::Script::SubscriberMailer->new->verify;
-    @deliveries = $transport->deliveries;
-    is( scalar @deliveries, 0, 'No verification emails re-sent' );
+    is( $transport->delivery_count, 0, 'No verification emails re-sent' );
+
 };
 
 done_testing;

--- a/t/subscribers.t
+++ b/t/subscribers.t
@@ -86,6 +86,16 @@ test_psgi $app => sub {
 
     $transport = DDGC::Util::Script::SubscriberMailer->new->execute;
     is( $transport->delivery_count, 0, 'Emails not re-sent' );
+
+    set_absolute_time('2016-10-20T12:00:00Z');
+    $transport = DDGC::Util::Script::SubscriberMailer->new->execute;
+    is( $transport->delivery_count, 0, '0 received emails - non scheduled' );
+
+    $unsubscribe->('test2@duckduckgo.com');
+
+    set_absolute_time('2016-10-21T12:00:00Z');
+    $transport = DDGC::Util::Script::SubscriberMailer->new->execute;
+    is( $transport->delivery_count, 2, '2 received emails - one unsubscribed' );
 };
 
 done_testing;

--- a/t/subscribers.t
+++ b/t/subscribers.t
@@ -28,6 +28,8 @@ my $app = builder {
 test_psgi $app => sub {
     my ( $cb ) = @_;
 
+    set_absolute_time('2016-10-18T12:00:00Z');
+
     for my $email (qw/
         test1@duckduckgo.com
         test2@duckduckgo.com

--- a/views/email/a/1.tx
+++ b/views/email/a/1.tx
@@ -1,0 +1,1 @@
+Placeholder 1

--- a/views/email/a/1.tx
+++ b/views/email/a/1.tx
@@ -1,1 +1,2 @@
 Placeholder 1
+<a href="<: $subscriber.unsubscribe_url :>">Unsubscribe</a>

--- a/views/email/a/2.tx
+++ b/views/email/a/2.tx
@@ -1,0 +1,1 @@
+Placeholder 2

--- a/views/email/a/2.tx
+++ b/views/email/a/2.tx
@@ -1,1 +1,2 @@
 Placeholder 2
+<a href="<: $subscriber.unsubscribe_url :>">Unsubscribe</a>

--- a/views/email/a/3.tx
+++ b/views/email/a/3.tx
@@ -1,0 +1,1 @@
+Placeholder 3

--- a/views/email/a/3.tx
+++ b/views/email/a/3.tx
@@ -1,1 +1,2 @@
 Placeholder 3
+<a href="<: $subscriber.unsubscribe_url :>">Unsubscribe</a>

--- a/views/email/a/4.tx
+++ b/views/email/a/4.tx
@@ -1,0 +1,1 @@
+Placeholder 4

--- a/views/email/a/4.tx
+++ b/views/email/a/4.tx
@@ -1,1 +1,2 @@
 Placeholder 4
+<a href="<: $subscriber.unsubscribe_url :>">Unsubscribe</a>

--- a/views/email/a/5.tx
+++ b/views/email/a/5.tx
@@ -1,0 +1,1 @@
+Placeholder 5

--- a/views/email/a/5.tx
+++ b/views/email/a/5.tx
@@ -1,1 +1,2 @@
 Placeholder 5
+<a href="<: $subscriber.unsubscribe_url :>">Unsubscribe</a>

--- a/views/email/a/6.tx
+++ b/views/email/a/6.tx
@@ -1,1 +1,3 @@
 Placeholder 6
+<a href="<: $subscriber.unsubscribe_url :>">Unsubscribe</a>
+

--- a/views/email/a/6.tx
+++ b/views/email/a/6.tx
@@ -1,0 +1,1 @@
+Placeholder 6

--- a/views/email/a/7.tx
+++ b/views/email/a/7.tx
@@ -1,1 +1,2 @@
 Placeholder 7
+<a href="<: $subscriber.unsubscribe_url :>">Unsubscribe</a>

--- a/views/email/a/7.tx
+++ b/views/email/a/7.tx
@@ -1,0 +1,1 @@
+Placeholder 7

--- a/views/email/a/v.tx
+++ b/views/email/a/v.tx
@@ -1,0 +1,1 @@
+<a href="<: $subscriber.verify_url :>">Please verify your email address</a>


### PR DESCRIPTION
##### Description :

This PR is an application to manage regular mail outs to verified email addresses:

- Web app to add, verify and remove subscriptions
- Script wrapper to send verification and scheduled mails

##### Reviewer notes :

Unit tests incoming.
- [x] Subscribe
- [x] Verify
- [x] Scheduling / cron
- [x] Unsubscribe

- New DDL in sql/1.189/subscriber.sql
- Add subscriber with:
````bash
curl -o /dev/null --data "campaign=a&email=<your email>" http://localhost:5001/s/a
```
- Send verification email with:
```bash
script/ddgc_subscriber_mail.pl --verify
```
- Send mail for a given date with (e.g. for tomorrow):
```bash
script/ddgc_subscriber_mail.pl --mock_date=2016-10-19
```
- Only a verified email address should receive email
- Unsubscribed emails should not receive any email
- There are 6 mail shots configured for every two days from tomorrow (or the day after subscription)
- Unsubscribe and verify links will be for staging - these should be changed to match the host of your dev instance.

##### Who should be informed of this change?

@MariagraziaAlastra @yegg 

##### Does this change have significant privacy, security, performance or deployment implications?

No - email verification and unsubscribe is in place, as with all mail jobs.

##### Checklist :
- [x] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android

The current data contains placeholder content.