### PR TITLE
Fixed extra padding on translate login page

### DIFF
--- a/root/static/css/content.css
+++ b/root/static/css/content.css
@@ -5118,7 +5118,6 @@ a.fill {
   float: right; }
 
 .account-actions {
-  padding-top: 22px;
   display: inline-block;
   white-space: nowrap;
   word-wrap: break-word; }

--- a/root/static/css/content.css
+++ b/root/static/css/content.css
@@ -5118,6 +5118,7 @@ a.fill {
   float: right; }
 
 .account-actions {
+  padding-top: 22px;
   display: inline-block;
   white-space: nowrap;
   word-wrap: break-word; }
@@ -5963,4 +5964,9 @@ h1 + .intro, .intro--mg {
   background: #fff;
   color: #333;
   text-shadow: none;
+}
+
+/* Translation login form fix */
+.notice .account-actions {
+  padding-top: 0;
 }


### PR DESCRIPTION
##### Description :
Removes some strange padding in the login box (translation page only).

##### Reviewer notes :


##### References issues / PRs:

#

##### Who should be informed of this change?
@jbarrett @chrismorast 

##### Does this change have significant privacy, security, performance or deployment implications?
No

##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
