### PR TITLE
Bounce handling via SNS

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -133,4 +133,8 @@ requires 'HTML::FormatText::WithLinks', '0.15';
 requires 'Cache::LRU', '0.04';
 requires 'Number::Format', '1.73';
 requires 'Starman', '0.4009';
-
+requires 'Ouch', '0.0410';
+requires 'Crypt::OpenSSL::X509' '1.804';
+requires 'Crypt::OpenSSL::Random' '0.11';
+requires 'Crypt::OpenSSL::RSA' '0.28';
+requires 'AWS::SNS::Verify' '0.0102';

--- a/lib/DDGC/Base/Web/LightService.pm
+++ b/lib/DDGC/Base/Web/LightService.pm
@@ -1,0 +1,44 @@
+package DDGC::Base::Web::LightService;
+
+# ABSTRACT: Base module for simple, unintegrated web services
+
+# Drops: Sessions, user integration
+# Keeps: Database, serializer
+
+use Import::Into;
+
+use strict;
+use warnings;
+use utf8;
+
+use DDGC::Base::Web::Light;
+use Dancer2::Plugin::DDGC::Service;
+use Dancer2::Plugin::DDGC::Bailout;
+
+{   no warnings 'redefine';
+    sub import {
+        my ($caller, $filename) = caller;
+        for (
+          qw/
+            strict
+            warnings
+            utf8
+            Dancer2
+          /
+        ) {
+            $_->import::into($caller);
+        }
+        Dancer2::Plugin::DDGC::Config->import::into( $caller, 'nosession' );
+        for (
+          qw/
+            DDGC::Base::Web::Light
+            Dancer2::Plugin::DDGC::Service
+            Dancer2::Plugin::DDGC::Bailout
+          /
+        ) {
+            $_->import::into($caller);
+        }
+    }
+};
+
+1;

--- a/lib/DDGC/Schema/Result/Subscriber.pm
+++ b/lib/DDGC/Schema/Result/Subscriber.pm
@@ -14,6 +14,8 @@ primary_column campaign      => { data_type => 'text' };
 
 column verified     => { data_type => 'int', default_value => 0 };
 column unsubscribed => { data_type => 'int', default_value => 0 };
+column bounced      => { data_type => 'int', default_value => 0 };
+column complaint    => { data_type => 'int', default_value => 0 };
 column flow         => { data_type => 'text', is_nullable => 1 };
 column v_key        => { data_type => 'text' };
 column u_key        => { data_type => 'text' };

--- a/lib/DDGC/Schema/ResultSet/Subscriber.pm
+++ b/lib/DDGC/Schema/ResultSet/Subscriber.pm
@@ -86,7 +86,7 @@ sub handle_bounces {
         $update_params = { complaint => 1 };
         push @emails, map { $_->{emailAddress} } @{$message->{complainedRecipients}};
     }
