### PR TITLE
Add additional checks to metadata upload script

### DIFF
--- a/script/ddgc_upload_metadata.sh
+++ b/script/ddgc_upload_metadata.sh
@@ -34,7 +34,7 @@ if [[ ( $DOWNLOAD_EXIT_CODE -eq 0 && $NEW_MODIFIED_TIME -gt $LAST_MODIFIED_TIME 
       if [ "$?" == "0" ] ; then
         s3cmd -P -m 'application/x-bzip2' --add-header='Content-Encoding: bzip2' --force -c /usr/local/etc/s3cmd/ddgc-metadata.s3cfg put $DDGC_REPO_BZIP2_OUT $DDGC_REPO_JSON_S3URL_TMP > /dev/null
         if [ "$?" == "0" ] ; then
-          s3cmd -c /usr/local/etc/s3cmd/ddgc-metadata.s3cfg mv $DDGC_REPO_JSON_S3URL_TMP $DDGC_REPO_JSON_S3URL > /dev/null
+          s3cmd --force -c /usr/local/etc/s3cmd/ddgc-metadata.s3cfg mv $DDGC_REPO_JSON_S3URL_TMP $DDGC_REPO_JSON_S3URL > /dev/null
         fi
       fi
     fi

--- a/script/ddgc_upload_metadata.sh
+++ b/script/ddgc_upload_metadata.sh
@@ -27,13 +27,17 @@ NEW_MODIFIED_TIME=0
 
 if [[ ( $DOWNLOAD_EXIT_CODE -eq 0 && $NEW_MODIFIED_TIME -gt $LAST_MODIFIED_TIME ) || ( $DOWNLOAD_EXIT_CODE -eq 0 && $FORCE_UPLOAD -eq 1 ) ]] ; then
   json_xs < $DDGC_REPO_JSON_OUT > /dev/null
-  [ "$?" == "0" ] && \
+  if [ "$?" == "0" ] ; then
     bzip2 --best --force --keep $DDGC_REPO_JSON_OUT
-    [ "$?" == "0" ] && \
+    if [ "$?" == "0" ] ; then
       bzip2 -t $DDGC_REPO_BZIP2_OUT
-      [ "$?" == "0" ] && \
+      if [ "$?" == "0" ] ; then
         s3cmd -P -m 'application/x-bzip2' --add-header='Content-Encoding: bzip2' --force -c /usr/local/etc/s3cmd/ddgc-metadata.s3cfg put $DDGC_REPO_BZIP2_OUT $DDGC_REPO_JSON_S3URL_TMP > /dev/null
-        [ "$?" == "0" ] && \
+        if [ "$?" == "0" ] ; then
           s3cmd -c /usr/local/etc/s3cmd/ddgc-metadata.s3cfg mv $DDGC_REPO_JSON_S3URL_TMP $DDGC_REPO_JSON_S3URL > /dev/null
+        fi
+      fi
+    fi
+  fi
 fi
 

--- a/script/ddgc_upload_metadata.sh
+++ b/script/ddgc_upload_metadata.sh
@@ -10,6 +10,7 @@ FORCE_UPLOAD=0
 [ "$DDGC_REPO_JSON_S3URL" == "" ] && \
   export DDGC_REPO_JSON_S3URL='s3://ddg-community/metadata/repo_all.json.bz2'
 DDGC_REPO_BZIP2_OUT="$DDGC_REPO_JSON_OUT.bz2"
+DDGC_REPO_JSON_S3URL_TMP="$DDGC_REPO_JSON_S3URL.$(date +%s)"
 
 [ $FORCE_UPLOAD -eq 1 ] && [ -f $DDGC_REPO_JSON_OUT ] && rm $DDGC_REPO_JSON_OUT
 LAST_MODIFIED_TIME=0
@@ -25,8 +26,14 @@ NEW_MODIFIED_TIME=0
   NEW_MODIFIED_TIME=$(/usr/bin/stat --format=%Y $DDGC_REPO_JSON_OUT)
 
 if [[ ( $DOWNLOAD_EXIT_CODE -eq 0 && $NEW_MODIFIED_TIME -gt $LAST_MODIFIED_TIME ) || ( $DOWNLOAD_EXIT_CODE -eq 0 && $FORCE_UPLOAD -eq 1 ) ]] ; then
-  bzip2 --best --force --keep $DDGC_REPO_JSON_OUT
+  json_xs < $DDGC_REPO_JSON_OUT > /dev/null
   [ "$?" == "0" ] && \
-    s3cmd -P -m 'application/x-bzip2' --add-header='Content-Encoding: bzip2' --force -c /usr/local/etc/s3cmd/ddgc-metadata.s3cfg put $DDGC_REPO_BZIP2_OUT $DDGC_REPO_JSON_S3URL > /dev/null
+    bzip2 --best --force --keep $DDGC_REPO_JSON_OUT
+    [ "$?" == "0" ] && \
+      bzip2 -t $DDGC_REPO_BZIP2_OUT
+      [ "$?" == "0" ] && \
+        s3cmd -P -m 'application/x-bzip2' --add-header='Content-Encoding: bzip2' --force -c /usr/local/etc/s3cmd/ddgc-metadata.s3cfg put $DDGC_REPO_BZIP2_OUT $DDGC_REPO_JSON_S3URL_TMP > /dev/null
+        [ "$?" == "0" ] && \
+          s3cmd -c /usr/local/etc/s3cmd/ddgc-metadata.s3cfg mv $DDGC_REPO_JSON_S3URL_TMP $DDGC_REPO_JSON_S3URL
 fi
 

--- a/script/ddgc_upload_metadata.sh
+++ b/script/ddgc_upload_metadata.sh
@@ -34,6 +34,6 @@ if [[ ( $DOWNLOAD_EXIT_CODE -eq 0 && $NEW_MODIFIED_TIME -gt $LAST_MODIFIED_TIME 
       [ "$?" == "0" ] && \
         s3cmd -P -m 'application/x-bzip2' --add-header='Content-Encoding: bzip2' --force -c /usr/local/etc/s3cmd/ddgc-metadata.s3cfg put $DDGC_REPO_BZIP2_OUT $DDGC_REPO_JSON_S3URL_TMP > /dev/null
         [ "$?" == "0" ] && \
-          s3cmd -c /usr/local/etc/s3cmd/ddgc-metadata.s3cfg mv $DDGC_REPO_JSON_S3URL_TMP $DDGC_REPO_JSON_S3URL
+          s3cmd -c /usr/local/etc/s3cmd/ddgc-metadata.s3cfg mv $DDGC_REPO_JSON_S3URL_TMP $DDGC_REPO_JSON_S3URL > /dev/null
 fi
 


### PR DESCRIPTION
##### Description :

Additional validation and upload stages for metadata upload

- JSON validity
- bzip file validity
- Atomic set-and-move depending on s3cmd success

##### Reviewer notes :


##### References issues / PRs:

#

##### Who should be informed of this change?

@jkv @kablamo 

##### Does this change have significant privacy, security, performance or deployment implications?


##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
