### PR TITLE
Silently drop invalid subscriber email addresses

### DIFF
--- a/lib/DDGC/Web/App/Subscriber.pm
+++ b/lib/DDGC/Web/App/Subscriber.pm
@@ -3,6 +3,7 @@ package DDGC::Web::App::Subscriber;
 # ABSTRACT: Subscriber management
 
 use DDGC::Base::Web::Light;
+use Email::Valid;
 
 get '/u/:campaign/:email/:key' => sub {
     my $params = params('route');
@@ -45,8 +46,10 @@ FORM
 
 post '/a' => sub {
     my $params = params('body');
+    my $email = Email::Valid->address($params->{email});
+    return unless $email;
     my $s = rset('Subscriber')->create( {
-        email_address => $params->{email},
+        email_address => $email,
         campaign      => $params->{campaign},
         flow          => $params->{flow}
     } );

--- a/t/subscribers.t
+++ b/t/subscribers.t
@@ -38,12 +38,19 @@ test_psgi $app => sub {
         test5@duckduckgo.com
         test6duckduckgo.com
         lateverify@duckduckgo.com
+        notanemailaddress
     / ) {
         ok( $cb->(
             POST '/s/a',
             [ email => $email, campaign => 'a', flow => 'flow1' ]
         ), "Adding subscriber : $email" );
     }
+
+    my $invalid = rset('Subscriber')->find( {
+        email_address => 'notanemailaddress',
+        campaign => 'a'
+    } );
+    is( $invalid, undef, 'Invalid address not inserted via POST' );
 
     my $transport = DDGC::Util::Script::SubscriberMailer->new->verify;
     is( $transport->delivery_count, 6, 'Correct number of verification emails sent' );


### PR DESCRIPTION
##### Description :

While this isn't strictly necessary, since we currently verify email addresses by emailing them, the possibility arises that our provider doesn't like us sending them trash envelopes.

This change silently drops POSTs which plainly aren't email addresses. The front end uses an ["email" type input element which is pretty much universally supported](http://caniuse.com/#search=email), so feeding back actual error conditions won't achieve much beyond this.

##### Reviewer notes :

- /s/form has a test form to submit addresses
- Submit a valid email address:
  - HTTP 200, content 'OK'
  - address appears in subscriber table
- Submit an invalid email address:
  - HTTP 200, content empty
  - address does not appear in subscriber table

[Email::Valid](https://metacpan.org/pod/Email::Valid) is used to filter addresses. This is pretty much best-in-class, so I don't think there is a need for us to test a range of types of invalid address. We just want to drop obvious trash (which I would guess is bot-generated).

##### References issues / PRs:

#

##### Who should be informed of this change?

@AdamSC1-ddg @yegg 

##### Does this change have significant privacy, security, performance or deployment implications?

No

##### Checklist :
- [x] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
