### PR TITLE
Remove ref to blue-lightest

### DIFF
--- a/src/scss/ia/_new.scss
+++ b/src/scss/ia/_new.scss
@@ -57,7 +57,7 @@
     }
     
     p {
-	color: $blue-lightest;
+	color: lighten($blue-light,20%);
     }
 }
 


### PR DESCRIPTION
We removed `$blue-lightest` here: https://github.com/duckduckgo/duckduckgo-colors/pull/6/files

This PR just removes the reference and creates the color locally here.

/cc @bbraithwaite 