### PR TITLE
Support for mail lists based on other lists with minor changes

### DIFF
--- a/lib/DDGC/Schema/ResultSet/Subscriber.pm
+++ b/lib/DDGC/Schema/ResultSet/Subscriber.pm
@@ -95,4 +95,11 @@ sub handle_bounces {
     return { ok => 1 };
 }
 
+sub exists {
+    my ( $self, $email, $campaigns ) = @_;
+    $self->search( \[ 'LOWER( email_address ) = ?', lc( $email ) ] )
+         ->search( { campaign => $campaigns } )
+         ->one_row;
+}
+
 1;

--- a/lib/DDGC/Util/Script/SubscriberMailer.pm
+++ b/lib/DDGC/Util/Script/SubscriberMailer.pm
@@ -69,7 +69,7 @@ sub _build_campaigns {
 
 
     for my $campaign ( keys %{ $campaigns } ) {
-        if ( my $base = delete $campaigns->{ $campaign }->{base} ) {
+        if ( my $base = $campaigns->{ $campaign }->{base} ) {
             if ( $campaigns->{ $base } ) {
                 $campaigns->{ $campaign } = merge( $campaigns->{ $campaign }, $campaigns->{ $base } );
             }
@@ -162,6 +162,13 @@ sub add {
     my ( $self, $params ) = @_;
     my $email = Email::Valid->address($params->{email});
     return unless $email;
+
+    my $campaigns = [ $params->{campaign} ];
+    push @{ $campaigns }, $self->campaigns->{ $params->{campaign} }->{base}
+        if $self->campaigns->{ $params->{campaign} }->{base};
+    my $exists = rset('Subscriber')->exists( $email, $campaigns );
+    return $exists if $exists;
+
     return rset('Subscriber')->create( {
         email_address => $email,
         campaign      => $params->{campaign},

--- a/lib/DDGC/Util/Script/SubscriberMailer.pm
+++ b/lib/DDGC/Util/Script/SubscriberMailer.pm
@@ -55,6 +55,7 @@ sub _build_campaigns {
         'b' => {
             base => 'a',
             verify => {
+                subject => 'Tracking in Incognito?',
                 template => 'email/a/1b.tx'
             }
         },
@@ -62,11 +63,11 @@ sub _build_campaigns {
             base => 'a',
             single_opt_in => 0,
             verify => {
+                subject => 'Tracking in Incognito?',
                 template => 'email/a/v.tx'
             }
         }
     };
-
 
     for my $campaign ( keys %{ $campaigns } ) {
         if ( my $base = $campaigns->{ $campaign }->{base} ) {


### PR DESCRIPTION
##### Description :

We will have instances where mail shots will have minor differences between runs. This adds support for defining additional campaigns which are mostly the same as another. You define the new one with a base (existing campaign you want to base the new one on) and any differences between them.

##### Reviewer notes :

TBD

##### Who should be informed of this change?

 @yegg @AdamSC1-ddg 

##### Does this change have significant privacy, security, performance or deployment implications?

No

##### Checklist :
- [x] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
