### PR TITLE
Stop setting tab name in ghIssues

### DIFF
--- a/script/ghIssues.pl
+++ b/script/ghIssues.pl
@@ -533,12 +533,6 @@ sub update_pr_template {
 
     map{ $data->{$_} = ' ' unless $data->{$_} } qw(src_url description tab);
 
-    if($data->{repo} =~ /fathead/i){
-        $data->{tab} = "About";
-    }elsif($data->{repo} =~ /goodie/i){
-        $data->{tab} = ($data->{tab} eq "Cheat Sheet")? $data->{tab} : "Answer";
-    }
-
     my $message = qq(
 ## [$data->{name}](https://duck.co/ia/view/$data->{meta_id})
 


### PR DESCRIPTION
##### Description :

Stop setting tab name for fatheads and goodies in ghIssues.pl

##### Reviewer notes :

Setting the tab name in ghIssues (for goodies at least) overrides more useful ones which should be made to stand out, such as Calculator.

##### References issues / PRs:

#

##### Who should be informed of this change?

@jdorweiler @russellholt @MariagraziaAlastra @jkv @moollaza @bsstoner @pjhampton

##### Does this change have significant privacy, security, performance or deployment implications?

No

##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
