### PR TITLE
Retire code relying on beta server

### DIFF
--- a/lib/DDGC/Web/Controller/InstantAnswer.pm
+++ b/lib/DDGC/Web/Controller/InstantAnswer.pm
@@ -851,45 +851,11 @@ sub commit_save :Chained('commit_base') :PathPart('save') :Args(0) {
     return $c->forward($c->view('JSON'));
 }
 
-# Install the data on the beta server
-# Data is an hash of arrays
-# {goodies: [#pr1, #pr2, #pr3], spice: [#pr1, #pr2] ... and so on
-sub send_to_beta :Chained('base') :PathPart('send_to_beta') :Args(0) {
-    my ( $self, $c ) = @_;
-    $c->check_action_token;
-    
-    my $ua = LWP::UserAgent->new;
-
-    my $result = '';
-    $c->stash->{x}->{result} = $result;
-    return $c->forward($c->view('JSON')) unless ($c->req->params->{data} && $c->user && $c->user->admin);
-
-    my $server = "http://beta.duckduckgo.com/ia_install";
-    my $key = $ENV{'BETA_KEY'};
-    my $decoded_data = from_json($c->req->params->{data});
-
-    for my $data (@{$decoded_data}) {
-        my $req = HTTP::Request->new(GET => $server);
-        my $header_data = "sha1=".Digest::SHA::hmac_sha1_hex(to_json($data), $key);
-        
-        $req->header('content-type' => 'application/json');
-        $req->header("x-hub-signature" => $header_data);
-        $req->content(to_json($data));
-
-        my $resp = $ua->request($req);
-        
-        $result = $resp->is_success? 1 : 0;
-        $c->stash->{x}->{result} = $result;
-    }
-
-    return $c->forward($c->view('JSON'));
-}
-
 sub beta_req {
     my ($self) = @_;
 
     my $ua = LWP::UserAgent->new;
-    my $server = "http://beta.duckduckgo.com/installed.json";
+    my $server = "https://s3.amazonaws.com/ddg-community/beta/installed.json";
     my $req = HTTP::Request->new(GET => $server);
 
     my $resp;

--- a/src/js/ia/IADevPipeline.js
+++ b/src/js/ia/IADevPipeline.js
@@ -10,7 +10,6 @@
             'important',
             'mentioned',
             'attention',
-            'beta'
         ],
 
         current_filter: '',
@@ -147,39 +146,6 @@
                     dev_p.query = $(this).val();
                     $("#pipeline-clear-filters").removeClass("hide");
                     filter();
-                }
-            });
-
-            $("body").on("click", "#beta_install", function(evt) {
-                if (!$(this).hasClass("disabled")) {
-                    $(this).addClass("disabled");
-                    var prs = [];
-                    $(".dev_pipeline-column__list .selected").each(function(idx) {
-                        var temp_pr = $.trim($(this).find(".item-activity a").attr("href"));
-                        var temp_hash = pr_hash(temp_pr);
-
-                        if (temp_hash) {
-                            prs.push(temp_hash);
-                        }
-                    });
-
-                    if (prs.length) {
-                        send_to_beta(JSON.stringify(prs));
-                    }
-                }
-            });
-
-            $("body").on("click", "#beta-single", function(evt) {
-                if (!$(this).hasClass("disabled")) {
-                    $(this).addClass("disabled");
-                    var prs = [];
-                    var pr = $.trim($("#pr").attr("href"));
-                    var tmp_hash = pr_hash(pr);
-
-                    if (pr_hash) {
-                        prs.push(tmp_hash);
-                        send_to_beta(JSON.stringify(prs));
-                    }
                 }
             });
 
@@ -342,16 +308,6 @@
                 return false;
             }
 
