### PR TITLE
John/translate announcement

### DIFF
--- a/templates/translate/alltokens.tx
+++ b/templates/translate/alltokens.tx
@@ -1,4 +1,5 @@
 
+: include 'translate/close.tx'
 <div class="language_nav">
 	<input type="submit" value="Go" class="button js-hide" /><: include "translate/tokens/nav_language.tx" :>
 </div>

--- a/templates/translate/close.tx
+++ b/templates/translate/close.tx
@@ -1,0 +1,8 @@
+	<div class="notice contrast">
+	<i class="icn icon-warning-sign"></i>
+		<strong>
+			We are in the process of <a href="https://github.com/duckduckgo/duckduckgo-locales">migrating DuckDuckGo Translations to GitHub</a>.
+			From 21 Jan 2019, contributions made on this site will no longer be published on DuckDuckGo.
+		</strong>
+	</div>
+

--- a/templates/translate/close.tx
+++ b/templates/translate/close.tx
@@ -2,7 +2,7 @@
 	<i class="icn icon-warning-sign"></i>
 		<strong>
 			We are in the process of <a href="https://github.com/duckduckgo/duckduckgo-locales">migrating DuckDuckGo Translations to GitHub</a>.
-			A huge thank you to everyone who has contributed to the translation system here on duck.co!
+			A huge thank you to everyone who has contributed to the translation system here on duck.co!<br />
 			Please note that from 21 Jan 2019, translations published on <a href="https://duckduckgo.com">DuckDuckGo search</a> will only be sourced from the GitHub repository. Feel free to join us there!
 		</strong>
 	</div>

--- a/templates/translate/close.tx
+++ b/templates/translate/close.tx
@@ -2,7 +2,8 @@
 	<i class="icn icon-warning-sign"></i>
 		<strong>
 			We are in the process of <a href="https://github.com/duckduckgo/duckduckgo-locales">migrating DuckDuckGo Translations to GitHub</a>.
-			From 21 Jan 2019, contributions made on this site will no longer be published on DuckDuckGo.
+			A huge thank you to everyone who has contributed to the translation system here on duck.co!
+			Please note that from 21 Jan 2019, translations published on <a href="https://duckduckgo.com">DuckDuckGo search</a> will only be sourced from the GitHub repository. Feel free to join us there!
 		</strong>
 	</div>
 

--- a/templates/translate/domainindex.tx
+++ b/templates/translate/domainindex.tx
@@ -1,4 +1,5 @@
 <h1><: $token_domain.name :></h1>
+: include 'translate/close.tx'
 
 <: if !$c.wiz_running { :>
 	<: include "translate/wiz_shortcuts.tx" :>

--- a/templates/translate/index.tx
+++ b/templates/translate/index.tx
@@ -1,6 +1,6 @@
 <h1>Welcome to DuckDuckGo Translations!</h1>
 <p class="intro-message">You can translate text ("tokens") from our sites.</p>
-
+: include 'translate/close.tx'
 <div class="row gw">
 	<div class="g twothirds">
 		<div class="notice  contrast  intro--m">

--- a/templates/translate/landing.tx
+++ b/templates/translate/landing.tx
@@ -3,6 +3,7 @@
 <span class="h3">For token domain <b><: $token_domain_language.token_domain.name :></b> in <b><: $token_domain_language.language.name_in_english :></b></span>
 </div>
 
+: include 'translate/close.tx'
 <div class="seventy block-mid mg-top--big mg-bottom">
 	<: if $user_can_speak { :>
 		<div class="row gw">

--- a/templates/translate/tokenlanguage.tx
+++ b/templates/translate/tokenlanguage.tx
@@ -1,3 +1,4 @@
+: include 'translate/close.tx'
 <div class="content-box translate-snippets">	
 	<div class="head">		
 		<h2><: $token_language.token_domain_language.token_domain.name :> in <: i($token_language.token_domain_language.language,'flag') :> <: $token_language.token_domain_language.language.name_in_english :></h2>


### PR DESCRIPTION
##### Description :

Adding notification of our migration of translation contributions to Github.

##### Reviewer notes :

Most pages under /translate should have the shut down notice.

##### References issues / PRs:

#

##### Who should be informed of this change?

@tagawa 

##### Does this change have significant privacy, security, performance or deployment implications?

No

##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
