### PR TITLE
Adding support to retire translation tokens

### DIFF
--- a/lib/DDGC/DB/Result/Token/Domain/Language.pm
+++ b/lib/DDGC/DB/Result/Token/Domain/Language.pm
@@ -157,7 +157,9 @@ msgstr ""
 EOF
 	$intro > $po;
 	my %doublecheck;
-	for my $tl ($self->search_related('token_languages',{},{
+	for my $tl ($self->search_related('token_languages',{
+		'token.retired' => 0
+	},{
 		prefetch => ['token',{ 
 			token_domain_language => [qw( language token_domain )],
 			token_language_translations => [{ user => { user_languages => 'language' }, token_language_translation_votes => 'user' }],

--- a/lib/DDGC/LocaleDist.pm
+++ b/lib/DDGC/LocaleDist.pm
@@ -90,7 +90,7 @@ sub BUILD {
 	my $lib_dir = dir($self->build_dir,'lib',@lib_dir_parts);
 	my $testdir = dir($self->build_dir,'t');
 
-	my $tokencount = $self->token_domain->tokens->search()->count;
+	my $tokencount = $self->token_domain->tokens->search({ 'retired' => 0 })->count;
 	my $domainname = $self->token_domain->name;
 
 	my %locales;

--- a/lib/DDGC/Web/Controller/Translate.pm
+++ b/lib/DDGC/Web/Controller/Translate.pm
@@ -62,8 +62,8 @@ sub active_tokens :Chained('base') :PathPart('active_tokens.json') :Args(1) {
 	my ( $self, $c, $domain ) = @_;
 	$domain ||= 'duckduckgo-duckduckgo';
 	$c->stash->{x} = {
-		tokens => {
-			map { $_->id, $_->msgid }
+		tokens => [
+			map { { id => $_->id, msgid => $_->msgid } }
 			$c->d->rs('Token')
 			->search({
 				retired => 0,
@@ -71,7 +71,7 @@ sub active_tokens :Chained('base') :PathPart('active_tokens.json') :Args(1) {
 			},
 			{ prefetch => 'token_domain' })
 			->all
-		}
+		]
 	};
 	$c->forward( $c->view('JSON') );
 }

--- a/lib/DDGC/Web/Controller/Translate.pm
+++ b/lib/DDGC/Web/Controller/Translate.pm
@@ -199,12 +199,15 @@ sub domain :Chained('logged_in') :PathPart('') :CaptureArgs(1) {
 						},)->get_column('token_language_id')->as_query,
 					},
 					'undone_count.token_domain_language_id' => { -ident => 'me.id' },
+					'token.retired' => 0,
 				],
 			},{
-				join => 'token_language_translations', alias => 'undone_count'
+				join => [ 'token', 'token_language_translations' ],
+				alias => 'undone_count'
 			})->count_rs->as_query,
 			token_total_count => $c->d->rs('Token')->search({
 				'total_count.token_domain_id' => { -ident => 'me.token_domain_id' },
+				'retired' => 0,
 			},{
 				join => 'token_domain', alias => 'total_count'
 			})->count_rs->as_query,

--- a/lib/DDGC/Web/Controller/Translate.pm
+++ b/lib/DDGC/Web/Controller/Translate.pm
@@ -58,6 +58,24 @@ sub logged_in :Chained('base') :PathPart('') :CaptureArgs(0) {
 	}
 }
 
+sub active_tokens :Chained('base') :PathPart('active_tokens.json') :Args(1) {
+	my ( $self, $c, $domain ) = @_;
+	$domain ||= 'duckduckgo-duckduckgo';
+	$c->stash->{x} = {
+		tokens => {
+			map { $_->id, $_->msgid }
+			$c->d->rs('Token')
+			->search({
+				retired => 0,
+				'token_domain.key' => $domain,
+			},
+			{ prefetch => 'token_domain' })
+			->all
+		}
+	};
+	$c->forward( $c->view('JSON') );
+}
+
 sub untranslated_all :Chained('logged_in') :Args(0) {
 	my ( $self, $c ) = @_;
 	$c->wiz_start( 'UntranslatedAll' );

--- a/lib/DDGC/Web/Controller/Translate.pm
+++ b/lib/DDGC/Web/Controller/Translate.pm
@@ -192,13 +192,17 @@ sub token_retire :Chained('single_token') :PathPart('retire') :Args(1) {
 	my ( $self, $c, $retire ) = @_;
 	if ( !$c->user->admin ) {
 		$c->response->status(403);
-		return $c->detach;
+		$c->stash->{x} = {
+			error => 403
+		}
 	}
-	$c->stash->{token}->retired($retire);
-	$c->stash->{token}->update;
-	$c->stash->{x} = {
-		check_result => $c->stash->{token}->retired,
-	};
+	else {
+		$c->stash->{token}->retired($retire);
+		$c->stash->{token}->update;
+		$c->stash->{x} = {
+			check_result => $c->stash->{token}->retired,
+		};
+	}
 	$c->forward( $c->view('JSON') );
 }
 

--- a/src/js/ddgc/ddgc.js
+++ b/src/js/ddgc/ddgc.js
@@ -271,7 +271,7 @@ $(document).ready(function() {
 				var text = ( data.check_result == 1 )
 					? 'Retired'
 					: 'Un-retired';
-				parent.html('<div class="button">'+text+'</div>');
+				parent.html('('+text+')');
 			}
 		});
 	});

--- a/src/js/ddgc/ddgc.js
+++ b/src/js/ddgc/ddgc.js
@@ -257,6 +257,25 @@ $(document).ready(function() {
 	    });
 	});
 
