### PR TITLE
Don't publish translations for en_US

### DIFF
--- a/lib/DDGC/DB/Result/Token/Domain/Language.pm
+++ b/lib/DDGC/DB/Result/Token/Domain/Language.pm
@@ -166,6 +166,7 @@ EOF
 		}],
 		order_by => [ 'token_language_translations.updated', 'token_language_translations.id' ],
 	})->all) {
+		next if $tl->token_domain_language->language->locale eq 'en_US';
 		$tl->auto_use; # should be renamed
 		my $msgid = $tl->token->msgid;
 		$msgid .= '||||msgctxt||||'.$tl->token->msgctxt if $tl->token->msgctxt;

--- a/t/translation.t
+++ b/t/translation.t
@@ -120,7 +120,7 @@ test_psgi $app => sub {
         token_domain_languages => {
             language => $_
         }
-    ) for ( $l2, $l3 );
+    ) for ( $l1, $l2, $l3 );
 
     $domain->create_related( tokens => { msgid => $_ } )
         for ( qw/ foo bar baz qux quux quuz / );
@@ -142,6 +142,14 @@ test_psgi $app => sub {
         my $quux = grep { /quux/ } io->file($fn)->all;
         ok( !$baz, "Retired token baz not in locale js for $lang" );
         ok( $quux, "Token quux is in locale js for $lang" );
+    }
+
+    my $en_us_dir = catfile( $dir, qw/ share en_US LC_MESSAGES / );
+    my @po = io->file( catfile( $en_us_dir, 'test.po' ) )->all;
+    my @js = io->file( catfile( $en_us_dir, 'test.js' ) )->all;
+    for my $token ( qw/ foo bar baz qux quux quuz / ) {
+        ok( !( grep { /$token/ } @js ), 'en_US tokens not in js' );
+        ok( !( grep { /$token/ } @po ), 'en_US tokens not in po' );
     }
 
 };


### PR DESCRIPTION
##### Description :
This removes translations completely for en_US.

##### Reviewer notes :
See locale updating notes in #1508

po and js files should be created for en_US which means gettext will still be built for it, but no tokens/translations should be present in the file.

##### References issues / PRs:

#1508 

##### Who should be informed of this change?

@bsstoner @andrey-p @tagawa 

##### Does this change have significant privacy, security, performance or deployment implications?


##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
