### PR TITLE
Hides XMPP information in user account pages

### DIFF
--- a/templates/my/account.tx
+++ b/templates/my/account.tx
@@ -196,7 +196,7 @@
 		</div>
 	</div>
 
-	<div class="content-box account-box">	
+	<div class="content-box account-box" style="display:none">	
 		<div class="head">
 			<h2>Your chat (XMPP)</h2>
 		</div>


### PR DESCRIPTION
##### Description :
Hides XMPP information in user account pages. Tested in Firefox, Vivaldi and Safari.

##### Reviewer notes :


##### References issues / PRs:

#

##### Who should be informed of this change?
@jbarrett @MariagraziaAlastra 

##### Does this change have significant privacy, security, performance or deployment implications?
Nope

##### Checklist :
- [N/A] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
