### PR TITLE
Bypass support@ for security reports

### DIFF
--- a/lib/DDGC/Config.pm
+++ b/lib/DDGC/Config.pm
@@ -389,6 +389,7 @@ sub first_active_campaign {
 }
 
 has_conf feedback_email => DDGC_FEEDBACK_EMAIL => 'support@duckduckgo.com';
+has_conf directline_email => DDGC_DIRECTLINE_EMAIL => 'support@duckduckgo.com';
 has_conf error_email => DDGC_ERROR_EMAIL => 'ddgc@duckduckgo.com';
 has_conf share_email => DDGC_SHARE_EMAIL => 'sharewear@duckduckgo.com';
 has_conf ia_email => DDGC_IA_EMAIL => 'ddgc-ia@duckduckgo.com';

--- a/lib/DDGC/Web/Controller/Feedback.pm
+++ b/lib/DDGC/Web/Controller/Feedback.pm
@@ -169,8 +169,9 @@ sub step :Chained('feedback') :PathPart('') :Args(1) {
       delete $data{$_} unless $data{$_};
     }
 
-    my $email;
+    my ( $email, $from );
     if ( $data{1} =~ /security/ ) {
+      $from = 'dax@duckduckgo.com';
       $email = $c->d->config->directline_email;
        $c->stash->{feedback_data} = {
          Bug => $data{'1_bug'},
@@ -179,6 +180,7 @@ sub step :Chained('feedback') :PathPart('') :Args(1) {
        };
        $c->stash->{directline} = 1;
     } else {
+      $from = '"DuckDuckGo Community" <noreply@duckduckgo.com>';
       $email = $c->d->config->feedback_email;
       $c->stash->{feedback_data} = \%data;
       my @header_field_names = $c->req->headers->header_field_names();
@@ -188,8 +190,7 @@ sub step :Chained('feedback') :PathPart('') :Args(1) {
     $c->stash->{c} = $c;
     $c->d->postman->template_mail(
       1,
-      $email,
-      '"DuckDuckGo Community" <noreply@duckduckgo.com>',
+      $email, $from,
       '[DDG Feedback '.$c->stash->{feedback_name}.'] '.$data{'1'},
       'feedback',
       $c->stash,

--- a/templates/email/base.tx
+++ b/templates/email/base.tx
@@ -5,11 +5,13 @@
   </head>
   <body style="padding:0; margin:0; background-color: #ffffff">
 	<table cellpadding="5" cellspacing="0" border="0" width="100%" bgcolor="#ffffff">
+		: if !$directline {
 		<tr>
 			<td height="20" align="center" valign="top" colspan="3" <: style("warning") :>>
 			  This is an automated email from DuckDuckGo's Community platform. <b>DO NOT REPLY</b>.
 			</td>
 		</tr>
+		: }
 		<tr>
 			<td width="5">&nbsp;</td>
 			<td>

--- a/templates/email/feedback.tx
+++ b/templates/email/feedback.tx
@@ -10,6 +10,7 @@
       <th><: $kv.value :></th>
     </tr>
   <: } :>
+  : if !$directline {
   <: if $c.user { :>
     <tr>
       <th><hr/></th>
@@ -38,4 +39,5 @@
       <th><: $c.req.header($field) :>
     </tr>
   <: } :>
+  : }
 </table>

--- a/templates/email/feedback.tx
+++ b/templates/email/feedback.tx
@@ -1,7 +1,9 @@
 <table>
+  : if !$directline {
   <tr>
     <th>Feedback Data</th>
   </tr>
+  : }
   <: for $feedback_data.kv() -> $kv { :>
     <tr>
       <td><: $kv.key :></td>

--- a/templates/feedback/option/next.tx
+++ b/templates/feedback/option/next.tx
@@ -1,3 +1,2 @@
-<input type="hidden" name="action_token" value="<: $action_token :>">
 <input type="submit" name="option_<: $index :>" value="<: $option.description :>" class="fb-step__body  fb-step__body--btn" />
 <i class="fb-step__arrow  ddgi-arrow-right"></i>


### PR DESCRIPTION
##### Description :

Bypass support address for security issues coming through feedback system

##### Reviewer notes :

Set `DDGC_DIRECTLINE_EMAIL` in env and visit /feedback/bug to begin a security report. Report should go to the address you set in the env.

##### References issues / PRs:

#

##### Who should be informed of this change?
@jkv @MariagraziaAlastra 

##### Does this change have significant privacy, security, performance or deployment implications?


##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
