### PR TITLE
Shift subscription schedule to date of email verification

### DIFF
--- a/lib/DDGC/Schema/Result.pm
+++ b/lib/DDGC/Schema/Result.pm
@@ -3,6 +3,7 @@ package DDGC::Schema::Result;
 # ABSTRACT: DBIC Result base class
 
 use Carp;
+use DateTime;
 use Moo;
 extends 'DBIx::Class::Core';
 
@@ -12,6 +13,13 @@ sub current_user {
     return if !$self->app->can('var');
     return $self->app->var('user');
 }
+
+sub format_datetime {
+    my $self = shift;
+    $self->result_source->schema->storage->datetime_parser->format_datetime(@_);
+}
+
+sub now { $_[0]->format_datetime( DateTime->now ) }
 
 __PACKAGE__->load_components(qw/
     InflateColumn::Serializer

--- a/lib/DDGC/Schema/Result/Subscriber.pm
+++ b/lib/DDGC/Schema/Result/Subscriber.pm
@@ -64,8 +64,11 @@ sub unsubscribe_url {
 
 sub verify {
     my ( $self, $key ) = @_;
-    $self->update({ verified => 1 })
-        if ( $key eq $self->v_key );
+    return unless ( $key eq $self->v_key );
+    $self->update({
+        verified => 1,
+        created  => $self->now,
+    });
 }
 
 sub unsubscribe {

--- a/lib/DDGC/Schema/Result/Subscriber.pm
+++ b/lib/DDGC/Schema/Result/Subscriber.pm
@@ -64,6 +64,7 @@ sub unsubscribe_url {
 
 sub verify {
     my ( $self, $key ) = @_;
+    return $self->verified if $self->verified;
     return unless ( $key eq $self->v_key );
     $self->update({
         verified => 1,

--- a/t/subscribers.t
+++ b/t/subscribers.t
@@ -37,6 +37,7 @@ test_psgi $app => sub {
         test4@duckduckgo.com
         test5@duckduckgo.com
         test6duckduckgo.com
+        lateverify@duckduckgo.com
     / ) {
         ok( $cb->(
             POST '/s/a',
@@ -45,7 +46,7 @@ test_psgi $app => sub {
     }
 
     my $transport = DDGC::Util::Script::SubscriberMailer->new->verify;
-    is( $transport->delivery_count, 5, 'Correct number of verification emails sent' );
+    is( $transport->delivery_count, 6, 'Correct number of verification emails sent' );
 
     $transport = DDGC::Util::Script::SubscriberMailer->new->verify;
     is( $transport->delivery_count, 0, 'No verification emails re-sent' );
@@ -79,6 +80,8 @@ test_psgi $app => sub {
     for my $email (qw/ test1@duckduckgo.com test2@duckduckgo.com test3@duckduckgo.com /) {
         $verify->( $email );
     }
+    set_absolute_time('2016-10-21T09:00:00Z');
+    $verify->( 'lateverify@duckduckgo.com' );
 
     set_absolute_time('2016-10-19T12:00:00Z');
     $transport = DDGC::Util::Script::SubscriberMailer->new->execute;
@@ -95,7 +98,7 @@ test_psgi $app => sub {
 
     set_absolute_time('2016-10-22T12:00:00Z');
     $transport = DDGC::Util::Script::SubscriberMailer->new->execute;
-    is( $transport->delivery_count, 2, '2 received emails - one unsubscribed' );
+    is( $transport->delivery_count, 3, '3 received emails - one unsubscribed, one rescheduled' );
 };
 
 done_testing;


### PR DESCRIPTION
##### Description :

This change updates the signup date for subscribers when their address has been verified 

##### Reviewer notes :

Unit tests have been updated, but the major change is that the created date for a subscriber row should be updated to `now()` matching the date the verification link was clicked.

##### Who should be informed of this change?

@yegg @AdamSC1-ddg @MariagraziaAlastra 

##### Does this change have significant privacy, security, performance or deployment implications?

No privacy changes

##### Checklist :
- [x] Back end tests (perl, scripts)
