### PR TITLE
Remove Catalyst::Plugin::ErrorCatcher::Email

### DIFF
--- a/lib/DDGC/Web.pm
+++ b/lib/DDGC/Web.pm
@@ -54,12 +54,6 @@ __PACKAGE__->config(
 		enable => $ENV{DDGC_ACTIVATE_ERRORCATCHING}||0,
 		emit_module => 'Catalyst::Plugin::ErrorCatcher::Email',
 	},
-	'Plugin::ErrorCatcher::Email' => {
-		to => $ENV{DDGC_ERROR_EMAIL} // 'ddgc@duckduckgo.com',
-		from => 'noreply@duckduckgo.com',
-		subject => '[DuckDuckGo Community] %p %l CRASH!!!',
-		use_tags => 1,
-	},
 	'Plugin::Static::Simple' => {
 		dirs => [
 			'root'


### PR DESCRIPTION
##### Description :

Since this software considers events like CSRF failures and missing help articles as critical failures, crash mail is close to useless.

This change disables crash mail.

##### Reviewer notes :

Dev nodes aren't set up for this, so we'll likely need to stage it to verify functionality.

Test plan:
- Contrive a "crash" by tampering the CSRF token in the login form.
- No email is sent

##### References issues / PRs:

#

##### Who should be informed of this change?


##### Does this change have significant privacy, security, performance or deployment implications?


##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