+	$('a.retire_link').click(function(e){
+		e.preventDefault();
+		var parent = $(this).parent();
+		$.ajax({
+			url: $(this).attr('href'),
+			beforeSend: function(xhr) {				
+				parent.html(
+					'<img class="loading-image"' +
+					'src="/static/img/ajax-loader.gif"/>');
+			},
+			success: function(data) {				
+				var text = ( data.check_result == 1 )
+					? 'Retired'
+					: 'Un-retired';
+				parent.html('<div class="button">'+text+'</div>');
+			}
+		});
+	});
+
 	$('a.checkfalse_link').click(function(e){
 		e.preventDefault();
 		var parent = $(this).parent();

--- a/t/translation.t
+++ b/t/translation.t
@@ -1,0 +1,135 @@
+use strict;
+use warnings;
+
+# Database setup
+BEGIN {
+    unlink 'ddgc_test.db';
+    $ENV{DDGC_DB_DSN} = 'dbi:SQLite:dbname=ddgc_test.db';
+}
+
+use Test::More;
+use t::lib::DDGC::TestUtils;
+use HTTP::Request::Common;
+use Plack::Test;
+use Plack::Builder;
+use Plack::Session::State::Cookie;
+use Plack::Session::Store::File;
+use File::Temp qw/ tempdir /;
+use JSON::MaybeXS qw/:all/;
+use URI;
+
+use DDGC;
+use DDGC::Web;
+
+my $d = DDGC->new;
+t::lib::DDGC::TestUtils::deploy( undef, $d->db );
+
+my $app = builder {
+    enable 'Session',
+        store => Plack::Session::Store::File->new(
+            dir => tempdir,
+        ),
+        state => Plack::Session::State::Cookie->new(
+            secure => 0,
+            httponly => 1,
+            expires => 21600,
+            session_key => 'ddgc_session',
+        );
+    mount '/testutils' => t::lib::DDGC::TestUtils->to_app;
+    mount '/' => DDGC::Web->new->psgi_app;
+};
+
+test_psgi $app => sub {
+    my ( $cb ) = @_;
+
+    my $create_user_and_get_cookie = sub {
+        my $opts = shift;
+
+        my $user_request = $cb->(
+            POST '/testutils/new_user',
+            {
+                username => $opts->{username},
+                ( $opts->{role} ) ? ( role => $opts->{role} ) : (),
+            }
+        );
+        ok( $user_request->is_success, 'Creating a user' );
+
+        my $session_request = $cb->(
+            POST '/testutils/user_session',
+            { username => $opts->{username} }
+        );
+        ok( $session_request->is_success, 'Getting user Cookie' );
+        my $cookie = 'ddgc_session=' . $session_request->content;
+    };
+
+    my $retire_request = sub {
+        my ( $user, $token_id, $retire ) = @_;
+
+        $cb->(
+            GET "/translate/single_token/$token_id/retire/$retire",
+            Cookie => $user,
+        );
+    };
+
+    my $token = sub {
+        $d->rs('Token')->search({ msgid => $_[0] })->one_row;
+    };
+
+    my $new_lang = sub {
+        my ( $locale, $name ) = @_;
+        $d->rs('Language')->create({
+            locale => $locale,
+            name_in_english => $name,
+            name_in_local => $name
+        });
+    };
+
+    my $admin = $create_user_and_get_cookie->( {
+        username => 'tadminuser',
+        role     => 'admin',
+    } );
+    my $admin_user = $d->find_user('tadminuser');
+
+    my $user = $create_user_and_get_cookie->( {
+        username => 'tuser',
+    } );
+    my $user_user = $d->find_user('tuser');
+
+    my $l1 = $new_lang->('en_US', 'US English');
+
+    my $domain = $d->rs('Token::Domain')->create({
+        name => 'test',
+        key => 'test',
+        source_language_id => $l1->id,
+    });
+
+    $_->create_related(
+        user_languages => {
+            grade => 5,
+            language_id => $l1->id,
+        }
+    ) for ( $admin_user, $user_user );
+
+    my $l2 = $new_lang->('en_GB', 'UK English');
+    my $l3 = $new_lang->('en_AU', 'Aus English');
+
+    $domain->create_related(
+        token_domain_languages => {
+            language => $_
+        }
+    ) for ( $l2, $l3 );
+
+    $domain->create_related( tokens => { msgid => $_ } )
+        for ( qw/ foo bar baz qux quux quuz / );
+
+    my $r = $retire_request->( $user, $token->('baz')->id, 1 );
+    ok( !$r->is_success, 'Non-admin cannot retire token' );
+    is( $token->('baz')->retired, 0, 'Token baz not retired' );
+
+    $r = $retire_request->( $admin, $token->('baz')->id, 1 );
+    ok( $r->is_success, 'Admin can retire token' );
+    is( $token->('baz')->retired, 1, 'Token baz retired' );
+
+};
+
+done_testing;

--- a/templates/translate/tokens/token_language.tx
+++ b/templates/translate/tokens/token_language.tx
@@ -3,25 +3,24 @@
 <: my $hide_field = "Hide translation field" :>
 <: my $show_field = "Add your own translation" :>
 
-: macro retired -> ( $c, $token_language ) {
+: macro retired -> ( $c, $token ) {
 	: if $c.user.admin {
 		<span>
-		: if $token_language.token.retired == 1 {
-			<a href="<: $u('Translate', 'token_retire', $token_language.token.id, 0) :>" class="retire_link button">
+		: if $token.retired == 1 {
+			<a href="<: $u('Translate', 'token_retire', $token.id, 0) :>" class="retire_link button">
 				Un-retire
 			</a>
 		: } else {
-			<a href="<: $u('Translate', 'token_retire', $token_language.token.id, 1) :>" class="retire_link button">
+			<a href="<: $u('Translate', 'token_retire', $token.id, 1) :>" class="retire_link button">
 				Retire
 			</a>
 		: }
 		</span>
 	: } else {
-		: if $token_language.token.retired == 1 {
+		: if $token.retired == 1 {
 			<span class="translation-invalid group">This token has been retired</span>
 		: }
 	: }
-	
 : }
 
 <fieldset class="row snippet">		
@@ -31,14 +30,14 @@
 		<div class="token__content">			
 			<strong class="snippet__heading"><: hilight_token_placeholders($token_language.token.msgid) :></strong>
 			<: if !$token_language_page { :><a href="<: $u('Translate','tokenlanguage',$token_language.id) :>" class="button  light  pull-right">Discuss</a><: } :>
-			: retired( $c, $token_language );
+			: retired( $c, $token_language.token );
 		</div>	
 	<: if $token_language.token.msgid_plural { :>
 		<div class="row">
 			<div class="token__label"><label>Term (Plural):</label></div>
 			<div class="token__content">
 				<strong class="snippet__heading"><: hilight_token_placeholders($token_language.token.msgid_plural) :></strong>
-				: retired( $c, $token_language );
+				: retired( $c, $token_language.token );
 			</div>
 		</div>
 	<: } :>

--- a/templates/translate/tokens/token_language.tx
+++ b/templates/translate/tokens/token_language.tx
@@ -3,6 +3,27 @@
 <: my $hide_field = "Hide translation field" :>
 <: my $show_field = "Add your own translation" :>
 
+: macro retired -> ( $c, $token_language ) {
+	: if $c.user.admin {
+		<span>
+		: if $token_language.token.retired == 1 {
+			<a href="<: $u('Translate', 'token_retire', $token_language.token.id, 0) :>" class="retire_link button">
+				Un-retire
+			</a>
+		: } else {
+			<a href="<: $u('Translate', 'token_retire', $token_language.token.id, 1) :>" class="retire_link button">
+				Retire
+			</a>
+		: }
+		</span>
+	: } else {
+		: if $token_language.token.retired == 1 {
+			<span class="translation-invalid group">This token has been retired</span>
+		: }
+	: }
+	
+: }
+
 <fieldset class="row snippet">		
 	
 	<div class="row">
@@ -10,12 +31,14 @@
 		<div class="token__content">			
 			<strong class="snippet__heading"><: hilight_token_placeholders($token_language.token.msgid) :></strong>
 			<: if !$token_language_page { :><a href="<: $u('Translate','tokenlanguage',$token_language.id) :>" class="button  light  pull-right">Discuss</a><: } :>
+			: retired( $c, $token_language );
 		</div>	
 	<: if $token_language.token.msgid_plural { :>
 		<div class="row">
 			<div class="token__label"><label>Term (Plural):</label></div>
 			<div class="token__content">
 				<strong class="snippet__heading"><: hilight_token_placeholders($token_language.token.msgid_plural) :></strong>
+				: retired( $c, $token_language );
 			</div>
 		</div>
 	<: } :>


### PR DESCRIPTION
##### Description :

This change should add a simple facility for admins to retire translation tokens which are no longer in use.

These tokens should not be counted in coverage metrics, should not show up in "unvoted" or "untranslated" sets and should not be included in published locale packages.

##### Reviewer notes :

A new button should be visible to admins on translation pages - Retire or Un-retire a token.

A message should be visible to non-admins to let them know a token has been retired.

Retired tokens should not show up in untranslated or unvoted work flows.

New unit tests assert that retired tokens are not published to locale packages. If you wish to verify this you can run (e.g. for the test domain in dev):

```bash
script/ddgc_update_locale_dist.pl --domain=test
```

The output of this script will give you a filename with base '/home/ddgc/ddgc/duckpan/', so 'authors/id/T/TE/TESTONE/DDGC-Locale-Test-20180313.104300.tar.gz' is in:

/home/ddgc/ddgc/duckpan/authors/id/T/TE/TESTONE/DDGC-Locale-Test-20180313.104300.tar.gz

Inside this tarball you can see files like share/$lang/LC_MESSAGES/test.{js,mo,po} - none of these should contain any reference to retired tokens.


##### References issues / PRs:

#

##### Who should be informed of this change?
@MariagraziaAlastra @bsstoner @bbraithwaite @andrey-p 

##### Does this change have significant privacy, security, performance or deployment implications?


##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
