### PR TITLE
Add extracted comments to po files from token notes

### DIFF
--- a/lib/DDGC/DB/Result/Token/Language.pm
+++ b/lib/DDGC/DB/Result/Token/Language.pm
@@ -151,6 +151,8 @@ sub gettext_snippet {
 		$vars{'msgstr'} = $self->gettext_escape($self->msgstr0) if $self->msgstr0;
 	}
 	return unless %vars || $fallback;
+	$vars{notes} = join "\n", map { "#. $_" } grep { $_ } split /[\n\r]+/, $self->token->notes
+		if $self->token->notes;
 	$vars{msgid} = $self->gettext_escape($self->token->msgid);
 	$vars{msgctxt} = $self->gettext_escape($self->token->msgctxt) if $self->token->msgctxt;
 	if ($self->token->msgid_plural) {
@@ -185,6 +187,7 @@ sub delete_msgstr {
 sub gettext_snippet_formatter {
 	my ( $self, %vars ) = @_;
 	my $return;
+	$return = ( delete $vars{notes} ) . "\n" if $vars{notes};
 	for (qw( msgctxt msgid msgid_plural )) {
 		$return .= $_.' "'.(delete $vars{$_}).'"'."\n" if $vars{$_};
 	}


### PR DESCRIPTION
##### Description :

Add token notes as extracted comments in generated po files. 

##### Reviewer notes :

- Log in as admin (TestOne)
- Add some notes in the translation interface for a token in the 'test' domain
- `script/ddgc_update_locale_dist.pl -f --domain=test`
- New package in : `/home/ddgc/ddgc/duckpan/authors/id/T/TE/TESTONE/`
    - For each language, share/$lang/LC_MESSAGES/test.po should contain your notes prefixed with `#.` (extracted comment)
    - These comments should not be in js files.

More info on locale package evaluation in #1508 

##### References issues / PRs:

#

##### Who should be informed of this change?


##### Does this change have significant privacy, security, performance or deployment implications?

N

##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
