### PR TITLE
Skip updating locale package if no update in last 12h

### DIFF
--- a/script/ddgc_update_locale_dist.pl
+++ b/script/ddgc_update_locale_dist.pl
@@ -13,13 +13,18 @@ use Getopt::Long;
 use File::Copy;
 use Path::Class;
 use DDP;
+use DateTime;
 
 my $domain;
 my $target;
+my $force = 0;
+my $delta = '12h';
 
 GetOptions(
 	"domain=s" => \$domain,
 	"target=s" => \$target,
+	"force"    => \$force,
+	"delta=s"  => \$delta,
 );
 
 die 'you must give a --domain' unless $domain;
@@ -27,6 +32,31 @@ die 'you must give a --domain' unless $domain;
 $target = dir($target)->absolute if $target;
 
 my $ddgc = DDGC->new;
+
+goto PUBLISH if $force;
+
+my $delta_elements = { reverse $delta =~ /([0-9]+)([smhd])/g };
+my $then_dt = DateTime->now->subtract(
+	DateTime::Duration->new(
+		seconds => $delta_elements->{s} // 0,
+		minutes => $delta_elements->{m} // 0,
+		hours   => $delta_elements->{h} // 0,
+		days    => $delta_elements->{d} // 0,
+	)
+);
+
+my @updated_since_then = map {
+	$ddgc->resultset( $_ )->search({
+		updated => {
+			'>=' => $ddgc->db->storage->datetime_parser->format_datetime( $then_dt )
+		}
+	})->all
+} qw/ Token::Language::Translation Token::Language::Translation::Vote /;
+
+die "Skipping locale package publish - no new data in last $delta" unless scalar @updated_since_then;
+
+PUBLISH:
+
 my $td = $ddgc->resultset('Token::Domain')->search({ key => $domain },{ prefetch => 'tokens' })->next;
 
 my $local_dist = DDGC::LocaleDist->new( token_domain => $td );


### PR DESCRIPTION
##### Description :

Do not publish locale package if there has not been a new translation or vote in 12 hours

##### Reviewer notes :

(Providing you have made no translation changes in the last 12h):

1. This will skip publishing the package:
`$ script/ddgc_update_locale_dist.pl --domain=test`
2. You can force it to update:
`$ script/ddgc_update_locale_dist.pl --domain=test --force`
3. Go to /translate/test and add or vote on a translation, then publish without force publishes a package:
`$ script/ddgc_update_locale_dist.pl --domain=test`
4. Wait a few seconds and try with a different delta - this should skip publish:
`$ script/ddgc_update_locale_dist.pl --domain=test --delta=5s`

##### References issues / PRs:

#

##### Who should be informed of this change?


##### Does this change have significant privacy, security, performance or deployment implications?


##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
