### PR TITLE
Do not apply session invalidation rules to basic auth requests

### DIFF
--- a/lib/DDGC/Web/Controller/Root.pm
+++ b/lib/DDGC/Web/Controller/Root.pm
@@ -26,7 +26,7 @@ sub base :Chained('/') :PathPart('') :CaptureArgs(0) {
 		}
 	}
 
-	if ($c->user) {
+	elsif ($c->user) {
 		$c->d->current_user($c->user);
 
 		if (


### PR DESCRIPTION
##### Description :
Do not apply session invalidation rules to basic auth requests since this can break duck workflow.

##### Reviewer notes :


##### References issues / PRs:

#

##### Who should be informed of this change?


##### Does this change have significant privacy, security, performance or deployment implications?


##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
