### PR TITLE
John/close blog

### DIFF
--- a/lib/DDGC/Web/Controller/Comment.pm
+++ b/lib/DDGC/Web/Controller/Comment.pm
@@ -57,7 +57,7 @@ sub delete : Chained('do') Args(1) {
 sub add :Chained('base') :Args(2) {
 	my ( $self, $c, $context, $context_id ) = @_;
 	return unless $c->user || ! $c->stash->{no_reply};
-	return if ( $context eq 'DDGC::DB::Result::Thread' || $context eq 'DDGC::DB::Result::Idea' );
+	return if ( $context eq 'DDGC::DB::Result::Thread' || $context eq 'DDGC::DB::Result::Idea' || $context eq 'DDGC::DB::Result::Blog' );
 	$c->require_action_token;
 	unless ($c->user) {
 		$c->response->redirect($c->chained_uri('My','login'));

--- a/views/includes/comments.tx
+++ b/views/includes/comments.tx
@@ -172,7 +172,7 @@
     <h3>This blog has been archived</h3>
     <p>
     Thank you for reading and contributing lively discussion to our blog!
-    Please feel free to read new posts from DuckDuckGo on <a href="https://spreadprivacy.com/">spreadprivacy.com</a>
+    Read more posts about online privacy on our new blog at <a href="https://spreadprivacy.com/">spreadprivacy.com</a>.
     </p>
 : if $vars.user {
     : comment_reply_form( $comment, $context, $context_id, 'nohide' );

--- a/views/includes/comments.tx
+++ b/views/includes/comments.tx
@@ -34,7 +34,7 @@
         <span class="comment-meta__link">
             &bull;
 
-            <a class='js-reply_link_<: $comment.id :>  js-comment-reply no-js-hide'
+            <!-- a class='js-reply_link_<: $comment.id :>  js-comment-reply no-js-hide'
                data-target='<: $comment.id :>'
                href='#'>
                 Reply
@@ -44,11 +44,11 @@
                data-target='<: $comment.id :>'
                href='#'>
                 Cancel
-            </a>
+            </a -->
         </span>
 
         : if ($vars.user.is('admin') or $vars.user.id == $comment.user.id) {
-            <span class="comment-meta__link">
+            <!-- span class="comment-meta__link">
                 : # TODO: Make this a POST
                 &bull;
                 <a href='<:
@@ -58,7 +58,7 @@
                    onclick="return confirm ('Are you sure?')">
                     Delete
                 </a>
-            </span>
+            </span -->
         : }
     : }
 : }
@@ -77,13 +77,14 @@
 : macro comment_report -> ( $comment ) {
     : if $vars.user && $vars.user.id != $comment.user.id {
         &bull;
+        <!-- 
         <a href='#report_<: $comment.id :>'
            class='js-reveal js-report-content'
            data-reveal-id='report-content'
            data-context='DDGC::DB::Result::Comment'
            data-context-id='<: $comment.id :>' >
             Report
-        </a>
+        </a -->
     : }
 : }
 
@@ -98,7 +99,7 @@
 
 : macro comment_reply_form -> ( $comment, $context, $context_id, $hide ) {
     : if $context and $context_id and $vars.user {
-        <form method='post'
+        <! -- form method='post'>
               class='comment_reply  js-reply_<: $context_id :>  <: ( $hide == 'hide' )? 'js-hide' : '' :>'
               action='/comment/add/<: $context :>/<: $context_id :>'>
 
@@ -118,7 +119,7 @@
 
             : include 'includes/bbcode_controls.tx'
 
-        </form>
+        </form -->
     : }
 : }
 
@@ -171,7 +172,7 @@
 : if $vars.user {
     : comment_reply_form( $comment, $context, $context_id, 'nohide' );
 : } else {
-    <div class="notice alert warning">
+    <!-- div class="notice alert warning">
         <i class="icn icon-warning-sign"></i>
         You must be logged in to comment. Please
         <a href='/my/login' data-reveal-id="login-box">
@@ -181,7 +182,7 @@
         <a href='/my/register'>
             Register
         </a>.
-    </div>
+    </div -->
 : }
 
 

--- a/views/includes/comments.tx
+++ b/views/includes/comments.tx
@@ -169,6 +169,11 @@
 
 <a name='comments'></a>
 
+    <h3>This blog has been archived</h3>
+    <p>
+    Thank you for reading and contributing lively discussion to our blog!
+    Please feel free to read new posts from DuckDuckGo on <a href="https://spreadprivacy.com/">spreadprivacy.com</a>
+    </p>
 : if $vars.user {
     : comment_reply_form( $comment, $context, $context_id, 'nohide' );
 : } else {


### PR DESCRIPTION
##### Description :

Close blog comments

##### Reviewer notes :

Comment form should no longer show, reply/report/delete links should no longer show on comments.

Comments with Blog context should not be added to thread.

You can test this by uncommenting the form in `macro comment_reply_form` and attempting a post.

##### References issues / PRs:


##### Who should be informed of this change?

@tagawa @russellholt 

##### Does this change have significant privacy, security, performance or deployment implications?

No

##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [x] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
