### PR TITLE
Filter out categories with no related helps

### DIFF
--- a/lib/DDGC/Web/Controller/Help.pm
+++ b/lib/DDGC/Web/Controller/Help.pm
@@ -14,7 +14,7 @@ sub base :Chained('/base') :PathPart('help') :CaptureArgs(0) {
     $c->d->rs('Help::Category')->search({},{
     order_by => { -asc => 'me.sort' },
     prefetch => [ 'help_category_contents', { helps => 'help_contents' } ],
-    cache_for => 600,
+    cache_for => 300,
   })->all ];
   $c->stash->{title} = 'Help pages';
   $c->stash->{help_language} = $c->d->rs('Language')->search({ locale => 'en_US' })->one_row;

--- a/lib/DDGC/Web/Controller/Help.pm
+++ b/lib/DDGC/Web/Controller/Help.pm
@@ -9,7 +9,9 @@ BEGIN {extends 'Catalyst::Controller'; }
 sub base :Chained('/base') :PathPart('help') :CaptureArgs(0) {
   my ( $self, $c ) = @_;
   $c->stash->{page_class} = "page-help  texture-ducksymbol";
-  $c->stash->{help_categories} = [ $c->d->rs('Help::Category')->search({},{
+  $c->stash->{help_categories} = [
+    grep { $_->helps->count }
+    $c->d->rs('Help::Category')->search({},{
     order_by => { -asc => 'me.sort' },
     prefetch => [ 'help_category_contents', { helps => 'help_contents' } ],
     cache_for => 600,


### PR DESCRIPTION
##### Description :
Do not show empty help categories on help pages

##### Reviewer notes :
Yes, this should be done in the query but this isn't significantly slower and allows me to not have to think about it.

- Removing or changing the `cache_for` value to 0 on line 17 should make testing this easier
- Using the help editor in /admin/help, remove all help articles from a given category
- This category should no longer be visible on /help or the side menu on help pages
- Re-adding articles to this category should show them again on these pages

##### References issues / PRs:

#

##### Who should be informed of this change?

 @tagawa 

##### Does this change have significant privacy, security, performance or deployment implications?

Nah - grepping across a handful of rows is fast enough.

##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
