### PR TITLE
Change security issue flow to link to hackerone

### DIFF
--- a/lib/DDGC/Feedback/Config/Bug.pm
+++ b/lib/DDGC/Feedback/Config/Bug.pm
@@ -11,8 +11,7 @@ sub feedback {[
       bug_mobile(),
   { description => "It's a bug on Desktop (good ole' fashion computers)", icon => "browser" },
       bug_desktop(),
-  { description => "It's a security issue", icon => "bug" },
-      bug_security(),
+  { description => "It's a security issue", icon => "bug", type => "external", link => "https://hackerone.com/duckduckgo" }
 ]}
 
 sub bug_mobile {[


### PR DESCRIPTION
##### Description :

Some pages still link to the feedback bug flow. This change links the 'security issue' option straight to hackerone.

##### Reviewer notes :

- Visit `/feedback/bug/-` and click "It's a security issue"
- You should be redirected to the DDG hackerone page.

##### References issues / PRs:

#

##### Who should be informed of this change?

@marcantonio @isaddg 

##### Does this change have significant privacy, security, performance or deployment implications?


##### Checklist :
- [ ] Back end tests (perl, scripts)
- [ ] Front end tests (js, integration)
- Browser verification
    - [ ] IE
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] Opera 
- Mobile verification
    - [ ] iOS
    - [ ] Android
