### PR TITLE
John/wrap up forum close

### DIFF
--- a/lib/DDGC.pm
+++ b/lib/DDGC.pm
@@ -426,6 +426,8 @@ sub _build_xslate {
                         # String::Truncate's elide function
                         truncate => \&elide,
 
+			p => sub { use DDP; return mark_raw( '<pre>' . p( $_[0] ) . '</pre>' ); },
+
 		},
 	});
 	return $xslate;

--- a/lib/DDGC/Web/Controller/Forum/My.pm
+++ b/lib/DDGC/Web/Controller/Forum/My.pm
@@ -18,6 +18,8 @@ sub base : Chained('/forum/base') PathPart('my') CaptureArgs(0) {
 # /forum/my/newthread
 sub newthread : Chained('base') Args(1) {
 	my ( $self, $c, $forum_id ) = @_;
+	$c->response->status(404);
+	return $c->detach;
 	$c->stash->{forum_index} = $forum_id // 1;
 	if (!$c->d->config->forums->{$c->stash->{forum_index}}) {
 		$c->response->redirect($c->chained_uri('Forum', 'general'));

--- a/templates/forum/archived.tx
+++ b/templates/forum/archived.tx
@@ -1,0 +1,3 @@
+    <h3>This forum has been archived</h3>
+    <p>Thank you all for the many comments, questions and suggestions. Particular thanks go to <a href="https://duck.co/user/x.15a2">user x.15a2</a> for constantly monitoring, replying and helping so many users here. To continue these discussions, please head over to the <a href="https://www.reddit.com/r/duckduckgo/">DuckDuckGo subreddit</a>.</p>
+

--- a/templates/i/comment/thread.tx
+++ b/templates/i/comment/thread.tx
@@ -73,8 +73,7 @@
 	<: } :>
 <: } :>
 : if ( $_.context == 'DDGC::DB::Result::Thread' || $_.context == 'DDGC::DB::Result::Idea' ) {
-    <h3>This forum has been archived</h3>
-    <p>Thank you all for the many comments, questions and suggestions. Particular thanks go to <a href="https://duck.co/user/x.15a2">user x.15a2</a> for constantly monitoring, replying and helping so many users here. To continue these discussions, please head over to the <a href="https://www.reddit.com/r/duckduckgo/">DuckDuckGo subreddit</a>.</p>
+	: include 'forum/archived.tx';
 : }
 <: if $c.user and !$no_reply { :>
     <: i('comment_add',{ context => $_context, context_id => $_context_id }) :>

--- a/templates/i/comment_add.tx
+++ b/templates/i/comment_add.tx
@@ -1,7 +1,6 @@
 <: if $context and $context_id and $c.user { :>
 	: if ( $context == 'DDGC::DB::Result::Idea' || $context == 'DDGC::DB::Result::Thread' ) {
-		<h3>This forum has been archived</h3>
-		<p>Thank you all for the many comments, questions and suggestions. Particular thanks go to <a href="https://duck.co/user/x.15a2">user x.15a2</a> for constantly monitoring, replying and helping so many users here. To continue these discussions, please head over to the <a href="https://www.reddit.com/r/duckduckgo/">DuckDuckGo subreddit</a>.</p>
+		: include 'forum/archived.tx';
 	: } else {
 	<form method="post" class="comment_reply  js-reply_<: $context_id:>  js-hide" action="<: $u('Comment','add',$context,$context_id) :>">    
 		<input type="hidden" name="action_token" value="<: $action_token :>">

--- a/templates/i/comment_rs/forum.tx
+++ b/templates/i/comment_rs/forum.tx
@@ -1,3 +1,5 @@
+    <h3>This forum has been archived</h3>
+    <p>Thank you all for the many comments, questions and suggestions. Particular thanks go to <a href="https://duck.co/user/x.15a2">user x.15a2</a> for constantly monitoring, replying and helping so many users here. To continue these discussions, please head over to the <a href="https://www.reddit.com/r/duckduckgo/">DuckDuckGo subreddit</a>.</p>
 <div class="content-box">
   <div class="group  head--forum">
     <div class="forum-nav">

--- a/templates/i/comment_rs/forum.tx
+++ b/templates/i/comment_rs/forum.tx
@@ -1,5 +1,4 @@
-    <h3>This forum has been archived</h3>
-    <p>Thank you all for the many comments, questions and suggestions. Particular thanks go to <a href="https://duck.co/user/x.15a2">user x.15a2</a> for constantly monitoring, replying and helping so many users here. To continue these discussions, please head over to the <a href="https://www.reddit.com/r/duckduckgo/">DuckDuckGo subreddit</a>.</p>
+: include 'forum/archived.tx';
 <div class="content-box">
   <div class="group  head--forum">
     <div class="forum-nav">

--- a/templates/i/comment_rs/view.tx
+++ b/templates/i/comment_rs/view.tx
@@ -6,7 +6,9 @@
 <: } elsif $no_reply { :>
   <p class="notice mg-top--double"><i class="icn icon-lock"></i>This thread has been locked and is now read-only.</p>
 <: } else { :>
+  : if !( $thread || $idea ) {
   <div class="notice alert warning"><i class="icn icon-warning-sign"></i> You must be logged in to comment. Please, <a href="<: $u('My','login') :>" data-reveal-id="login-box">Log in</a> or <a href="<: $u('My','register') :>">Register</a>.</div>
+  : }
 <: } :>
 <: if $_.count { :>	
 	<: for $_.order_by({ '-asc' => 'me.updated' }).all_ref -> $comment { :>

--- a/templates/i/table/ideas.tx
+++ b/templates/i/table/ideas.tx
@@ -1,3 +1,5 @@
+    <h3>This forum has been archived</h3>
+    <p>Thank you all for the many comments, questions and suggestions. Particular thanks go to <a href="https://duck.co/user/x.15a2">user x.15a2</a> for constantly monitoring, replying and helping so many users here. To continue these discussions, please head over to the <a href="https://www.reddit.com/r/duckduckgo/">DuckDuckGo subreddit</a>.</p>
 <div class="content-box">
 	<div class="head--forum  group">
 	<div class="forum-nav">

--- a/templates/i/table/ideas.tx
+++ b/templates/i/table/ideas.tx
@@ -1,5 +1,4 @@
-    <h3>This forum has been archived</h3>
-    <p>Thank you all for the many comments, questions and suggestions. Particular thanks go to <a href="https://duck.co/user/x.15a2">user x.15a2</a> for constantly monitoring, replying and helping so many users here. To continue these discussions, please head over to the <a href="https://www.reddit.com/r/duckduckgo/">DuckDuckGo subreddit</a>.</p>
+: include 'forum/archived.tx';
 <div class="content-box">
 	<div class="head--forum  group">
 	<div class="forum-nav">

--- a/templates/i/thread_rs/forum.tx
+++ b/templates/i/thread_rs/forum.tx
@@ -1,3 +1,5 @@
+    <h3>This forum has been archived</h3>
+    <p>Thank you all for the many comments, questions and suggestions. Particular thanks go to <a href="https://duck.co/user/x.15a2">user x.15a2</a> for constantly monitoring, replying and helping so many users here. To continue these discussions, please head over to the <a href="https://www.reddit.com/r/duckduckgo/">DuckDuckGo subreddit</a>.</p>
 <div class="content-box">
   <div class="group  head--forum">
     <div class="forum-nav">

--- a/templates/i/thread_rs/forum.tx
+++ b/templates/i/thread_rs/forum.tx
@@ -1,5 +1,4 @@
-    <h3>This forum has been archived</h3>
-    <p>Thank you all for the many comments, questions and suggestions. Particular thanks go to <a href="https://duck.co/user/x.15a2">user x.15a2</a> for constantly monitoring, replying and helping so many users here. To continue these discussions, please head over to the <a href="https://www.reddit.com/r/duckduckgo/">DuckDuckGo subreddit</a>.</p>
+: include 'forum/archived.tx';
 <div class="content-box">
   <div class="group  head--forum">
     <div class="forum-nav">


### PR DESCRIPTION
##### Description :

- Completely close newthread POST endpoint
- Hide Log In prompt on forum / idea pages
- Add 'archived' message to forum / idea index pages.

##### Reviewer notes :

Most of these updates are cosmetic, but if you wish to verify new thread creation no longer works, the form at '/forum/my/newthread/1' is still present. Submitting any new threads from here should result in 404.

##### References issues / PRs:

#1442 

##### Who should be informed of this change?

@tagawa 

##### Does this change have significant privacy, security, performance or deployment implications?

n

##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