-    return { status => 'OK' } if !$update_params || !@emails;
+    return { ok => 1 } if !$update_params || !@emails;
     for my $email (@emails) {
         my $subscribers = $self->search(\[ 'LOWER( email ) = ?', lc( $email ) ]);
         $subscribers->update( $update_params ) if $subscribers;

--- a/lib/DDGC/Schema/ResultSet/Subscriber.pm
+++ b/lib/DDGC/Schema/ResultSet/Subscriber.pm
@@ -84,7 +84,7 @@ sub handle_bounces {
     }
     elsif ( $message->{notificationType} eq 'Complaint' ){
         $update_params = { complaint => 1 };
-        push @emails, map { $_->{emailAddress} } @{$message->{complainedRecipients}};
+        push @emails, map { $_->{emailAddress} } @{$message->{complaint}->{complainedRecipients}};
     }
     return { ok => 1 } if !$update_params || !@emails;
     for my $email (@emails) {

--- a/lib/DDGC/Schema/ResultSet/Subscriber.pm
+++ b/lib/DDGC/Schema/ResultSet/Subscriber.pm
@@ -82,7 +82,7 @@ sub handle_bounces {
         $update_params = { bounced => 1 };
         push @emails, map { $_->{emailAddress} } @{$message->{bounce}->{bouncedRecipients}};
     }
-    elsif ( $message->{complaintFeedbackType} ){
+    elsif ( $message->{notificationType} eq 'Complaint' ){
         $update_params = { complaint => 1 };
         push @emails, map { $_->{emailAddress} } @{$message->{complainedRecipients}};
     }

--- a/lib/DDGC/Schema/ResultSet/Subscriber.pm
+++ b/lib/DDGC/Schema/ResultSet/Subscriber.pm
@@ -26,6 +26,11 @@ sub unverified {
     $self->search_rs( { verified => 0 } );
 }
 
+sub unbounced {
+    my ( $self ) = @_;
+    $self->search_rs( { bounced => 0, complaint => 0 } );
+}
+
 sub mail_unsent {
     my ( $self, $campaign, $email ) = @_;
     $self->search_rs( {

--- a/lib/DDGC/Schema/ResultSet/Subscriber.pm
+++ b/lib/DDGC/Schema/ResultSet/Subscriber.pm
@@ -88,7 +88,7 @@ sub handle_bounces {
     }
     return { ok => 1 } if !$update_params || !@emails;
     for my $email (@emails) {
-        my $subscribers = $self->search(\[ 'LOWER( email ) = ?', lc( $email ) ]);
+        my $subscribers = $self->search(\[ 'LOWER( email_address ) = ?', lc( $email ) ]);
         $subscribers->update( $update_params ) if $subscribers;
     }
     return { ok => 1 };

--- a/lib/DDGC/Schema/ResultSet/Subscriber.pm
+++ b/lib/DDGC/Schema/ResultSet/Subscriber.pm
@@ -80,7 +80,7 @@ sub handle_bounces {
     my @emails;
     if ( $message->{notificationType} eq 'Bounce' && $message->{bounce}->{bounceType} eq 'Permanent' ) {
         $update_params = { bounced => 1 };
-        push @emails, map { $_->{emailAddress} } @{$message->{bouncedRecipients}};
+        push @emails, map { $_->{emailAddress} } @{$message->{bounce}->{bouncedRecipients}};
     }
     elsif ( $message->{complaintFeedbackType} ){
         $update_params = { complaint => 1 };

--- a/lib/DDGC/Schema/ResultSet/Subscriber.pm
+++ b/lib/DDGC/Schema/ResultSet/Subscriber.pm
@@ -91,7 +91,7 @@ sub handle_bounces {
         my $subscribers = $self->search(\[ 'LOWER( email ) = ?', lc( $email ) ]);
         $subscribers->update( $update_params ) if $subscribers;
     }
-    return { status => 'OK' };
+    return { ok => 1 };
 }
 
 1;

--- a/lib/DDGC/Schema/ResultSet/User.pm
+++ b/lib/DDGC/Schema/ResultSet/User.pm
@@ -52,7 +52,7 @@ sub handle_bounces {
             $users->update({ email_verified => 0 }) if $users;
         }
     }
-    return { status => 'OK' };
+    return { ok => 1 };
 }
 
 1;

--- a/lib/DDGC/Schema/ResultSet/User.pm
+++ b/lib/DDGC/Schema/ResultSet/User.pm
@@ -37,7 +37,9 @@ sub find_by_username {
 
 sub handle_bounces {
     my ( $self, $message ) = @_;
-    if ( $message->{bounceType} eq 'Permanent' || $message->{complaintFeedbackType} ) {
+    if ( ( $message->{bounce}->{bounceType}
+            && $message->{bounce}->{bounceType} eq 'Permanent' )
+            || $message->{notificationType} eq 'Complaint' ) {
         my @emails;
         push @emails,
              map { $_->{emailAddress} }

--- a/lib/DDGC/Schema/ResultSet/User.pm
+++ b/lib/DDGC/Schema/ResultSet/User.pm
@@ -43,12 +43,12 @@ sub handle_bounces {
         my @emails;
         push @emails,
              map { $_->{emailAddress} }
-             @{$message->{bouncedRecipients}}
-             if $message->{bouncedRecipients};
+             @{$message->{bounce}->{bouncedRecipients}}
+             if $message->{bounce}->{bouncedRecipients};
         push @emails,
              map { $_->{emailAddress} }
-             @{$message->{complainedRecipients}}
-             if $message->{complainedRecipients};
+             @{$message->{complaint}->{complainedRecipients}}
+             if $message->{complaint}->{complainedRecipients};
         for my $email ( @emails ) {
             my $users = $self->search(\[ 'LOWER( email ) = ?', lc( $email ) ]);
             $users->update({ email_verified => 0 }) if $users;

--- a/lib/DDGC/Util/Script/SubscriberMailer.pm
+++ b/lib/DDGC/Util/Script/SubscriberMailer.pm
@@ -88,6 +88,7 @@ sub execute {
                 ->campaign( $campaign )
                 ->subscribed
                 ->verified
+                ->unbounced
                 ->mail_unsent( $campaign, $mail )
                 ->by_days_ago( $self->campaigns->{ $campaign }->{mails}->{ $mail }->{days} )
                 ->all;

--- a/lib/DDGC/Web/Service/Bounce.pm
+++ b/lib/DDGC/Web/Service/Bounce.pm
@@ -19,7 +19,9 @@ post '/handler' => sub {
     if ( $packet->{Type} eq 'SubscriptionConfirmation' ) {
         return verify( $packet );
     }
-    return rset('Subscriber')->handle_bounces( decode_json( $packet->{Message} ) );
+    my $message = decode_json( $packet->{Message} );
+    rset('User')->handle_bounces( $message );
+    return rset('Subscriber')->handle_bounces( $message );
 };
 
 1;

--- a/lib/DDGC/Web/Service/Bounce.pm
+++ b/lib/DDGC/Web/Service/Bounce.pm
@@ -18,6 +18,7 @@ sub verify {
     return {
         ok => $ok,
         status => $res->{status},
+        message => $res->{reason}
     };
 }
 

--- a/lib/DDGC/Web/Service/Bounce.pm
+++ b/lib/DDGC/Web/Service/Bounce.pm
@@ -4,13 +4,21 @@ package DDGC::Web::Service::Bounce;
 
 use DDGC::Base::Web::LightService;
 use JSON::MaybeXS;
+use HTTP::Tiny;
 
 my $json = JSON::MaybeXS->new;
 
 sub verify {
+    my $ok = 1;
     my $res = HTTP::Tiny->new->get( $_[0]->{SubscribeURL} );
-    status $res->{status} unless $res->{success};
-    return { content => $res->{content} };
+    if ( !$res->{success} ) {
+        status $res->{status};
+        $ok = 0;
+    }
+    return {
+        ok => $ok,
+        status => $res->{status},
+    };
 }
 
 post '/handler' => sub {

--- a/lib/DDGC/Web/Service/Bounce.pm
+++ b/lib/DDGC/Web/Service/Bounce.pm
@@ -1,0 +1,25 @@
+package DDGC::Web::Service::Bounce;
+
+# ABSTRACT: Bounce management
+
+use DDGC::Base::Web::LightService;
+use JSON::MaybeXS;
+
+my $json = JSON::MaybeXS->new;
+
+sub verify {
+    my $res = HTTP::Tiny->new->get( $_[0]->{SubscribeURL} );
+    status $res->{status} unless $res->{success};
+    return { content => $res->{content} };
+}
+
+post '/handler' => sub {
+    my $packet = params('body');
+
+    if ( $packet->{Type} eq 'SubscriptionConfirmation' ) {
+        return verify( $packet );
+    }
+    return rset('Subscriber')->handle_bounces( decode_json( $packet->{Message} ) );
+};
+
+1;

--- a/lib/DDGC/Web/Service/Bounce.pm
+++ b/lib/DDGC/Web/Service/Bounce.pm
@@ -8,7 +8,7 @@ use HTTP::Tiny;
 
 my $json = JSON::MaybeXS->new;
 
-sub verify {
+sub verify_subscription {
     my $ok = 1;
     my $res = HTTP::Tiny->new->get( $_[0]->{SubscribeURL} );
     if ( !$res->{success} ) {
@@ -26,7 +26,7 @@ post '/handler' => sub {
     my $packet = params('body');
 
     if ( $packet->{Type} eq 'SubscriptionConfirmation' ) {
-        return verify( $packet );
+        return verify_subscription( $packet );
     }
     my $message = decode_json( $packet->{Message} );
     rset('User')->handle_bounces( $message );

--- a/lib/Dancer2/Plugin/DDGC/Config.pm
+++ b/lib/Dancer2/Plugin/DDGC/Config.pm
@@ -20,6 +20,7 @@ on_plugin_import {
     my $config = DDGC::Config->new;
     my $appdir = $dsl->config->{appdir};
 
+    $dsl->set(verify_sns => !$ENV{DDGC_SNS_VERIFY_TEST});
     $dsl->set(ddgc_config => $config);
     $dsl->set(charset => 'UTF-8');
 

--- a/lib/Dancer2/Plugin/DDGC/Service.pm
+++ b/lib/Dancer2/Plugin/DDGC/Service.pm
@@ -42,6 +42,7 @@ on_plugin_import {
                     if ( $datum->{status} >= 400 ) {
                         $datum->{ok} = 0;
                     }
+                    $dsl->status( $datum->{status} );
                 }
             },
         )

--- a/script/ddgc_dev_server.psgi
+++ b/script/ddgc_dev_server.psgi
@@ -15,6 +15,7 @@ use DDGC::Web;
 use DDGC::Web::App::Blog;
 use DDGC::Web::App::Subscriber;
 use DDGC::Web::Service::Blog;
+use DDGC::Web::Service::Bounce;
 use DDGC::Web::Service::ActivityFeed;
 use Plack::App::File;
 use Plack::Session::State::Cookie;
@@ -42,6 +43,7 @@ builder {
         ];
     }
     mount '/s' => DDGC::Web::App::Subscriber->to_app;
+    mount '/bounce' => DDGC::Web::Service::Bounce->to_app;
     mount '/blog' => DDGC::Web::App::Blog->to_app;
     mount '/blog.json' => DDGC::Web::Service::Blog->to_app;
     mount '/activityfeed.json' => DDGC::Web::Service::ActivityFeed->to_app;

--- a/sql/1.203/bounces.sql
+++ b/sql/1.203/bounces.sql
@@ -1,0 +1,2 @@
+ALTER TABLE subscriber ADD COLUMN bounced integer DEFAULT 0 NOT NULL;
+ALTER TABLE subscriber ADD COLUMN complaint integer DEFAULT 0 NOT NULL;

--- a/t/bounces.t
+++ b/t/bounces.t
@@ -3,6 +3,7 @@ use warnings;
 
 BEGIN {
     $ENV{DDGC_DB_DSN} = 'dbi:SQLite:dbname=ddgc_test.db';
+    $ENV{DDGC_SNS_VERIFY_TEST} = 1;
     $ENV{DDGC_MAIL_TEST} = 1;
 }
 

--- a/t/bounces.t
+++ b/t/bounces.t
@@ -1,0 +1,69 @@
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{DDGC_DB_DSN} = 'dbi:SQLite:dbname=ddgc_test.db';
+    $ENV{DDGC_MAIL_TEST} = 1;
+}
+
+use Plack::Test;
+use Plack::Builder;
+use HTTP::Request::Common;
+use Test::More;
+use t::lib::DDGC::TestUtils;
+use aliased 't::lib::DDGC::TestUtils::AWS' => 'sns';
+use DDGC::Web::App::Subscriber;
+use DDGC::Web::Service::Bounce;
+use DDGC::Base::Web::LightService;
+
+t::lib::DDGC::TestUtils::deploy( { drop => 1 }, schema );
+
+my $app = builder {
+    mount '/s' => DDGC::Web::App::Subscriber->to_app;
+    mount '/bounce' => DDGC::Web::Service::Bounce->to_app;
+};
+
+test_psgi $app => sub {
+    my ( $cb ) = @_;
+
+    for my $email (qw/
+        test1@duckduckgo.com
+        test2@duckduckgo.com
+        test3@duckduckgo.com
+    / ) {
+        ok( $cb->(
+            POST '/s/a',
+            [ email => $email, campaign => 'a', flow => 'flow1' ]
+        ), "Adding subscriber : $email" );
+    }
+
+    is( rset('Subscriber')->unbounced->count, 3,
+        'No bounce reports received - 3 subscribers' );
+
+    ok( $cb->( POST '/bounce/handler',
+            'Content-Type' => 'application/json',
+            Content => sns->sns_complaint( 'test1@duckduckgo.com' )
+        ), 'Complaint from test1@duckduckgo.com' );
+
+    is( rset('Subscriber')->unbounced->count, 2,
+        'Complaint report received - 2 subscribers remain' );
+
+    ok( $cb->( POST '/bounce/handler',
+            'Content-Type' => 'application/json',
+            Content => sns->sns_transient_bounce( 'test2@duckduckgo.com' )
+        ), 'Transient bounce message about test2@duckduckgo.com' );
+
+    is( rset('Subscriber')->unbounced->count, 2,
+        'Transient bounce received - 2 subscribers remain' );
+
+    ok( $cb->( POST '/bounce/handler',
+            'Content-Type' => 'application/json',
+            Content => sns->sns_permanent_bounce( 'test3@duckduckgo.com' )
+        ), 'Permanent bounce message about test3@duckduckgo.com' );
+
+    is( rset('Subscriber')->unbounced->count, 1,
+        'Permanent bounce received - 1 subscriber remains' );
+
+};
+
+done_testing;

--- a/t/bounces.t
+++ b/t/bounces.t
@@ -44,7 +44,7 @@ test_psgi $app => sub {
     ok( $cb->( POST '/bounce/handler',
             'Content-Type' => 'application/json',
             Content => sns->sns_complaint( 'test1@duckduckgo.com' )
-        ), 'Complaint from test1@duckduckgo.com' );
+        )->is_success, 'Complaint from test1@duckduckgo.com' );
 
     is( rset('Subscriber')->unbounced->count, 2,
         'Complaint report received - 2 subscribers remain' );
@@ -52,7 +52,7 @@ test_psgi $app => sub {
     ok( $cb->( POST '/bounce/handler',
             'Content-Type' => 'application/json',
             Content => sns->sns_transient_bounce( 'test2@duckduckgo.com' )
-        ), 'Transient bounce message about test2@duckduckgo.com' );
+        )->is_success, 'Transient bounce message about test2@duckduckgo.com' );
 
     is( rset('Subscriber')->unbounced->count, 2,
         'Transient bounce received - 2 subscribers remain' );
@@ -60,10 +60,11 @@ test_psgi $app => sub {
     ok( $cb->( POST '/bounce/handler',
             'Content-Type' => 'application/json',
             Content => sns->sns_permanent_bounce( 'test3@duckduckgo.com' )
-        ), 'Permanent bounce message about test3@duckduckgo.com' );
+        )->is_success, 'Permanent bounce message about test3@duckduckgo.com' );
 
     is( rset('Subscriber')->unbounced->count, 1,
         'Permanent bounce received - 1 subscriber remains' );
+
 
 };
 

--- a/t/lib/DDGC/TestUtils/AWS.pm
+++ b/t/lib/DDGC/TestUtils/AWS.pm
@@ -1,0 +1,75 @@
+package t::lib::DDGC::TestUtils::AWS;
+use strict;
+use warnings;
+
+# ABSTRACT: Mock AWS messages
+
+use JSON::MaybeXS;
+
+sub _packet {
+    my $message = $_[0];
+    return encode_json(
+        {
+            Type => 'Notification',
+            Message => $message,
+        }
+    );
+}
+
+sub sns_complaint {
+    my $email = $_[1];
+    die "Need an email address parameter" unless $email;
+    my $message = encode_json(
+        {
+            notificationType => 'Complaint',
+            complaint => {
+                complainedRecipients => [
+                    {
+                        emailAddress => $email,
+                    },
+                ]
+            }
+        }
+    );
+    return _packet( $message );
+}
+
+sub sns_permanent_bounce {
+    my $email = $_[1];
+    die "Need an email address parameter" unless $email;
+    my $message = encode_json(
+        {
+            notificationType => 'Bounce',
+            bounce => {
+                bounceType => 'Permanent',
+                bouncedRecipients => [
+                    {
+                        emailAddress => $email,
+                    },
+                ]
+            }
+        }
+    );
+    return _packet( $message );
+}
+
+sub sns_transient_bounce {
+    my $email = $_[1];
+    die "Need an email address parameter" unless $email;
+    my $message = encode_json(
+        {
+            notificationType => 'Bounce',
+            bounce => {
+                bounceType => 'Transient',
+                bouncedRecipients => [
+                    {
+                        emailAddress => $email,
+                    },
+                ]
+            }
+        }
+    );
+    return _packet( $message );
+}
+
+1;

--- a/t/sns_verify.t
+++ b/t/sns_verify.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+
+BEGIN {
+    $ENV{DDGC_SNS_VERIFY_TEST} = 0;
+}
+
+use Plack::Test;
+use Plack::Builder;
+use HTTP::Request::Common;
+use Test::More;
+use aliased 't::lib::DDGC::TestUtils::AWS' => 'sns';
+use DDGC::Web::Service::Bounce;
+
+my $app = builder {
+    mount '/bounce' => DDGC::Web::Service::Bounce->to_app;
+};
+
+test_psgi $app => sub {
+    my ( $cb ) = @_;
+
+    ok( !$cb->( POST '/bounce/handler',
+            'Content-Type' => 'application/json',
+            Content => sns->sns_transient_bounce( 'test2@duckduckgo.com' )
+        )->is_success, 'Unsigned message fails SNS verify' );
+};
+
+done_testing;


### PR DESCRIPTION
##### Description :

Service to remove subscribers, acting upon bounce notifications from SNS.

##### Reviewer notes :

- Schema change in sql/1.203/bounces.sql
- ...

##### Who should be informed of this change?

@yegg @AdamSC1-ddg 

##### Does this change have significant privacy, security, performance or deployment implications?

This PR introduces additional facilities to verify users and respect user privacy.

New CPAN dependencies:

```
+requires 'Ouch', '0.0410';
+requires 'Crypt::OpenSSL::X509' '1.804';
+requires 'Crypt::OpenSSL::Random' '0.11';
+requires 'Crypt::OpenSSL::RSA' '0.28';
+requires 'AWS::SNS::Verify' '0.0102';
```

New service definition will be created elsewhere.

##### Checklist :
- [x] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
