### PR TITLE
Switch to using PagerDuty v2 API

### DIFF
--- a/lib/DDGC/PagerDuty.pm
+++ b/lib/DDGC/PagerDuty.pm
@@ -31,7 +31,7 @@ sub on_call {
             $_->{escalation_policy}->{summary} eq 'ops on-call' && $_->{escalation_level} == 1
         } @{ $self->json->decode( $res->decoded_content )->{oncalls} };
         $req = $self->_build_req('https://api.pagerduty.com/users/' . $on_call->{user}->{id});
-        $res = $http->request($req);
+        $res = $self->ddgc->http->request($req);
         if ($res->is_success) {
             return $self->json->decode( $res->decoded_content )->{user}->{email};
         }

--- a/lib/DDGC/PagerDuty.pm
+++ b/lib/DDGC/PagerDuty.pm
@@ -13,21 +13,29 @@ sub _build_json { JSON::MaybeXS->new->utf8 }
 has api_key => ( is => 'lazy' );
 sub _build_api_key { $_[0]->ddgc->config->pagerduty_api_key }
 
-sub on_call {
-    my ( $self ) = @_;
-    my $req = GET 'https://duckduckgo.pagerduty.com/api/v1/users/on_call';
+sub _build_req {
+    my ( $self, $url ) = @_;
+    my $req = GET $url;
+    $req->header('Accept', 'application/vnd.pagerduty+json;version=2');
     $req->authorization('Token token=' . $self->api_key);
     $req->content_type('application/json');
+    return $req;
+}
 
+sub on_call {
+    my ( $self ) = @_;
+    my $req = $self->_build_req('https://api.pagerduty.com/oncalls');
     my $res = $self->ddgc->http->request($req);
     if ($res->is_success) {
         my ( $on_call ) = grep {
-            grep {
-                $_->{escalation_policy}->{name} eq 'ops on-call' && $_->{level} == 1
-            } @{ $_->{on_call} }
-        } @{ $self->json->decode( $res->decoded_content )->{users} };
+            $_->{escalation_policy}->{summary} eq 'ops on-call' && $_->{escalation_level} == 1
+        } @{ $self->json->decode( $res->decoded_content )->{oncalls} };
+        $req = $self->_build_req('https://api.pagerduty.com/users/' . $on_call->{user}->{id});
+        $res = $http->request($req);
+        if ($res->is_success) {
+            return $self->json->decode( $res->decoded_content )->{user}->{email};
+        }
 
-        return $on_call->{email};
     }
     return 0;
 }


### PR DESCRIPTION
##### Description :
@jbarrett, we need to switch to using PagerDuty v2 as v1 will stop working soon. Can you review/test this?

##### Reviewer notes :


##### References issues / PRs:

#

##### Who should be informed of this change?


##### Does this change have significant privacy, security, performance or deployment implications?


##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