-            function send_to_beta(prs) {
-                var jqxhr = $.post("/ia/send_to_beta", {
-                    data : prs,
-                    action_token: $.trim($('meta[name=action-token]').attr("content")) 
-                })
-                .done(function(data) {
-                    dev_p.saved = true;
-                });
-            }
-
             function autocommit(field, value, id) {
                var jqxhr = $.post("/ia/save", {
                    field : field,
@@ -401,7 +357,6 @@
                    var actions_data = {};
                    actions_data.permissions = dev_p.data.permissions;
                    actions_data.selected = selected;
-                   actions_data.beta = 1;
                    actions_data.got_prs = 0;
                    var same_type = true;
                    var temp_type = '';
@@ -411,11 +366,6 @@
                        var milestone = $(this).parents(".dev_pipeline-column").attr("id").replace("pipeline-", "");
                        var page_data = getPageData(meta_id, milestone);
                         
-                       // If at least one of the selected IAs isn't on beta we show the "install on beta" button
-                       if ((page_data.beta_install && (!page_data.beta_install.match(/^success/))) || (!page_data.beta_install)) {
-                           actions_data.beta = 0;
-                       }
-
                        if (page_data.pr && (page_data.pr.status === "open" || page_data.pr.status === "merged")) {
                            actions_data.got_prs = 1;
                        }

--- a/src/js/ia/IAPage.js
+++ b/src/js/ia/IAPage.js
@@ -55,12 +55,6 @@
                             ia_data.permissions.admin = 1;
                         }
 
-                        if (ia_data.live.hasOwnProperty("beta_install") && ia_data.live.beta_install) {
-                            if(ia_data.live.beta_install.match(/^success/) && ia_data.live.example_query) {
-                                ia_data.live.can_show = true;
-                            }
-                        }
-
                         // Avoid using the edited dev milestone to decide what page layout
                         // to show, if the live version or the dev version
                         if (ia_data.hasOwnProperty("edited") && ia_data.edited && ia_data.edited.dev_milestone) {
@@ -200,18 +194,6 @@
                         }
                         return value.length * 8 || 100;
                     }
-
-                    $("body").on("click", "#beta-install", function(evt) {
-                        if (!$(this).hasClass("disabled")) {
-                            $(this).addClass("disabled");
-                            var temp_hash = {
-                                "action" : "duckco",
-                                "number" : ia_data.live.pr.id,
-                                "repo" : "zeroclickinfo-" + ia_data.live.repo
-                            };
-                            beta_install(temp_hash);
-                        }
-                    });
 
                     $("body").on("change", "select.top-details.js-autocommit", function(evt) {
                         if($(this).hasClass("topic")) {
@@ -1518,25 +1500,6 @@
                             $("." + val.field).addClass("not_saved");
                             var $error_msg = $("." + val.field).siblings(".error-notification");
                             $error_msg.removeClass("hide").text(val.msg);
-                        });
-                    }
-
-                    //Install pr on beta
-                    function beta_install(pr) {
-                        var prs = [pr];
-                        var action_token = $.trim($('meta[name=action-token]').attr("content"));
-                        
-                        var data = JSON.stringify(prs);
-                        var jqxhr = $.post("/ia/send_to_beta", {
-                            data : data,
-                            action_token : action_token
-                        })
-                        .done(function (data) {
-                            if (!ia_data.staged) {
-                                ia_data.staged = {};
-                            }
-                                
-                            ia_data.staged.beta = 1;
                         });
                     }
 

--- a/src/templates/dev_pipeline.handlebars
+++ b/src/templates/dev_pipeline.handlebars
@@ -37,11 +37,6 @@
           <span class="filter-count right" id="count-missing"></span>
       </span> 
 
-      <span class="pipeline-filter right" id="filter-beta" title="Show IAs on beta">
-        On Beta
-        <span class="filter-count" id="count-beta"></span>
-      </span>
-      
       <!--- <span class="toggle-details right">
         <i class="icon-check-empty"></i>
         Show activity details

--- a/src/templates/dev_pipeline_actions.handlebars
+++ b/src/templates/dev_pipeline_actions.handlebars
@@ -38,21 +38,5 @@
                   </select>
 		</span>
             </div>
-
-            {{#if got_prs}}
-            <div class="frm__label field-label"> Dev Machine </div>
-                <div class="field-section">
-                    {{#if beta}}
-                        <p>Installed on <a href="https://beta.duckduckgo.com">beta</a></p>
-                        <div class="pipeline-actions__button button btn--primary" id="beta_install">
-                            Re-install on beta
-                        </div>
-                    {{else}}
-                        <div class="pipeline-actions__button button btn--primary" id="beta_install">
-                            Install on beta
-                        </div>
-                    {{/if}}
-                </div>
-            {{/if}}
         </div>
 {{/if}}

--- a/src/templates/dev_pipeline_detail.handlebars
+++ b/src/templates/dev_pipeline_detail.handlebars
@@ -96,25 +96,6 @@
         {{/is_false}}
     </div>
     
-    {{#if pr.issue_id}}
-        <div class="sidebar-field">
-            <div class="field-label primary-label"> Dev Machine </div>
-            {{#match beta_install 'success'}}
-                <p>Installed on <a href="http://beta.duckduckgo.com/{{#if beta_query}}?q={{beta_query}}{{/if}}">beta</a></p>
-                {{#eq pr.status 'open'}}
-                    <div class="button btn--primary" id="beta-single">Re-install on beta</div>
-                {{/eq}}
-            {{else}}
-                {{#eq pr.status 'open'}}
-                    {{#if beta_install}}Install on beta failed: <div class="readonly">{{beta_install}}</div>{{/if}}
-                    <div class="button btn--primary" id="beta-single">Install on beta</div>
-                {{else}}
-                    <span></span>
-                {{/eq}}
-            {{/match}}
-        </div>
-    {{/if}}
-
     {{#if priority_msg}}
         <div class="sidebar-field">
             <div class="field-label primary-label">Priority</div>
@@ -168,15 +149,6 @@
             <span class="readonly"> {{#each developer}} <a {{#eq type 'github'}}href="http://duckduckhack.com/u/{{slug (final_path url)}}" class="userpage-link"{{else}}href="{{url}}"{{/eq}}>{{name}}</a>{{#unless @last}}, {{/unless}}{{/each}}</span>
         </div>
     {{/is_true}}
-
-    {{#if pr.issue_id}}
-        {{#match beta_install 'success'}}
-            <div class="sidebar-field">
-                <div class="field-label primary-label"> Dev Machine </div>
-                    <p>Installed on <a href="http://beta.duckduckgo.com/{{#if beta_query}}?q={{beta_query}}{{/if}}">beta</a></p>
-            </div>
-        {{/match}}
-    {{/if}}
 {{/if}}
 
 {{#if pr.status}}

--- a/src/templates/devinfo.handlebars
+++ b/src/templates/devinfo.handlebars
@@ -83,38 +83,6 @@
             </span>
         </div>
     {{/if}}
-    
-    <div class="ia-single--info">
-        <h3 class="ia-single--header">Dev Machine</h3>
-
-        {{#if permissions.admin}}
-            {{#match beta_install 'success'}}
-                <p>Installed on <a href="http://beta.duckduckgo.com/{{#or example_query beta_query}}?q={{#if example_query}}{{example_query}}{{else}}{{beta_query}}{{/if}}{{/or}}">beta</a></p>
-                {{#if pr.id}}
-                    <div class="button btn--primary {{#if staged.beta}}disabled{{/if}}" id="beta-install">Re-install on beta</div>
-                {{/if}}
-            {{else}}
-                {{#if beta_install}}
-                    <p class="not-saved">Install on beta failed: {{beta_install}}</p>
-                {{/if}}
-                {{#if pr.id}}
-                    <div class="button btn--primary {{#if staged.beta}}disabled{{/if}}" id="beta-install">Install on beta</div>
-                {{else}}
-                    <p> Can't install on beta without a PR </p>
-                {{/if}}
-            {{/match}}
-        {{else}}
-            <span class="readonly--info" id="test_machine--readonly">
-                {{#match beta_install 'success'}}
-                    Installed on <a href="http://beta.duckduckgo.com/{{#or example_query beta_query}}?q={{#if example_query}}{{example_query}}{{else}}{{beta_query}}{{/if}}{{/or}}">beta</a>
-                {{else}}
-                    <span class="no-available">
-                        Not yet installed on beta
-                    </span>
-                {{/match}}
-            </span>
-        {{/if}}
-    </div>
 {{/ne_and}}
 
 <div class="ia-single--info">

--- a/src/templates/overview.handlebars
+++ b/src/templates/overview.handlebars
@@ -9,13 +9,9 @@
       <header>
 	<strong>
 	  <span class="pull-left">
-	    {{#eq @key 'new'}}
-	      Recently on Beta
-	    {{else}}
-	      Recently Live
-	    {{/eq}}
+	    Recently Live
 	  </span>
-          <a class="pull-right tx-clr--lt" href="/ia{{#eq @key 'new'}}/dev/pipeline?filter=beta{{/eq}}">{{count}} Total</a>
+          <a class="pull-right tx-clr--lt" href="/ia">{{count}} Total</a>
 	</strong>
       </header>
         


### PR DESCRIPTION
##### Description :
change JSON API URL to the new one, retire beta installation code on the backend and frontend.

##### Who should be informed of this change?
@kablamo @jkv @moollaza @jdorweiler @tagawa 

##### Does this change have significant privacy, security, performance or deployment implications?
We'll test this for a day and assuming nothing unexpected breaks, we'll keep the change.
This might make the dev pipeline inaccurate going forward (especially the "Testing" column) and might also break the "generate screenshot" button in the single IA Pages.

#### Steps to test
1. Populate the IA DB if not done already by running script/ddgc_populate_ia_dev.pl
2. run grunt
3. script/ddgc_dev_server.sh
4. On the instance, verify the following paths: /ia (shows list of IAs), /ia/dev/pipeline (Dev Pipeline), single IA Pages - they should all  be populated and looking like in prod
5. Log in as admin (TestOne) and go to single IA Page live and also in development - there should be no beta install button in the sidebar
6. Click on the *name* and not on the anchor link for some IAs in the Dev Pipeline. A sideview should open. No "install on beta" button should be there
7. Editing and committing should still work for single IA Pages
8. In case something's wrong, the relevant JSON endpoints are ia/json and ia/dev/pipeline/json

##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
