### PR TITLE
Removed links to old forum

### DIFF
--- a/lib/DDGC/Feedback/Config/Feature.pm
+++ b/lib/DDGC/Feedback/Config/Feature.pm
@@ -9,12 +9,8 @@ sub feedback_title { "I've got a feature request." }
 sub feedback {[
   { description => "We'd love your suggestions!. Please check our <a href='https://duck.co/help'>Help pages</a> for common requests like making an email service or a browser. If you can't find what you're looking for, use the options below:", type => "info", icon => "newspaper", },
 
-  { description => "It's a feature that could be an Instant Answer", icon => "sun" },
-
-    "Please submit Instant Answer ideas to our community voting platform at <a href='https://duck.co/ideas'>https://duck.co/ideas</a>. If you're a developer, you can even make them yourself at <a href='http://duckduckhack.com/'>http://duckduckhack.com/</a>.",
-
-  { description => "It's a feature that wouldn’t work as an Instant Answer", icon => "coffee" },
-    "Please submit your idea to our community forum so that others can help expand (or even develop) your idea: <a href='https://duck.co/forum'>https://duck.co/forum</a>",
+  { description => "It's a feature", icon => "sun" },
+    "Please share your idea with the DuckDuckGo community on our subreddit: <a href='https://www.reddit.com/r/duckduckgo/'>reddit.com/r/duckduckgo</a>",
 
   { description => "It's a translation request", icon => "globe" },
     "You can translate DuckDuckGo to your language through the <a href='https://duck.co/translate'>Community Platform</a>. If you don't see your language available, please request it <a href='https://duck.co/my/requestlanguage'>here</a>.",


### PR DESCRIPTION
##### Description :
In our feedback flow, we're currently sending people with feature ideas to the old (closed) forum. This PR changes that to the DDG subreddit.

##### Reviewer notes :


##### References issues / PRs:

#

##### Who should be informed of this change?
@moollaza 

##### Does this change have significant privacy, security, performance or deployment implications?
No

##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
