### PR TITLE
Close forum posting functions

### DIFF
--- a/lib/DDGC/Feedback/Config/Suggest.pm
+++ b/lib/DDGC/Feedback/Config/Suggest.pm
@@ -6,6 +6,8 @@ use warnings;
 
 use DDGC::Config;
 
+=for comment
+
 sub feedback_title { "I have something to share." }
 
 sub feedback {[
@@ -83,5 +85,6 @@ sub suggest_idea {[
   },
   "" # workaround for non submittable ending points like this here.
 ]}
+=cut
 
 1;

--- a/lib/DDGC/Web/Controller/Comment.pm
+++ b/lib/DDGC/Web/Controller/Comment.pm
@@ -57,6 +57,7 @@ sub delete : Chained('do') Args(1) {
 sub add :Chained('base') :Args(2) {
 	my ( $self, $c, $context, $context_id ) = @_;
 	return unless $c->user || ! $c->stash->{no_reply};
+	return if ( $context eq 'DDGC::DB::Result::Thread' || $context eq 'DDGC::DB::Result::Idea' );
 	$c->require_action_token;
 	unless ($c->user) {
 		$c->response->redirect($c->chained_uri('My','login'));

--- a/lib/DDGC/Web/Controller/Feedback.pm
+++ b/lib/DDGC/Web/Controller/Feedback.pm
@@ -56,6 +56,9 @@ sub feedback :Chained('base') :PathPart('') :CaptureArgs(1) {
     $c->stash->{feedback_config} = DDGC::Feedback::Config::NoLove->feedback;
     $c->stash->{feedback_title} = DDGC::Feedback::Config::NoLove->feedback_title;
   } elsif ($feedback eq 'suggest') {
+    $c->response->status(404);
+    $c->response->redirect('/');
+    return $c->detach;
     if (!$c->user) {
       $c->response->redirect($c->chained_uri('My','login'));
       return $c->detach;

--- a/templates/forum/share_suggestion.tx
+++ b/templates/forum/share_suggestion.tx
@@ -1,6 +1,7 @@
-
+<!--
 <p class="mg-bottom--double">
 	<a class="button blue text-big tall media full--l" href="<: $u('Feedback','feedback_redirect','suggest') :>"><i class="media__img icon-bubbles"></i><span class="media__body">New Post</span></a>
 </p>
+-->
 
 : #	<p class="mg-bottom--big"><span class="account-actions"><a href="<: $u('My','login') :>" class="account-actions__btn account-actions__btn--first  nav-login" data-reveal-id="login-box">Login</a> <a href="<: $u('My','register') :>" class="account-actions__btn  nav-signup">Sign up</a> </span></p>

--- a/templates/i/comment/thread.tx
+++ b/templates/i/comment/thread.tx
@@ -29,7 +29,7 @@
         <: if !$no_reply && $c.user { :>
             <: if !$c.user.admin && $forum_index == d().config.id_for_forum('special') { :>
 		<: # we may put something here :>
-            <: } else { :>
+            <: } elsif ( $_.context != 'DDGC::DB::Result::Thread' && $_.context != 'DDGC::DB::Result::Idea' ) { :>
                 <a class="right  js-thread-reply  no-js-hide" href="#"><i class="thread__foot__icon  icon-reply"></i><span class="thread__foot__txt">Reply</span></a>
                 <a class="right  js-thread-cancel  no-js-hide  hide" href="#"><i class="thread__foot__icon  icon-remove"></i><span class="thread__foot__txt">Cancel</span></a>
             <: } :>

--- a/templates/i/comment/thread.tx
+++ b/templates/i/comment/thread.tx
@@ -74,6 +74,7 @@
 <: } :>
 : if ( $_.context == 'DDGC::DB::Result::Thread' || $_.context == 'DDGC::DB::Result::Idea' ) {
     <h3>This forum has been archived</h3>
+    <p>Thank you all for the many comments, questions and suggestions. Particular thanks go to <a href="https://duck.co/user/x.15a2">user x.15a2</a> for constantly monitoring, replying and helping so many users here. To continue these discussions, please head over to the <a href="https://www.reddit.com/r/duckduckgo/">DuckDuckGo subreddit</a>.</p>
 : }
 <: if $c.user and !$no_reply { :>
     <: i('comment_add',{ context => $_context, context_id => $_context_id }) :>

--- a/templates/i/comment/thread.tx
+++ b/templates/i/comment/thread.tx
@@ -72,6 +72,9 @@
 		<img id="img-<: $screenshot.media.id:>" src="/static/img/spinner.gif" data-src="<: $screenshot.media.url :>" alt="<: $screenshot.media.upload_filename :> - Full" class="reveal-modal reveal-modal--img" />
 	<: } :>
 <: } :>
+: if ( $_.context == 'DDGC::DB::Result::Thread' || $_.context == 'DDGC::DB::Result::Idea' ) {
+    <h3>This forum has been archived</h3>
+: }
 <: if $c.user and !$no_reply { :>
     <: i('comment_add',{ context => $_context, context_id => $_context_id }) :>
 <: } :>

--- a/templates/i/comment/view.tx
+++ b/templates/i/comment/view.tx
@@ -37,7 +37,7 @@
 				<: if !$no_reply && $c.user && (!$_.ghosted || ($_.ghosted && $_.users_id == $c.user.id)) { :>
 					<: if !$c.user.admin and $forum_index == d().config.id_for_forum('special') { :>
 						<: # we may put something here :>
-					<: } else { :>
+					<: } elsif ( $_.context != 'DDGC::DB::Result::Thread' && $_.context != 'DDGC::DB::Result::Idea' ) { :>
 						<span class="comment-meta__link">
 							&bull; <a class="js-reply_link_<: $_.id :>  js-comment-reply no-js-hide" data-target="<: $_.id :>" href="#">Reply</a>
 							<a class="js-cancel_link_<: $_.id :>  js-comment-cancel no-js-hide hide" data-target="<: $_.id :>" href="#">Cancel</a>

--- a/templates/i/comment_add.tx
+++ b/templates/i/comment_add.tx
@@ -1,6 +1,7 @@
 <: if $context and $context_id and $c.user { :>
 	: if ( $context == 'DDGC::DB::Result::Idea' || $context == 'DDGC::DB::Result::Thread' ) {
 		<h3>This forum has been archived</h3>
+		<p>Thank you all for the many comments, questions and suggestions. Particular thanks go to <a href="https://duck.co/user/x.15a2">user x.15a2</a> for constantly monitoring, replying and helping so many users here. To continue these discussions, please head over to the <a href="https://www.reddit.com/r/duckduckgo/">DuckDuckGo subreddit</a>.</p>
 	: } else {
 	<form method="post" class="comment_reply  js-reply_<: $context_id:>  js-hide" action="<: $u('Comment','add',$context,$context_id) :>">    
 		<input type="hidden" name="action_token" value="<: $action_token :>">

--- a/templates/i/comment_add.tx
+++ b/templates/i/comment_add.tx
@@ -1,4 +1,7 @@
-<: if $context and $context_id and $c.user { :> 
+<: if $context and $context_id and $c.user { :>
+	: if ( $context == 'DDGC::DB::Result::Idea' || $context == 'DDGC::DB::Result::Thread' ) {
+		<h3>This forum has been archived</h3>
+	: } else {
 	<form method="post" class="comment_reply  js-reply_<: $context_id:>  js-hide" action="<: $u('Comment','add',$context,$context_id) :>">    
 		<input type="hidden" name="action_token" value="<: $action_token :>">
 		<div class="user-avatar icon-user">
@@ -10,4 +13,5 @@
 		<input type="hidden" name="from" value="<: $c.req.uri :>" />
                 <: i('bbcode_controls') :>
 	</form> 
+	: }
 <: } :>


### PR DESCRIPTION
##### Description :

This change should disallow further posting on the forum on duck.co. It has a mixture of template and backend changes:

- New thread links removed
- Reply links removed
- Reply text boxes removed 

##### Reviewer notes :

It should no longer be possible to create new posts or replies in forum / ideas.

Posting replies on blog posts, translation pages should still work.

##### References issues / PRs:

https://duck.co/forum/thread/27632/staff-notice-forum-closing-in-january-2017

##### Who should be informed of this change?

@tagawa 

##### Does this change have significant privacy, security, performance or deployment implications?

Nope.

##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [x] Chrome
    - [x] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android