### PR TITLE
Hiding the call for translation managers

### DIFF
--- a/templates/translate/domainindex.tx
+++ b/templates/translate/domainindex.tx
@@ -4,8 +4,8 @@
 	<: include "translate/wiz_shortcuts.tx" :>
 <: } :>
 
-<div class="content-box translate-overview">	
-	<div class="head">		
+<div class="content-box translate-overview">
+	<div class="head">
 		<h2>Translate <: $token_domain.name :> into ...</h2>
 		<a class="button pull-right" title="Back to list of token domains" href="<: $u(['Translate','index']) :>"><i class="icon-fast-backward"></i></a>
 	</div>
@@ -13,25 +13,24 @@
 		<: for $can_speak -> $token_domain_language { :>
 			<: include "translate/domainindex/token_domain_language.tx" { token_domain_language => $token_domain_language } :>
 		<: } :>
-	</div> 
+	</div>
 </div>
 
 <a class="notice contrast" href="<: $u('Translate','domainsearch',$token_domain.key) :>">
 	<i class="icn icn--large icon-search"></i><h3>Search through all tokens and translations!</h3>
 </a>
 
-<a class="notice contrast" href="https://duck.co/blog/post/9/help-managing-translations">
+<!--<a class="notice contrast" href="https://duck.co/blog/post/9/help-managing-translations">
 	<i class="icn icn--large icon-flag"></i><h3>Become a Translation Manager!</h3>
-</a>
+</a>-->
 
-<div class="content-box translate-overview">	
-	<div class="head">		
+<div class="content-box translate-overview">
+	<div class="head">
 		<h2>other languages ...</h2>
 	</div>
 	<div class="body">
 		<: for $not_speak -> $token_domain_language { :>
 			<: include "translate/domainindex/token_domain_language.tx" { token_domain_language => $token_domain_language } :>
 		<: } :>
-	</div> 
+	</div>
 </div>
-				

--- a/templates/translate/index.tx
+++ b/templates/translate/index.tx
@@ -1,9 +1,9 @@
 <h1>Welcome to DuckDuckGo Translations!</h1>
 <p class="intro-message">You can translate text ("tokens") from our sites.</p>
 
-<div class="row gw">	
+<div class="row gw">
 	<div class="g twothirds">
-		<div class="notice  contrast  intro--m">	
+		<div class="notice  contrast  intro--m">
 			<i class="icn icon-paperclip"></i>
 			<h4>To get started, just follow these steps:</h4>
 			<ul class="checks">
@@ -33,17 +33,17 @@
 	<: } :>
 <: } :>
 
-<a class="notice contrast" href="https://duck.co/blog/post/9/help-managing-translations">
+<!--<a class="notice contrast" href="https://duck.co/blog/post/9/help-managing-translations">
 	<i class="icn icn--large icon-flag"></i><h3>Become a Translation Manager!</h3>
-</a>
+</a>-->
 
 <: for $token_domains -> $token_domain { :>
 	<: if $token_domain.get_column('token_count') { :>
-		<div class="content-box translate-overview">	
-			<div class="head">		
+		<div class="content-box translate-overview">
+			<div class="head">
 				<h2><: $token_domain.name :></h2>
-				<: if $token_domain.is_duckduckgo { :>				
-					<img src="/static/images/duckduckgo-icon.png" width="32" height="32" title="Official DuckDuckGo Token Domain" class="admin-badge pull-right" />				
+				<: if $token_domain.is_duckduckgo { :>
+					<img src="/static/images/duckduckgo-icon.png" width="32" height="32" title="Official DuckDuckGo Token Domain" class="admin-badge pull-right" />
 				<: } :>
 			</div>
 			<div class="body">
@@ -52,12 +52,12 @@
 						<i class="icon icon-pencil"></i> Help us translate <: $token_domain.name :>!
 					</a>
 					<p><: r($token_domain.description) :></p>
-				</div>			
-			</div> 
+				</div>
+			</div>
 		</div>
 	<: } :>
 <: } :>
-	
+
 <: if $c.user && $c.user.translation_manager { :>
 	<div class="content-box">
 		<div class="head">


### PR DESCRIPTION
##### Description :
Commenting out the call for translation managers because this is not our focus at the moment.
Note that my editor removed lots of trailing spaces.

##### Reviewer notes :


##### References issues / PRs:


##### Who should be informed of this change?
@jbarrett 

##### Does this change have significant privacy, security, performance or deployment implications?
Nope

##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android

